### PR TITLE
ivy: fix ivy--resize-minibuffer-to-fit for small delta

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1752,7 +1752,10 @@ Should be run via minibuffer `post-command-hook'."
         (let ((text-height (cdr (window-text-pixel-size)))
               (body-height (window-body-height nil t)))
           (when (> text-height body-height)
-            (window-resize nil (- text-height body-height) nil t t)))
+            ;; Note: the size increment needs to be at least frame-char-height,
+            ;; otherwise resizing won't do anything.
+            (let ((delta (max (- text-height body-height) (frame-char-height))))
+              (window-resize nil delta nil t t))))
       (let ((text-height (count-screen-lines))
             (body-height (window-body-height)))
         (when (> text-height body-height)


### PR DESCRIPTION
Very small size increments can be necessary if the initial candidate
list is short (e.g. 3 items) and line-height is set to something other
than zero. In that case, only half of the last line is initially visible.
ivy--resize-minibuffer-to-fit recognizes this and tries to enlarge the
window up the the exact pixel height required, however window-resize
doesn't do anything if the delta is below frame-char-height.

Before:

<img width="328" alt="before" src="https://cloud.githubusercontent.com/assets/6915/12157131/dfe2212e-b4cf-11e5-9c72-fd9cb351d791.png">

After:

<img width="327" alt="after" src="https://cloud.githubusercontent.com/assets/6915/12157134/e5f27348-b4cf-11e5-925e-4e1d359e8a75.png">
