### PR TITLE
Fix minibuffer collapse in text mode emacs

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -890,7 +890,10 @@ candidates with each input."
              (let* ((hist (or history 'ivy-history))
                     (minibuffer-completion-table collection)
                     (minibuffer-completion-predicate predicate)
-                    (resize-mini-windows nil)
+                    (resize-mini-windows (cond
+                                          ((display-graphic-p) nil)
+                                          ((null resize-mini-windows) 'grow-only)
+                                          (t resize-mini-windows)))
                     (res (read-from-minibuffer
                           prompt
                           (ivy-state-initial-input ivy-last)


### PR DESCRIPTION
In graphic mode : resize-mini-windows is temporarily set to nil, the
only value which does not collapse the minibuffer.

In text mode : if resize-mini-windows is nil, it is temporarily set to
'grow-only (default emacs value).

This prevent the minibuffer collapse in both graphic and text mode.

In text mode it respects the user settings if it is already set to
'grow-only or t.

Fix #237 in text mode emacs too.