### PR TITLE
ivy.el (ivy-sort-default): New option

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1095,6 +1095,12 @@ Prioritize directories."
         nil
       (string< x y))))
 
+(defcustom ivy-sort-default t
+  "If non nil, sort collection passed to `ivy-completing-read' by
+default."
+  :group 'ivy
+  :type 'boolean)
+
 (defcustom ivy-sort-functions-alist
   '((read-file-name-internal . ivy-sort-file-function-default)
     (internal-complete-buffer . nil)
@@ -1531,7 +1537,7 @@ INHERIT-INPUT-METHOD is currently ignored."
               (let ((sort (assoc this-command ivy-sort-functions-alist)))
                 (if sort
                     (cdr sort)
-                  t)))))
+                  ivy-sort-default)))))
 
 (defvar ivy-completion-beg nil
   "Completion bounds start.")


### PR DESCRIPTION
I was trying to use projectile's default sorting and it got annoying to lookup `this-command` for every case, so I'd rather just turn it off by default.