### PR TITLE
swiper.el (swiper-font-lock-exclude): Add forth-block-mode

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -206,6 +206,7 @@
     emms-stream-mode
     erc-mode
     forth-mode
+    forth-block-mode
     org-agenda-mode
     dired-mode
     jabber-chat-mode


### PR DESCRIPTION
Also added `forth-block-mode` to resolve [#526](https://github.com/abo-abo/swiper/issues/526) completely.