### PR TITLE
Optionally disable ignore patterns for some functions.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -542,13 +542,15 @@ Possible value: \"\\(?:\\`[#.]\\)\\|\\(?:[#~]\\'\\)\"."
   "Return REGEXP-matching CANDIDATES.
 Skip some dotfiles unless `ivy-text' requires them."
   (let ((res (ivy--re-filter regexp candidates)))
-    (if (or (null counsel-find-file-ignore-regexp)
+    (if (or (null ivy-use-ignore)
+            (null counsel-find-file-ignore-regexp)
             (string-match counsel-find-file-ignore-regexp ivy-text))
         res
-      (cl-remove-if
-       (lambda (x)
-         (string-match counsel-find-file-ignore-regexp x))
-       res))))
+      (or (cl-remove-if
+           (lambda (x)
+             (string-match counsel-find-file-ignore-regexp x))
+           res)
+          res))))
 
 (defun counsel-git-grep-matcher (regexp candidates)
   (or (and (equal regexp ivy--old-re)


### PR DESCRIPTION
I saw that ivy-ignore-buffers was added, which is a neat feature.  I remember using the feature back when I used ido :-)

This patch adds the ability to optionally disable user-configured filtering at the command invocation.  The convention is that if called with a non-nil prefix arg, then user-filtering is turned off.  I added this to the new buffer filtering and `counsel-find-file` as well.

Example usage would look similar to:
<kbd>C-x</kbd><kbd>b</kbd> - ivy-switch-buffer with ivy-ignore-buffers filtering
<kbd>C-u</kbd><kbd>C-x</kbd><kbd>b</kbd> - ivy-switch-buffer, no filtering
<kbd>C-x</kbd><kbd>C-f</kbd> - counsel-find-file with counsel-find-file-ignore-regexp filtering
<kbd>C-u</kbd><kbd>C-x</kbd><kbd>C-f</kbd> - counsel-find-file, no filtering

One thing you might want to change in the patch is that I used `current-prefix-arg` directly rather than `(interactive "P")` because this would change the positional arguments in `counsel-find-file` and break any users' scripts that are using it with an initial-input.

If that's not really a concern then it would be better to use `(interactive "P")`, and make the prefix arg a normal optional argument and easier to use programatically.