### PR TITLE
fix 1-too-far scrolling issue

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -545,13 +545,13 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
 (defun ivy-scroll-up-command ()
   "Scroll the candidates upward by the minibuffer height."
   (interactive)
-  (ivy-set-index (min (+ ivy--index ivy-height)
+  (ivy-set-index (min (1- (+ ivy--index ivy-height))
                       (1- ivy--length))))
 
 (defun ivy-scroll-down-command ()
   "Scroll the candidates downward by the minibuffer height."
   (interactive)
-  (ivy-set-index (max (- ivy--index ivy-height)
+  (ivy-set-index (max (1+ (- ivy--index ivy-height))
                       0)))
 
 (defun ivy-minibuffer-grow ()


### PR DESCRIPTION
Functions `ivy-scroll-up-command` and `ivy-scroll-down-command` would
scroll 1 unit too far. So one item in the list would be skipped
and never seen for each scroll.