### PR TITLE
option to add newline after ivy-read prompt

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -124,6 +124,10 @@ Set this to \"(%d/%d) \" to display both the index and the count."
           (const :tag "Count matches and show current match" "(%d/%d) ")
           string))
 
+(defcustom ivy-add-newline-after-prompt nil
+  "When non-nil, add a newline after the `ivy-read' prompt."
+  :type 'boolean)
+
 (defcustom ivy-wrap nil
   "When non-nil, wrap around after the first and the last candidate."
   :type 'boolean)
@@ -1856,6 +1860,8 @@ depending on the number of candidates."
                  (window-width))
               (setq n-str (concat n-str "\n" d-str))
             (setq n-str (concat n-str d-str)))
+          (when ivy-add-newline-after-prompt
+            (setq n-str (concat n-str "\n")))
           (let ((regex (format "\\([^\n]\\{%d\\}\\)[^\n]" (window-width))))
             (while (string-match regex n-str)
               (setq n-str (replace-match (concat (match-string 1 n-str) "\n") nil t n-str 1))))


### PR DESCRIPTION
The reason why I am interested in this option is that, being visually impaired, I work with a screen magnifier constantly turned on and following the cursor. Thus when ivy-read is called, the magnified area moves around the cursor (at the end of the pompt line), and as I start typing patterns the candidates are often left outside this area. Inserting a newline after the prompt reduces the distance between the patterns and the candidates (because now they all start from the beginning of their respective lines) and this almost always solves the problem, which greatly improves my user experience.

I hope I am being clear and I don't know whether this could be interesting for anyone else than me, but in case here is the pull request.