### PR TITLE
Add counsel-mode

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1688,6 +1688,34 @@ An extra action allows to switch to the process buffer."
               ("e" counsel-rhythmbox-enqueue-song "Enqueue song"))
             :caller 'counsel-rhythmbox))
 
+(defvar counsel-mode-map
+  (let ((map (make-sparse-keymap)))
+    (dolist (binding
+             '((describe-bindings . counsel-descbinds)
+               (describe-function . counsel-describe-function)
+               (describe-variable . counsel-describe-variable)
+               (find-file         . counsel-find-file)
+               (imenu             . counsel-imenu)
+               (load-library      . counsel-load-library)
+               (load-theme        . counsel-load-theme)
+               (yank-pop          . counsel-yank-pop)))
+      (define-key map (vector 'remap (car binding)) (cdr binding)))
+    map)
+  "Map for `counsel-mode'. Remaps built-in functions to counsel
+replacements.")
+
+;;;###autoload
+(define-minor-mode counsel-mode
+  "Toggle Counsel mode on or off.
+Turn Counsel mode on if ARG is positive, off otherwise. Counsel
+mode remaps built-in emacs functions that have counsel
+replacements. "
+  :group 'ivy
+  :global t
+  :keymap counsel-mode-map
+  :lighter " counsel")
+
+
 (provide 'counsel)
 
 ;;; counsel.el ends here


### PR DESCRIPTION
A minor-mode that remaps built-in functions that have counsel
replacements available.