### PR TITLE
Make counsel-ag support limiting in files.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1682,10 +1682,18 @@ If non-nil, EXTRA-AG-ARGS string is appended to BASE-CMD."
           (regex (counsel-unquote-regex-parens
                   (setq ivy--old-re
                         (ivy--regex string)))))
-      (let ((ag-cmd (format base-cmd
-                            (concat extra-ag-args
-                                    " -- "
-                                    (shell-quote-argument regex)))))
+      (let* ((args-end (string-match " -- " extra-ag-args))
+             (file (if args-end
+                       (substring-no-properties extra-ag-args (+ args-end 3))
+                     ""))
+             (extra-ag-args (if args-end
+                                (substring-no-properties extra-ag-args 0 args-end)
+                              extra-ag-args))
+             (ag-cmd (format counsel-ag-base-command
+                             (concat extra-ag-args
+                                     " -- "
+                                     (shell-quote-argument regex)
+                                     file))))
         (if (file-remote-p default-directory)
             (split-string (shell-command-to-string ag-cmd) "\n" t)
           (counsel--async-command ag-cmd)


### PR DESCRIPTION
This is be done by detecting " -- " in extra-ag-args after
prompting, since ag supports " -- pattern file1 file2" style
of searching.

Common usage is: `C-u M-x counsel-ag`, select a directory, adjust the optional arguments to something like `--nocolor --nogroup -- package *.el`, and search `PATTERN`, given results like
<img width="641" alt="screen shot 2016-12-09 at 9 34 37 am" src="https://cloud.githubusercontent.com/assets/16749790/21034425/bda2495e-bdf2-11e6-88d2-2ff089e55926.png">

compared to the unlimited file version with argument `--nocolor --nogroup `

<img width="642" alt="screen shot 2016-12-09 at 9 34 21 am" src="https://cloud.githubusercontent.com/assets/16749790/21034436/cd251028-bdf2-11e6-934a-e2ea2bb4118a.png">