### PR TITLE
Counsel set variable current val in prompt

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -538,9 +538,10 @@ input corresponding to the chosen variable."
                ((eq sym-type 'boolean)
                 (setq cands '(("nil" . nil) ("t" . t))))
                (t nil)))
-        (let ((res (ivy-read (format "Set (%S): " sym)
+        (let* ((sym-val (symbol-value sym))
+               (res (ivy-read (format "Set (%S ‹%s›): " sym sym-val)
                              cands
-                             :preselect (prin1-to-string (symbol-value sym)))))
+                             :preselect (prin1-to-string sym-val))))
           (when res
             (setq res
                   (if (assoc res cands)


### PR DESCRIPTION
* counsel-set-variable: The current value of the selected variable is
  now also shown in the prompt, between the ‹..› brackets.  That way, the
  current value of the variable is more explicit to the user.

*Apologies! This PR includes my earlier PR ( https://github.com/abo-abo/swiper/pull/545) too. I forgot to rebase to upstream master before creating this commit.*