### PR TITLE
Escape `%` chars if present in the symbol value

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -541,9 +541,11 @@ input corresponding to the chosen variable."
                 (setq cands '(("nil" . nil) ("t" . t))))
                (t nil)))
         (let* ((sym-val (symbol-value sym))
-               (res (ivy-read (format "Set (%S <%s>): " sym sym-val)
-                             cands
-                             :preselect (prin1-to-string sym-val))))
+               ;; Escape '%' chars if present
+               (sym-val-str (replace-regexp-in-string "%" "%%" (format "%s" sym-val)))
+               (res (ivy-read (format "Set (%S <%s>): " sym sym-val-str)
+                              cands
+                              :preselect (prin1-to-string sym-val))))
           (when res
             (setq res
                   (if (assoc res cands)


### PR DESCRIPTION
* counsel-set-variable: The current value of the variable to be modified
  is displayed in the ivy prompt.  If the symbol value has literal '%'
  characters they need to be escaped to '%%' so that they are not
  processed by `ivy--reset-state`.