### PR TITLE
`ivy-format-function-line' and minor format-function refactoring

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -877,7 +877,8 @@ Optional INITIAL-INPUT is the initial input in the minibuffer."
               (lambda (cmd)
                 (when (featurep 'smex)
                   (smex-rank (intern cmd)))
-                (let ((prefix-arg current-prefix-arg))
+                (let ((prefix-arg current-prefix-arg)
+                      (ivy-format-function store))
                   (command-execute (intern cmd) 'record)))
               :sort sort
               :keymap counsel-describe-map

--- a/ivy.el
+++ b/ivy.el
@@ -1880,9 +1880,13 @@ Prefix matches to NAME are put ahead of the list."
     (error
      cands)))
 
-(defvar ivy-format-function 'ivy-format-function-default
+(defcustom ivy-format-function 'ivy-format-function-default
   "Function to transform the list of candidates into a string.
-This string will be inserted into the minibuffer.")
+This string will be inserted into the minibuffer."
+  :type '(choice
+          (const :tag "Default" ivy-format-function-default)
+          (const :tag "Arrow prefix" ivy-format-function-arrow)
+          (const :tag "Full line" ivy-format-function-line)))
 
 (defun ivy--truncate-string (str width)
   "Truncate STR to WIDTH."
@@ -1893,27 +1897,35 @@ This string will be inserted into the minibuffer.")
 
 (defun ivy-format-function-default (cands)
   "Transform CANDS into a string for minibuffer."
-  (if (bound-and-true-p truncate-lines)
-      (mapconcat #'identity cands "\n")
-    (let ((ww (- (window-width)
-                 (if (and (boundp 'fringe-mode) (eq fringe-mode 0)) 1 0))))
-      (mapconcat
-       (if truncate-lines
-           (lambda (s)
-             (ivy--truncate-string s ww))
-         #'identity)
-       cands "\n"))))
+  (let ((i -1))
+    (mapconcat
+     (lambda (s)
+       (when (eq (cl-incf i) ivy--index)
+         (ivy--add-face s 'ivy-current-match))
+       s)
+     cands "\n")))
 
 (defun ivy-format-function-arrow (cands)
   "Transform CANDS into a string for minibuffer."
   (let ((i -1))
     (mapconcat
      (lambda (s)
-       (concat (if (eq (cl-incf i) ivy--index)
-                   "> "
-                 "  ")
-               s))
+       (let ((curr (eq (cl-incf i) ivy--index)))
+         (when curr
+           (ivy--add-face s 'ivy-current-match))
+         (concat (if curr "> " "  ") s)))
      cands "\n")))
+
+(defun ivy-format-function-line (cands)
+  "Transform CANDS into a string for minibuffer."
+  (let ((i -1))
+    (mapconcat
+     (lambda (s)
+       (let ((line (concat s "\n")))
+         (when (eq (cl-incf i) ivy--index)
+           (ivy--add-face line 'ivy-current-match))
+         line))
+     cands "")))
 
 (defface ivy-minibuffer-match-face-1
   '((((class color) (background light))
@@ -2018,8 +2030,6 @@ CANDS is a list of strings."
       (setq cands (mapcar
                    #'ivy--format-minibuffer-line
                    cands))
-      (setf (nth index cands)
-            (ivy--add-face (nth index cands) 'ivy-current-match))
       (let* ((ivy--index index)
              (res (concat "\n" (funcall ivy-format-function cands))))
         (put-text-property 0 (length res) 'read-only nil res)


### PR DESCRIPTION
This patch adds `ivy-format-function-line` which highlights the full line, instead of the stub.  It also allows `ivy-format-function` to be customized via the customize system.

I noticed that there was some dead code related to line truncation in `ivy-format-function-default`, so I've removed it.  I tested using it, and it seems using the truncating behavior of the minibuffer gives better results (especially when resizing with ivy open). You may want to add it back in a different way if it is useful for something though.



