### PR TITLE
Shrink the window when/after reading actions.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -567,11 +567,17 @@ selection, non-nil otherwise."
                (setcar actions (1+ action-idx))
                (ivy-set-action actions)))))))
 
+(defun ivy-shrink-after-dispatching ()
+  "Shrink the window after dispatching when action list is too large."
+  (let ((window (selected-window)))
+    (window-resize window (- ivy-height (window-height window)))))
+
 (defun ivy-dispatching-done ()
   "Select one of the available actions and call `ivy-done'."
   (interactive)
   (when (ivy-read-action)
-    (ivy-done)))
+    (ivy-done))
+  (ivy-shrink-after-dispatching))
 
 (defun ivy-dispatching-call ()
   "Select one of the available actions and call `ivy-call'."
@@ -581,7 +587,8 @@ selection, non-nil otherwise."
     (unwind-protect
         (when (ivy-read-action)
           (ivy-call))
-      (ivy-set-action actions))))
+      (ivy-set-action actions)))
+  (ivy-shrink-after-dispatching))
 
 (defun ivy-build-tramp-name (x)
   "Reconstruct X into a path.

--- a/ivy.el
+++ b/ivy.el
@@ -552,7 +552,7 @@ selection, non-nil otherwise."
     (if (null (ivy--actionp actions))
         t
       (let* ((hint (funcall ivy-read-action-format-function (cdr actions)))
-             (resize-mini-windows 'grow-only)
+             (resize-mini-windows t)
              (key (string (read-key hint)))
              (action-idx (cl-position-if
                           (lambda (x) (equal (car x) key))


### PR DESCRIPTION
There are two commits in this pull request.

One is to deal with the action window height after dispatching action(Shrink ivy back to ivy-height).
The other one is to deal with the action height when reading action(Shrink action window to suitable height.

Please read the commit message for more details. Thanks !