### PR TITLE
Fix invalid package header line

### DIFF
--- a/swiper-helm.el
+++ b/swiper-helm.el
@@ -1,4 +1,4 @@
-;;; swiper.el --- Helm version of Swiper. -*- lexical-binding: t -*-
+;;; swiper-helm.el --- Helm version of Swiper. -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2015 Oleh Krehel
 


### PR DESCRIPTION
This was leading to "No description available" and missing dependency specs in MELPA.