### PR TITLE
Fix the case where file name can contain ~

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1158,7 +1158,7 @@ Should be run via minibuffer `post-command-hook'."
 		   (let ((drive-root (match-string 0 ivy-text)))
 		     (when (file-exists-p drive-root)
 		       (ivy--cd drive-root)))))
-             (if (string-match "~\\'" ivy-text)
+             (if (string-match "\\`~\\'" ivy-text)
                  (ivy--cd (expand-file-name "~/")))))
           ((eq (ivy-state-collection ivy-last) 'internal-complete-buffer)
            (when (or (and (string-match "\\` " ivy-text)


### PR DESCRIPTION
- The fix make opening files like init.el~ now possible. Earlier,
  hitting that last ~ char switch the dir to ~/
- This commit will now make that cd to ~/ only if ~ is the first char in
  the search term