### PR TITLE
ivy.el: Add `counsel-find-file' transformer.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2422,6 +2422,8 @@ SEPARATOR is used to join the candidates."
     str))
 
 (ivy-set-display-transformer
+ 'counsel-find-file 'ivy-read-file-transformer)
+(ivy-set-display-transformer
  'read-file-name-internal 'ivy-read-file-transformer)
 
 (defun ivy-read-file-transformer (str)


### PR DESCRIPTION
The `counsel-find-file` caller should have the same behavior
as `read-file-name-internal`.

--

Fixes a bug introduced at https://github.com/abo-abo/swiper/commit/cf78d42eb455f263dd6410e22bb486e83119723d.