### PR TITLE
CD to home on `~/` not just `~`

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2194,10 +2194,10 @@ Should be run via minibuffer `post-command-hook'."
             (ivy--insert-minibuffer
              (ivy--format ivy--all-candidates))))
       (cond (ivy--directory
-             (if (string-match "/\\'" ivy-text)
-                 (ivy--magic-file-slash)
-               (if (string-match "\\`~\\'" ivy-text)
-                   (ivy--cd (expand-file-name "~/")))))
+             (if (string-match "\\`~/\\'" ivy-text)
+                 (ivy--cd (expand-file-name "~/"))
+               (if (string-match "/\\'" ivy-text)
+                   (ivy--magic-file-slash))))
             ((eq (ivy-state-collection ivy-last) 'internal-complete-buffer)
              (when (or (and (string-match "\\` " ivy-text)
                             (not (string-match "\\` " ivy--old-text)))


### PR DESCRIPTION
Previously when using counsel-find-file, to find a file relative to
the home directory one needed to type `~$FILENAME`. This is counter to
lots of training/convention in using shells.

If you had typed `~/$FILENAME` it would be relative the root as `~`
would jump to home and then `/` would jump to root.

With this change it doesn't trigger the jump to home just on typing
the tilde, it waits for tilde-slash.