### PR TITLE
Make ivy--regex-plus recognize ! at the beginning of the str

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1471,7 +1471,11 @@ match. Everything after \"!\" should not match."
       (0
        "")
       (1
-       (ivy--regex (car parts)))
+       (if (string-equal (substring str 0 1) "!")
+            (list
+             (cons "" t)
+             (list (ivy--regex (car parts))))
+           (ivy--regex (car parts))))
       (2
        (let ((res
               (mapcar #'list


### PR DESCRIPTION
When one types '!foo, he expects the candidates to be filtered out
by 'foo'.