### PR TITLE
counsel.el (counsel-prompt-function-dir): Make portable

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -179,7 +179,8 @@ Update the minibuffer with the amount of lines collected every
 (defun counsel-prompt-function-dir (prompt)
   "Return PROMPT appended with the parent directory."
   (let ((directory counsel--git-grep-dir))
-    (format " [%s]: "
+    (format "%s [%s]: "
+	    prompt
             (let ((dir-list (eshell-split-path directory)))
               (if (> (length dir-list) 3)
 		  (apply #'concat

--- a/counsel.el
+++ b/counsel.el
@@ -33,6 +33,7 @@
 
 (require 'swiper)
 (require 'etags)
+(require 'esh-util)
 
 ;;* Utility
 (defun counsel-more-chars (n)
@@ -179,13 +180,11 @@ Update the minibuffer with the amount of lines collected every
   "Return PROMPT appended with the parent directory."
   (let ((directory counsel--git-grep-dir))
     (format " [%s]: "
-            (let ((dir-list (split-string directory "/")))
+            (let ((dir-list (eshell-split-path directory)))
               (if (> (length dir-list) 3)
-                  (mapconcat
-                   #'identity
-                   (append '("..")
-                           (cl-subseq dir-list (- (length dir-list) 3)))
-                   "/")
+		  (apply #'concat
+			 (append '("...")
+				 (cl-subseq dir-list (- (length dir-list) 3))))
                 directory)))))
 
 (defun counsel-delete-process ()


### PR DESCRIPTION
Use the built-in eshell-split-path to split the directory path into
components instead of split-string which is not likely to work on all
systems.

Note: I hope it's ok to depend on eshell here. 

I also used three dots when the directory is truncated to avoid confusion with the standard meaning of two dots