### PR TITLE
Fixed ivy--preselect-index on windows

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -784,7 +784,7 @@ Minibuffer bindings:
   (or (cl-position preselect candidates :test 'equal)
       (cl-position-if
        (lambda (x)
-         (string-match preselect x))
+         (string-match (regexp-quote preselect) x))
        candidates)))
 
 ;;* Implementation


### PR DESCRIPTION
The drives on windows ends with a backslash (C:\, D:\, etc.) and the string-match will fail with a "Trailing backslash".