### PR TITLE
Set `swiper--opoint' in `swiper--init'

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -111,12 +111,12 @@
   "`isearch' with an overview.
 When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
-  (setq swiper--opoint (point))
   (swiper--ivy initial-input))
 
 (defun swiper--init ()
   "Perform initialization common to both completion methods."
   (deactivate-mark)
+  (setq swiper--opoint (point))
   (setq swiper--len 0)
   (setq swiper--anchor (line-number-at-pos))
   (setq swiper--window (selected-window)))


### PR DESCRIPTION
Currently `swiper--opoint` is set directly in `swiper`; as such, it's not set when using `swiper-helm`. However, both `swiper--ivy` and `swiper-helm` call `swiper--init`, so by setting it there it's handled in both cases.