### PR TITLE
colir.el (colir-parse-color): Fix color parsing in terminal

### DIFF
--- a/colir.el
+++ b/colir.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'color)
+(require 'rx)
 
 (defcustom colir-compose-method 'colir-compose-alpha
   "Select a method to compose two color channels."
@@ -69,6 +70,20 @@ C1 and C2 are triples of floats in [0.0 1.0] range."
             colir-compose-method)
           c1 c2)))
 
+(defun colir-color-parse (color)
+  "Convert string COLOR to triple of floats in [0.0 1.0]."
+  (if (string-match (rx (and "#" (and (group hex hex)
+                                      (group hex hex)
+                                      (group hex hex)))) color)
+      (mapcar (lambda (v) (/ (string-to-number v 16) 255.0))
+              (list (match-string 1 color)
+                    (match-string 2 color)
+                    (match-string 3 color)))
+    ;; does not work properly in terminal (maps color to nearest color
+    ;; from available color palette).
+    (color-name-to-rgb color)
+    ))
+
 (defun colir-blend-face-background (start end face &optional object)
   "Append to the face property of the text from START to END the face FACE.
 When the text already has a face with a non-plain background,
@@ -89,8 +104,8 @@ See also `font-lock-append-text-property'."
                (if background-prev
                    (cons `(background-color
                            . ,(colir-blend
-                               (color-name-to-rgb background-prev)
-                               (color-name-to-rgb (face-background face nil t))))
+                               (colir-color-parse background-prev)
+                               (colir-color-parse (face-background face nil t))))
                          prev)
                  (list face prev))
                object)))


### PR DESCRIPTION
Built-in color-name-to-rgb function is not working properly in terminal
as it maps parsed color to colosest available color from available
palette, and it is done before blending. This changes basically
adds function which basiacally parses color in # prefixed format,
and fallbacks to color-name-to-rgb otherwise.

Fixes #541