### PR TITLE
Make counsel-imenu show functions as "Function: func".

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2278,6 +2278,14 @@ PREFIX is used to create the key."
                                            (cdr elm))))))))
              alist))
 
+(defun counsel-imenu-categorize-functions (items)
+  "Categorize all the functions of imenu."
+  (let* ((others (remove-if-not (lambda (x) (listp (cdr x))) items))
+         (functions (remove-if (lambda (x) (listp (cdr x))) items)))
+    (if functions
+        (append others `(("Function" ,@functions)))
+      items)))
+
 ;;;###autoload
 (defun counsel-imenu ()
   "Jump to a buffer position indexed by imenu."
@@ -2289,7 +2297,8 @@ PREFIX is used to create the key."
                                        (buffer-size)
                                      imenu-auto-rescan-maxout))
          (items (imenu--make-index-alist t))
-         (items (delete (assoc "*Rescan*" items) items)))
+         (items (delete (assoc "*Rescan*" items) items))
+         (items (counsel-imenu-categorize-functions items)))
     (ivy-read "imenu items:" (counsel-imenu-get-candidates-from items)
               :preselect (thing-at-point 'symbol)
               :require-match t


### PR DESCRIPTION
Add the missing category of functions for counsel-imenu.
The global function is display in
`Function: func`.
All the other contents will retain unchanged, e.g.
```
Package: pack
Variables: var
Import: pack
```

Tested in `emacs-lisp-mode`, `c++mode` and `python-mode`.