### PR TITLE
Add cousel-ag-base-command var

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1112,6 +1112,13 @@ Usable with `ivy-resume', `ivy-next-line-and-call' and
            (org-agenda-set-tags nil nil))
       (fset 'org-set-tags store))))
 
+(defcustom counsel-ag-base-command "ag --vimgrep %S"
+  "Format string to use in `cousel-ag-function' to construct the
+command. %S will be replaced by the regex string. The default is
+\"ag --vimgrep %S\"."
+  :type 'stringp
+  :group 'ivy)
+
 (defun counsel-ag-function (string &optional _pred &rest _unused)
   "Grep in the current directory for STRING."
   (if (< (length string) 3)
@@ -1121,7 +1128,7 @@ Usable with `ivy-resume', `ivy-next-line-and-call' and
                   (setq ivy--old-re
                         (ivy--regex string)))))
       (counsel--async-command
-       (format "ag --vimgrep %S" regex))
+       (format counsel-ag-base-command regex))
       nil)))
 
 ;;;###autoload


### PR DESCRIPTION
Allows the command run by counsel-ag-function to be customized. There
are several reasons to allow this: The vimgrep option is a recent
addition; on windows it's more convenient to use pt; and the user might
want to customize ignored files.