### PR TITLE
counsel.el (counsel-ag): Add initial-directory

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1040,18 +1040,19 @@ Usable with `ivy-resume', `ivy-next-line-and-call' and
   "Grep in the current directory for STRING."
   (if (< (length string) 3)
       (counsel-more-chars 3)
-    (let ((regex (counsel-unquote-regex-parens
+    (let ((default-directory counsel--git-grep-dir)
+          (regex (counsel-unquote-regex-parens
                   (setq ivy--old-re
                         (ivy--regex string)))))
       (counsel--async-command
        (format "ag --noheading --nocolor %S" regex))
       nil)))
 
-(defun counsel-ag (&optional initial-input)
+(defun counsel-ag (&optional initial-input initial-directory)
   "Grep for a string in the current directory using ag.
 INITIAL-INPUT can be given as the initial minibuffer input."
   (interactive)
-  (setq counsel--git-grep-dir default-directory)
+  (setq counsel--git-grep-dir (or initial-directory default-directory))
   (ivy-read "ag: " 'counsel-ag-function
             :initial-input initial-input
             :dynamic-collection t


### PR DESCRIPTION
Support alternative initial directory which helps other packages call
this function with their unique starting directory.