### PR TITLE
Add new counsel command, `command-history'

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3036,6 +3036,31 @@ candidate."
               :caller 'counsel-faces
               :sort t)))
 
+;;** `counsel-command-history'
+(defun counsel-command-history-action-eval (cmd)
+  "Eval the command CMD."
+    (eval (read cmd)))
+
+(defun counsel-command-history-action-edit-and-eval (cmd)
+  "Edit and eval the command CMD."
+    (edit-and-eval-command "Eval: " (read cmd)))
+
+(ivy-set-actions
+ 'counsel-command-history
+ '(("r" counsel-command-history-action-eval           "eval command")
+   ("e" counsel-command-history-action-edit-and-eval  "edit and eval command")))
+
+(defun counsel-command-history ()
+  "Show the history of commands."
+  (interactive)
+  (ivy-read "%d Command: "
+            (mapcar (lambda (x)
+                        (format "%s" x))
+                    command-history)
+          :require-match t
+          :action #'counsel-command-history-action-eval
+          :caller 'counsel-command-history))
+
 ;** `counsel-mode'
 (defvar counsel-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION

![command-history](https://cloud.githubusercontent.com/assets/390964/21153815/645c0e52-c16c-11e6-8054-4ad1298590ca.png)


This command, `counsel-command-history` shows you the history of the Emacs commands executed and let you select and eval one again, or edit it first if you wish. It could be a replacement for the helm command `helm-complex-command-history`.