### PR TITLE
Filter buffers with functions.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2472,9 +2472,9 @@ CANDS is a list of strings."
       (setq ivy--virtual-buffers (nreverse virtual-buffers))
       (mapcar #'car ivy--virtual-buffers))))
 
-(defcustom ivy-ignore-buffers nil
-  "List of regexps matching buffer names to ignore."
-  :type '(repeat regexp))
+(defcustom ivy-ignore-buffers '("\\` ")
+  "List of regexps or functions matching buffer names to ignore."
+  :type '(repeat (choice regexp function)))
 
 (defun ivy--buffer-list (str &optional virtual)
   "Return the buffers that match STR.
@@ -2549,8 +2549,10 @@ Skip buffers that match `ivy-ignore-buffers'."
       (or (cl-remove-if
            (lambda (buf)
              (cl-find-if
-              (lambda (regexp)
-                (string-match regexp buf))
+              (lambda (f-or-r)
+                (if (functionp f-or-r)
+                    (funcall ff buf)
+                  (string-match-p f-or-r buf)))
               ivy-ignore-buffers))
            res)
           res))))


### PR DESCRIPTION
This is more flexible.
Hope it will fit int 15 lines limit.)
And here is a suggestion of how to improve this -- Create a named function to check if a buffer name is matching against ignored regexps(ivy--is-buffer-name-ignored-by-regex-p), add the `:set` function to the `ivy-ignore-buffers` variable, inside `:set` check if the new value is `nil` -- then remove that function(ivy--is-buffer-name-ignored-by-regex-p) from the `ivy-ignore-buffer-functions`, if non nil -- add it.