### PR TITLE
ivy.el: hydra-style action prompt 

### DIFF
--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -88,6 +88,28 @@ _h_ ^+^ _l_ | _d_one      ^ ^  | _o_ops   | _m_: matcher %-5s(ivy--matcher-desc)
         (lambda (_) (find-function 'hydra-ivy/body)))
        :exit t))
 
+(defun ivy-hydra--make-action-hint (actions)
+  "Generate a hydra-style hint for `ivy-read-action'."
+  (let ((docstring (or (plist-get ivy--action-hints-list (ivy-state-caller ivy-last))
+                       (plist-get ivy--action-hints-list this-command)
+                       (plist-get ivy--action-hints-list t)
+                       (lambda (actions)
+                         (mapconcat (lambda (x)
+                                      (format "\n_%s_: %s" (car x) (nth 2 x)))
+                                    (cdr actions)
+                                    "")))))
+    (eval (hydra--format "hydra-ivy-actions" '(:hint nil :exit t :foreign-keys nil)
+                         (cond
+                          ((stringp docstring)
+                           docstring)
+                          ((functionp docstring)
+                           (funcall docstring actions))
+                          (t
+                           (user-error "Cannot generate action hint")))
+                         (mapcar (lambda (x)
+                                   `(,(car x) nil))
+                                 (cdr actions))))))
+
 (provide 'ivy-hydra)
 
 ;;; ivy-hydra.el ends here


### PR DESCRIPTION
In case you find it useful (it is useful to me for ivy-read commands with many actions). 

There is really just one commit, I probably did something wrong to end up with two identical ones. Let me know if you need me to make changes.

- Add a custom variable `ivy-action-display-style` to optionally toggle
the use of a `hydra`-style docstring as hint in the `ivy-read-action`
minibuffer prompt.

- Add a variable `ivy--action-hints-lists` and a command
`ivy-set-action-hint` to customize this string globally or
per command. This gives some flexibility to arrange the layout of the
action prompt, which can be useful especially for commands with a large
number of actions.

- Add a function `ivy-hydra--make-action-hint` which is called by
`ivy-read-action` to build the docstring when `ivy-action-display-style`
is set to `'hydra`. This function is defined in `ivy-hydra.el` since it
depends on the `hydra` package, and is autoloaded in ivy.el.