### PR TITLE
Fix #126 again.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -138,7 +138,7 @@
   "Return current symbol at point as a string."
   (let ((s (thing-at-point 'symbol)))
     (and (stringp s)
-         (if (string-match "\\`[`']?\\(.*\\)'?\\'" s)
+         (if (string-match "\\`[`']?\\(.*?\\)'?\\'" s)
              (match-string 1 s)
            s))))
 


### PR DESCRIPTION
After #126 has been solved, the regexp has been changed to

  "\\`[`']?\\(.*\\)'?\\'"

where the trailing ' is optional ("'?").  However, the preceeding
"\\(.*\\)" group will already capture the trailing ' because .* is
greedy.  Now I've replaced it with the non-greedy .*? which makes it
work again.