### PR TITLE
ivy.el (ivy-next-line): Fix wraparound at end of candidates

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -392,7 +392,7 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
   (interactive "p")
   (setq arg (or arg 1))
   (cl-incf ivy--index arg)
-  (when (>= ivy--index (1- ivy--length))
+  (when (> ivy--index (1- ivy--length))
     (if ivy-wrap
         (ivy-beginning-of-buffer)
       (setq ivy--index (1- ivy--length)))))


### PR DESCRIPTION
The `when` clause previously ran even when the updated `ivy-index` was the proper last candidate `(1- ivy--length)`.  When not wrapping, the code still worked, since `ivy-index` is explicitly set again.  With `ivy-wrap` `t`, the choice was immediately set to the first candidate, so you could not reach the last candidate by going down.

Fixed, symmetric to `ivy-previous-line`.