### PR TITLE
Fixed a bug in counsel-list-processes-action-switch and made some improvements to counsel-find-file

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1722,7 +1722,7 @@ PREFIX is used to create the key."
   (let* ((proc (get-process x))
          (buf (and proc (process-buffer proc))))
     (if buf
-        (switch-to-buffer x)
+        (switch-to-buffer buf)
       (message "Process %s doesn't have a buffer" x))))
 
 ;;;###autoload

--- a/counsel.el
+++ b/counsel.el
@@ -1056,8 +1056,12 @@ done") "\n" t)))
 (add-to-list 'ivy-ffap-url-functions 'counsel-github-url-p)
 (add-to-list 'ivy-ffap-url-functions 'counsel-emacs-url-p)
 (ivy-set-actions
- 'counsel-find-file
- '(("f" find-file-other-window "other window")))
+   'counsel-find-file
+   '(("f" find-file-other-window "other window")
+     ("v" view-file "view")
+     ("d" delete-file "delete")
+     ("l" load-file "load")
+     ("b" byte-compile-file "byte compile")))
 
 (defcustom counsel-find-file-at-point nil
   "When non-nil, add file-at-point to the list of candidates."

--- a/counsel.el
+++ b/counsel.el
@@ -1114,7 +1114,8 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
                 (find-file (expand-file-name x ivy--directory))))
             :preselect (when counsel-find-file-at-point
                          (require 'ffap)
-                         (ffap-guesser))
+                         (let ((f (ffap-guesser)))
+                           (when f (expand-file-name f))))
             :require-match 'confirm-after-completion
             :history 'file-name-history
             :keymap counsel-find-file-map))


### PR DESCRIPTION
The counsel-list-processes-action-switch fix was simple, and possibly my fault in the first place.

The counsel-find-file changes fix a bug with the use of ffap.  With point on a file name such as dev/emacs/BUGS, it wouldn't expand the file name completely, leaving the user on emacs/ with no available options.

The final piece is additional actions to counsel-find-file.  Helm has all of these, and I've found them to be useful.