### PR TITLE
Fix #795: Address multiple problems with counsel-rg

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -407,7 +407,7 @@ actions.
      line.
 
      Comes in handy when opening multiple files from
-     =counsel-find-file=, =counsel-git-grep=, =counsel-ag=, or
+     =counsel-find-file=, =counsel-git-grep=, =counsel-ag=, =counsel-rg=, or
      =counsel-locate= lists. Just hold ~C-M-n~ for rapid-fire default
      action on each successive element of the list.
 

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -544,9 +544,10 @@ Combines @kbd{C-n} and @kbd{C-M-m}. Applies an action and moves to next
 line.
 
 Comes in handy when opening multiple files from
-@code{counsel-find-file}, @code{counsel-git-grep}, @code{counsel-ag}, or
-@code{counsel-locate} lists. Just hold @kbd{C-M-n} for rapid-fire default
-action on each successive element of the list.
+@code{counsel-find-file}, @code{counsel-git-grep}, @code{counsel-ag},
+@code{counsel-rg}, or @code{counsel-locate} lists. Just hold
+@kbd{C-M-n} for rapid-fire default action on each successive element
+of the list.
 @end indentedblock
 @subsubheading @kbd{C-M-p} (@code{ivy-previous-line-and-call})
 @vindex ivy-previous-line-and-call

--- a/ivy.el
+++ b/ivy.el
@@ -2773,7 +2773,7 @@ SEPARATOR is used to join the candidates."
 (defun ivy--format-minibuffer-line (str)
   (let ((start
          (if (and (memq (ivy-state-caller ivy-last)
-                        '(counsel-git-grep counsel-ag counsel-pt))
+                        '(counsel-git-grep counsel-ag counsel-rg counsel-pt))
                   (string-match "^[^:]+:[^:]+:" str))
              (match-end 0)
            0))
@@ -3431,7 +3431,7 @@ updated original buffer."
              (let ((inhibit-read-only t))
                (erase-buffer)
                (funcall (plist-get ivy--occurs-list caller) t))))
-          ((memq caller '(counsel-git-grep counsel-grep counsel-ag))
+          ((memq caller '(counsel-git-grep counsel-grep counsel-ag counsel-rg))
            (let ((inhibit-read-only t))
              (erase-buffer)
              (funcall (plist-get ivy--occurs-list caller)))))))
@@ -3486,7 +3486,7 @@ EVENT gives the mouse position."
           (beginning-of-line)
           (looking-at "\\(?:./\\|    \\)\\(.*\\)$"))
     (when (memq (ivy-state-caller ivy-occur-last)
-                '(swiper counsel-git-grep counsel-grep counsel-ag
+                '(swiper counsel-git-grep counsel-grep counsel-ag counsel-rg
                   counsel-describe-function counsel-describe-variable))
       (let ((window (ivy-state-window ivy-occur-last)))
         (when (or (null (window-live-p window))


### PR DESCRIPTION
* counsel-ag-function: Take base-cmd as a parameter instead of using counsel-ag-base-command
* counsel-rg-base-command: Include line numbers and current directory so it works on Windows
* Make counsel-rg a modified copy of counsel-ag instead of calling it, so we get a working occur buffer
* Update docs to mention counsel-rg
* ivy: Add 'counsel-rg to multiple memq lists that check for 'counsel-ag