### PR TITLE
Convert ivy formatting functions to dotted pairs.

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -115,7 +115,7 @@
 
 (ert-deftest ivy--format ()
   (should (string= (let ((ivy--index 10)
-                         (ivy-format-function (lambda (x) (mapconcat #'identity x "\n")))
+                         (ivy-format-function (lambda (x) (mapconcat (lambda (y) (car y)) x "\n")))
                          (cands '("NAME"
                                   "SYNOPSIS"
                                   "DESCRIPTION"


### PR DESCRIPTION
I noticed this evening that my ivy-format-function patch (#306) had an unintentional change on the way that `counsel-M-x` selections were displayed.  When moving `ivy--add-face` to the ivy-format-functions to accommodate for the full-line case, this has the side effect of being run after counsel has added its additional information (the keybinding information added by `counsel-M-x`), so they are also highlighted.

To restore the old behavior, I am proposing this patch, which has the ivy-format-functions take a cell `(stub . extra)`.  `counsel-M-x` then adds the additional information to the cdr portion, while the car remains the original candidate.  The stub-highlighting versions (default and arrow) will apply `ivy-current-match` face to just the stub (like it did before), and the full line formatter will apply it to stub, extra, and \n.

---

As a side note, if this patch is acceptable, since it is changing the data structure passed between ivy and counsel, it should probably be an atomic upgrade.  I'm not really savvy on MELPA or if you can do atomic upgrades with two packages.  If not, then I would recommend splitting it into two commits, committing changes to ivy{,-test}.el, waiting for MELPA to package it, then committing the changes to counsel.el.

The problem is that if MELPA picks up the changes to counsel first, any users upgrading during that window will have an error thrown when using `counsel-M-x`.  To prevent it, they need the ivy changes first, or at the same time as the counsel changes.

