### PR TITLE
change point of the buffer after the action of counsel-ag/grep/pt

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -920,6 +920,12 @@ Describe the selected candidate."
   (list counsel-git-grep-cmd-default)
   "History for `counsel-git-grep' shell commands.")
 
+(defcustom counsel-grep-post-function 'recenter
+  "A function to change pooint in the buffer after go to string
+match. The default is recenter"
+  :type 'function
+  :group 'ivy)
+
 (defun counsel-prompt-function-dir ()
   "Return prompt appended with the parent directory."
   (ivy-add-prompt-count
@@ -956,6 +962,7 @@ Describe the selected candidate."
         (forward-line (1- (string-to-number line-number)))
         (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
         (swiper--ensure-visible)
+        (funcall counsel-grep-post-function)
         (unless (eq ivy-exit 'done)
           (swiper--cleanup)
           (swiper--add-overlays (ivy--regex ivy-text)))))))
@@ -1823,6 +1830,7 @@ the command."
           (forward-line (- line-number counsel-grep-last-line))
           (setq counsel-grep-last-line line-number))
         (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
+        (funcall counsel-grep-post-function)
         (if (eq ivy-exit 'done)
             (swiper--ensure-visible)
           (isearch-range-invisible (line-beginning-position)


### PR DESCRIPTION
add a defcunstom function to recenter the buffer after action of counsel-grep/ag/pt, pull request for 
#751 

This is my first pull request in GitHub, hope it is the correct way to make a pull request.