### PR TITLE
Clean `ivy--regex-plus' to prepare to `ivy--regex-plus-ignore-order'

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1545,8 +1545,7 @@ match. Everything after \"!\" should not match."
       (1
        (if (string-equal (substring str 0 1) "!")
            (list
-            (cons "" t)
-            (list (ivy--regex (car parts))))
+            (cons (ivy--regex (car parts)) nil))
          (ivy--regex (car parts))))
       (2
        (let ((res

--- a/ivy.el
+++ b/ivy.el
@@ -1534,25 +1534,42 @@ Ignore the order of each group."
        (mapcar (lambda (x) (cons x t))
                subs)))))
 
+(defun ivy--regex-normalize (regex &optional discard)
+  "If regex is a list, only adjust its discard part. If it is a
+string, return a list of cons out of it. The discard argument
+indicate whether the matched candidates should be discarded or
+not."
+  (if (listp regex)
+      (mapcar
+       (lambda (part)
+         (cons (car part) (not discard))
+         )
+       regex)
+    (list (cons regex (not discard)))
+    )
+  )
+
 (defun ivy--regex-plus (str)
   "Build a regex sequence from STR.
 Spaces are wild card characters, everything before \"!\" should
 match. Everything after \"!\" should not match."
-  (let ((parts (split-string str "!" t)))
+  (let (
+        (parts (split-string str "!" t))
+        (regex '()))
     (cl-case (length parts)
       (0
        "")
       (1
-       (if (string-equal (substring str 0 1) "!")
-           (list
-            (cons (ivy--regex (car parts)) nil))
-         (ivy--regex (car parts))))
+       (let ((discard (string-equal (substring str 0 1) "!")))
+         (ivy--regex-normalize (ivy--regex (car parts)) discard)))
       (2
-       (let ((res
-              (mapcar #'list
-                      (split-string (cadr parts) " " t))))
-         (cons (cons (ivy--regex (car parts)) t)
-               res)))
+       (append
+        (ivy--regex-normalize
+         (ivy--regex (car parts))
+         nil)
+        (ivy--regex-normalize
+         (ivy--regex (cadr parts))
+         t)))
       (t (error "Unexpected: use only one !")))))
 
 (defun ivy--regex-fuzzy (str)


### PR DESCRIPTION
The current implementation of `ivy--regex-ignore-order' does not take into account the '!' character like  `ivy--regex-plus' does.

When trying to implement the '!' behavior in `ivy--regex-ignore-order', I realized that it behaves more like `ivy--regex' in the sense that it provides a way to create regex out of a string.

I also realized that ivy--regex-plus could be considered as a thin wrapper around "something that returns regex" and added the behavior of '!'. I thought that it could be a good idea to use it around ivy--regex-ignore-order also.

Unfortunately, ivy--regex-plus is difficult to work on since it returns either a string or a list of cons (let's call it a ivy style regex :-)). Also, it assumed that the called function (ivy--regex) returned a string and not an ivy style regex.

The purpose of this patch is to make `ivy--regex-plus' cleaner, not relying on the assumption that the called function returns a string.

To do that, I added ivy--regex-normalize that is fed with either a string or a ivy style regex and return a ivy style regex. Then ivy--regex-plus makes use of it.

I don't know yet how to customize ivy--regex-plus to use either ivy--regex or ivy--regex-ignore-order, but now, I feel that the base is clean enough to do this.