### PR TITLE
Fix #794: Add support for counsel-find-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Ivy and Swiper wiki is here: [the wiki](https://github.com/abo-abo/swiper/wiki).
 (global-set-key (kbd "C-x C-f") 'counsel-find-file)
 (global-set-key (kbd "<f1> f") 'counsel-describe-function)
 (global-set-key (kbd "<f1> v") 'counsel-describe-variable)
-(global-set-key (kbd "<f1> l") 'counsel-load-library)
+(global-set-key (kbd "<f1> l") 'counsel-find-library)
 (global-set-key (kbd "<f2> i") 'counsel-info-lookup-symbol)
 (global-set-key (kbd "<f2> u") 'counsel-unicode-char)
 (global-set-key (kbd "C-c g") 'counsel-git)

--- a/counsel.el
+++ b/counsel.el
@@ -702,10 +702,8 @@ Optional INITIAL-INPUT is the initial input in the minibuffer."
               :caller 'counsel-M-x)))
 
 ;;** `counsel-load-library'
-;;;###autoload
-(defun counsel-load-library ()
-  "Load a selected the Emacs Lisp library.
-The libraries are offered from `load-path'."
+(defun counsel-library-candidates ()
+  "Return a list of completion candidates for `counsel-load-library'."
   (interactive)
   (let ((dirs load-path)
         (suffix (concat (regexp-opt '(".el" ".el.gz") t) "\\'"))
@@ -744,10 +742,29 @@ The libraries are offered from `load-path'."
                                 'full-name (expand-file-name file dir))
                                dir) cands)))))))
     (maphash (lambda (_k v) (push (car v) res)) cands)
-    (ivy-read "Load library: " (nreverse res)
+    (nreverse res)))
+
+;;;###autoload
+(defun counsel-load-library ()
+  "Load a selected the Emacs Lisp library.
+The libraries are offered from `load-path'."
+  (interactive)
+  (let ((cands (counsel-library-candidates)))
+    (ivy-read "Load library: " cands
               :action (lambda (x)
                         (load-library
                          (get-text-property 0 'full-name x)))
+              :keymap counsel-describe-map)))
+
+;;** `counsel-find-library'
+;;;###autoload
+(defun counsel-find-library ()
+  "Visit a selected the Emacs Lisp library.
+The libraries are offered from `load-path'."
+  (interactive)
+  (let ((cands (counsel-library-candidates)))
+    (ivy-read "Find library: " cands
+              :action #'counsel--find-symbol
               :keymap counsel-describe-map)))
 
 ;;** `counsel-load-theme'
@@ -2641,6 +2658,7 @@ And insert it into the minibuffer. Useful during
                 (describe-function . counsel-describe-function)
                 (describe-variable . counsel-describe-variable)
                 (find-file . counsel-find-file)
+                (find-library . counsel-find-library)
                 (imenu . counsel-imenu)
                 (load-library . counsel-load-library)
                 (load-theme . counsel-load-theme)

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -248,7 +248,7 @@ The recommended key bindings are:
      (global-set-key (kbd "C-x C-f") 'counsel-find-file)
      (global-set-key (kbd "<f1> f") 'counsel-describe-function)
      (global-set-key (kbd "<f1> v") 'counsel-describe-variable)
-     (global-set-key (kbd "<f1> l") 'counsel-load-library)
+     (global-set-key (kbd "<f1> l") 'counsel-find-library)
      (global-set-key (kbd "<f2> i") 'counsel-info-lookup-symbol)
      (global-set-key (kbd "<f2> u") 'counsel-unicode-char)
      #+end_src

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -343,7 +343,7 @@ The recommended key bindings are:
      (global-set-key (kbd "C-x C-f") 'counsel-find-file)
      (global-set-key (kbd "<f1> f") 'counsel-describe-function)
      (global-set-key (kbd "<f1> v") 'counsel-describe-variable)
-     (global-set-key (kbd "<f1> l") 'counsel-load-library)
+     (global-set-key (kbd "<f1> l") 'counsel-find-library)
      (global-set-key (kbd "<f2> i") 'counsel-info-lookup-symbol)
      (global-set-key (kbd "<f2> u") 'counsel-unicode-char)
 @end lisp


### PR DESCRIPTION
* This is a helpful and unsurprising alternative to using C-. with counsel-load-library
* Extract counsel-library-candidates which is used by both counsel-load-library and
  counsel-find-library
* Use counsel-find-library in place of counsel-load-library in the docs, in order to better match
  the feel of the surrounding keybindings, which are all locate-based rather than mutate-based.