### PR TITLE
ivy: enlarge the minibuffer window if the candiate list doesn't fit

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1215,7 +1215,6 @@ Insert .* between each char."
   (set (make-local-variable 'minibuffer-default-add-function)
        (lambda ()
          (list ivy--default)))
-  (setq line-spacing 0)
   (setq-local max-mini-window-height ivy-height)
   (add-hook 'post-command-hook #'ivy--exhibit nil t)
   ;; show completions with empty input
@@ -1377,7 +1376,18 @@ Should be run via minibuffer `post-command-hook'."
       (let ((buffer-undo-list t))
         (save-excursion
           (forward-line 1)
-          (insert text))))))
+          (insert text))))
+    (when (display-graphic-p)
+      (ivy--resize-minibuffer-to-fit))))
+
+(defun ivy--resize-minibuffer-to-fit ()
+  "Resize the minibuffer window so it has enough space to display
+all of the text contained in the minibuffer."
+  (with-selected-window (minibuffer-window)
+    (let ((text-height (cdr (window-text-pixel-size)))
+          (body-height (window-body-height nil t)))
+      (when (> text-height body-height)
+        (window-resize nil (- text-height body-height) nil t t)))))
 
 (declare-function colir-blend-face-background "ext:colir")
 


### PR DESCRIPTION
This change adjusts the minibuffer height after candidates have been inserted
to prevent text overflow. Overflow can occur with non-zero `line-spacing` (#198) 
or if the text contains characters that are rendered larger than usual (#161). 

I prefer this solution to resetting `line-spacing` because additional spacing increases
readability and is a personal choice.
