### PR TITLE
Ensure that ivy--regex-ignore-order always returns legal regexps

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -169,7 +169,9 @@
   (should (equal (ivy--regex-ignore-order "one two !three four")
                  '(("one" . t) ("two" . t) ("three") ("four"))))
   (should (equal (ivy--regex-ignore-order "!three four")
-                 '(("" . t) (("three") ("four"))))))
+                 '(("" . t) (("three") ("four")))))
+  (should (equal (ivy--regex-ignore-order "foo[ bar[xy]")
+                 '(("foo\\[" . t) ("bar[xy]" . t)))))
 
 (ert-deftest ivy--format ()
   (should (string= (let ((ivy--index 10)

--- a/ivy.el
+++ b/ivy.el
@@ -1959,16 +1959,27 @@ When GREEDY is non-nil, join words in a greedy way."
                             ".*?")))))
                     ivy--regex-hash)))))
 
+(defun ivy--legal-regex-p (str)
+  "Return t if STR is valid regular expression."
+  (condition-case nil
+      (progn
+        (string-match-p str "")
+        t)
+    (invalid-regexp nil)))
+
 (defun ivy--regex-ignore-order--part (str &optional discard)
   "Re-build regex from STR by splitting at spaces.
-Ignore the order of each group."
+Ignore the order of each group. If any substring is not a valid
+regex, treat it as a literal string."
   (let* ((subs (split-string str " +" t))
          (len (length subs)))
     (cl-case len
       (0
        "")
       (t
-       (mapcar (lambda (x) (cons x (not discard)))
+       (mapcar (lambda (s)
+                 (cons (if (ivy--legal-regex-p s) s (regexp-quote s))
+                       (not discard)))
                subs)))))
 
 (defun ivy--regex-ignore-order (str)


### PR DESCRIPTION
The input from the user may not be a valid regexp. Even when a user
types a valid regexp, there may be points where the intermediate value
is not a valid regexp.

Fall back to a literal string match if the input is not a valid regexp.

Fixes #765.