### PR TITLE
Fix remapping commit c9b6e0

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -228,7 +228,7 @@ Example:
     (define-key map (kbd "C-s") 'ivy-next-line-or-history)
     (define-key map (kbd "C-r") 'ivy-reverse-i-search)
     (define-key map (kbd "SPC") 'self-insert-command)
-    (define-key map (kbd "DEL") 'ivy-backward-delete-char)
+    (define-key map [remap delete-backward-char] 'ivy-backward-delete-char)
     (define-key map [remap backward-kill-word] 'ivy-backward-kill-word)
     (define-key map [remap delete-char] 'ivy-delete-char)
     (define-key map [remap forward-char] 'ivy-forward-char)


### PR DESCRIPTION
- delete duplication of #'ivy-next-line and #'ivy-previous-line
- replace alias #'backward-delete-char by #'delete-backward-char because
  only the second is bound to a key

Fixes #467