### PR TITLE
ivy: Add C-return for immediate-done

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -218,6 +218,7 @@ Example:
     (define-key map (kbd "C-M-m") 'ivy-call)
     (define-key map (kbd "C-j") 'ivy-alt-done)
     (define-key map (kbd "C-M-j") 'ivy-immediate-done)
+    (define-key map (kbd "<C-return>") 'ivy-immediate-done)
     (define-key map (kbd "TAB") 'ivy-partial-or-done)
     (define-key map (kbd "C-n") 'ivy-next-line)
     (define-key map (kbd "C-p") 'ivy-previous-line)


### PR DESCRIPTION
We have C-M-j which builds off of C-j, but C-return also makes sense to
me as it's close to RET. I think having both is useful, and C-return
does nothing at the moment.