### PR TITLE
counsel.el (counsel-set-variable): Allow new symbols

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -552,6 +552,8 @@ input corresponding to the chosen variable."
                       (cdr (assoc res cands))
                     (read res)))
             (eval `(setq ,sym ,res))))
+      (unless (boundp sym)
+        (set sym nil))
       (counsel-read-setq-expression sym))))
 
 ;;** `counsel-info-lookup-symbol'


### PR DESCRIPTION
If a symbol is not defined, initialize it to nil.