### PR TITLE
Don't crash if default-directory is nil.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2731,8 +2731,9 @@ When VIRTUAL is non-nil, add virtual buffers."
     (mapcar
      (lambda (x)
        (if (with-current-buffer x
-             (file-remote-p
-              (abbreviate-file-name default-directory)))
+             (and default-directory
+                  (file-remote-p
+                   (abbreviate-file-name default-directory))))
            (propertize x 'face 'ivy-remote)
          (let ((face (with-current-buffer x
                        (cdr (assoc major-mode


### PR DESCRIPTION
I think this is a pretty rare occurrence (for some reason I had a
`*Backtrace*` buffer with `default-directory` set to nil). However,
`ivy-switch-buffer` breaks in this situation, which is inconvenient.