### PR TITLE
Inherit standard faces by default

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -43,7 +43,7 @@
   :group 'convenience)
 
 (defface ivy-current-match
-    '((t (:background "#e5b7c0")))
+  '((t (:inherit highlight)))
   "Face used by Ivy for highlighting first match.")
 
 (defcustom ivy-height 10

--- a/swiper.el
+++ b/swiper.el
@@ -49,23 +49,23 @@
           (const :tag "Ivy" ivy)))
 
 (defface swiper-match-face-1
-    '((t (:background "#FEEA89")))
+  '((t (:inherit isearch-lazy-highlight-face)))
   "Face for `swiper' matches.")
 
 (defface swiper-match-face-2
-  '((t (:background "#F9A35A")))
+  '((t (:inherit isearch)))
   "Face for `swiper' matches.")
 
 (defface swiper-match-face-3
-  '((t (:background "#fb7905")))
+  '((t (:inherit match)))
   "Face for `swiper' matches.")
 
 (defface swiper-match-face-4
-  '((t (:background "#F15C79")))
+  '((t (:inherit isearch)))
   "Face for `swiper' matches.")
 
 (defface swiper-line-face
-  '((t (:background "#f3d3d3")))
+  '((t (:inherit highlight)))
   "Face for current `swiper' line.")
 
 (defcustom swiper-faces '(swiper-match-face-1


### PR DESCRIPTION
Every time a new custom face definition is created, it breaks every existing
theme.  Better, then, to inherit standard faces by default.

This commit has the side benefit of making the faces defined here legible in
themes with dark backgrounds.