### PR TITLE
Add option for swiper line number to be searchable

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2408,7 +2408,7 @@ Prefix matches to NAME are put ahead of the list."
               (res 0)
               (i 0))
           (dolist (c cands)
-            (when (eq n (read (get-text-property 0 'display c)))
+            (when (eq n (read (get-text-property 0 'swiper-line-number c)))
               (setq res i))
             (cl-incf i))
           res)))))

--- a/swiper.el
+++ b/swiper.el
@@ -77,6 +77,11 @@
   "Only highlight matches for regexps at least this long."
   :type 'integer)
 
+(defcustom swiper-include-line-number-in-search nil
+  "Include line number in text of search candidates."
+  :type 'boolean
+  :group 'swiper)
+
 (defvar swiper-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "M-q") 'swiper-query-replace)
@@ -305,10 +310,14 @@ numbers; replaces calculating the width from buffer line count."
                             (point)
                             (line-end-position)))))))
               (remove-text-properties 0 (length str) '(field) str)
-              (put-text-property 0 1 'display
-                                 (format swiper--format-spec
-                                         (cl-incf line-number))
-                                 str)
+              (let ((line-number-str
+                     (format swiper--format-spec (incf line-number))))
+                (if swiper-include-line-number-in-search
+                    (setq str (concat line-number-str str))
+                  (put-text-property
+                   0 1 'display line-number-str str))
+                (put-text-property
+                 0 1 'swiper-line-number line-number-str str))
               (push str candidates))
             (funcall advancer 1))
           (nreverse candidates))))))
@@ -344,7 +353,7 @@ When REVERT is non-nil, regenerate the current *ivy-occur* buffer."
                            fname
                            (propertize
                             (string-trim-right
-                             (get-text-property 0 'display s))
+                             (get-text-property 0 'swiper-line-number s))
                             'face 'compilation-line-number)
                            (substring s 1)))
                  (if (null revert)
@@ -502,7 +511,7 @@ Matched candidates should have `swiper-invocation-face'."
                   "    " "\t"
                   (funcall ivy--regex-function ivy-text)))
              (re (if (stringp re) re (caar re)))
-             (str (get-text-property 0 'display ivy--current))
+             (str (get-text-property 0 'swiper-line-number ivy--current))
              (num (if (string-match "^[0-9]+" str)
                       (string-to-number (match-string 0 str))
                     0)))
@@ -589,7 +598,7 @@ WND, when specified is the window."
 
 (defun swiper--action (x)
   "Goto line X."
-  (let ((ln (1- (read (or (get-text-property 0 'display x)
+  (let ((ln (1- (read (or (get-text-property 0 'swiper-line-number x)
                           (and (string-match ":\\([0-9]+\\):.*\\'" x)
                                (match-string-no-properties 1 x))))))
         (re (ivy--regex ivy-text)))
@@ -715,12 +724,12 @@ Run `swiper' for those buffers."
          (delete-minibuffer-contents))))
 
 (defun swiper-multi-action-2 (x)
-  (let ((buf-space (get-text-property (1- (length x)) 'display x)))
+  (let ((buf-space (get-text-property (1- (length x)) 'swiper-line-number x)))
     (with-ivy-window
       (when (string-match "\\` *\\([^ ]+\\)\\'" buf-space)
         (switch-to-buffer (match-string 1 buf-space))
         (goto-char (point-min))
-        (forward-line (1- (read (get-text-property 0 'display x))))
+        (forward-line (1- (read (get-text-property 0 'swiper-line-number x))))
         (re-search-forward
          (ivy--regex ivy-text)
          (line-end-position) t)


### PR DESCRIPTION
 * swiper.el (swiper-include-line-number-in-search): Add option
 * swiper.el: Use swiper-line-number to store candidate line number
 * ivy.el: Same

Store swiper line number in new text property swiper-line-number,
reserving the display property for the display of text. When the option
is enabled the only change is that the line number is included as text
in the candidates instead of in the display property.