### PR TITLE
update 'counsel-bookmark' with the ability to create, edit, and delete bookmarks.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -618,16 +618,22 @@ input corresponding to the chosen variable."
 
 ;;;###autoload
 (defun counsel-bookmark ()
-  "Forward to `bookmark-jump'."
+  "Forward to `bookmark-jump' or `bookmark-set' if bookmark doesn't exist."
   (interactive)
   (require 'bookmark)
-  (ivy-read "Jump to bookmark: "
+  (ivy-read "Create or jump to bookmark: "
             (bookmark-all-names)
             :action (lambda (x)
-                      (with-ivy-window
-                        (bookmark-jump x)))
-            :require-match t
+                      (if (member x (bookmark-all-names))
+                          (with-ivy-window
+                            (bookmark-jump x))
+                        (bookmark-set x)))
             :caller 'counsel-bookmark))
+
+(ivy-set-actions
+ 'counsel-bookmark
+ '(("d" bookmark-delete "delete")
+   ("e" bookmark-rename "edit")))
 
 (defun counsel-M-x-transformer (cmd)
   "Return CMD appended with the corresponding binding in the current window."


### PR DESCRIPTION
This pull request removes the required match restriction from ```counsel-bookmark``` and allows a user to create a new bookmark if a match does not exist. Additionally it adds two additional actions that allow a bookmark to either be renamed or deleted.

This solves one minor pain point I ran into in my conversion from helm to ivy.

Also, I've submitted a request to 'assign@gnu.org'. I'll update this pull request once the copyright assignment has been completed.