### PR TITLE
Initialize ivy-last to empty state.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -238,7 +238,7 @@ Only \"./\" and \"../\" apply here. They appear in reverse order."
   dynamic-collection
   caller)
 
-(defvar ivy-last nil
+(defvar ivy-last (make-ivy-state)
   "The last parameters passed to `ivy-read'.
 
 This should eventually become a stack so that you could use


### PR DESCRIPTION
Initialize `ivy-last` to an empty state.

This fixes an error that occurs when running the single-match-case `ivy-completion-in-region` before `ivy-read` in the Emacs session.

Previously,

```emacs-lisp
(setf (ivy-state-window ivy-last) (selected-window))
```

`ivy-last` might be `nil`, resulting in the error.
