### PR TITLE
Fix `counsel-ag` on Windows

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1104,7 +1104,7 @@ Usable with `ivy-resume', `ivy-next-line-and-call' and
                   (setq ivy--old-re
                         (ivy--regex string)))))
       (counsel--async-command
-       (format "ag --noheading --nocolor %S" regex))
+       (format "ag --vimgrep %S" regex))
       nil)))
 
 (defun counsel-ag (&optional initial-input initial-directory)


### PR DESCRIPTION
Use `ag --vimgrep` instead of `ag --noheading --nocolor` to fix `counsel-ag` on Windows

`counsel-ag` is not working properly on Windows (hangs on search).
This commit fixes the issue.

`--vimgrep` should provide the same results according to `ag` documentation.