### PR TITLE
counsel: no need to hard-code ivy-height values

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -241,7 +241,6 @@ Update the minibuffer with the amount of lines collected every
                    (car bnd)
                    (cdr bnd))
                 ""))
-         (ivy-height 7)
          (funp (eq (char-before (car bnd)) ?\())
          symbol-names)
     (if bnd
@@ -334,7 +333,6 @@ Update the minibuffer with the amount of lines collected every
          (str (buffer-substring-no-properties
                (car bnd) (cdr bnd)))
          (candidates (funcall completion-fn str))
-         (ivy-height 7)
          (res (ivy-read (format "pattern (%s): " str)
                         candidates)))
     (when (stringp res)
@@ -1294,8 +1292,7 @@ done") "\n" t)))
   (interactive)
   (let ((counsel-async-split-string-re "\ncommit ")
         (counsel-yank-pop-truncate-radius 5)
-        (ivy-format-function #'counsel--yank-pop-format-function)
-        (ivy-height 4))
+        (ivy-format-function #'counsel--yank-pop-format-function))
     (ivy-read "Grep log: " #'counsel-git-log-function
               :dynamic-collection t
               :action #'counsel-git-log-action
@@ -2274,8 +2271,7 @@ INITIAL-INPUT can be given as the initial minibuffer input."
                     (or (< (length s) 3)
                         (string-match "\\`[\n[:blank:]]+\\'" s)))
                   (delete-dups kill-ring)))))
-    (let ((ivy-format-function #'counsel--yank-pop-format-function)
-          (ivy-height 5))
+    (let ((ivy-format-function #'counsel--yank-pop-format-function))
       (ivy-read "kill-ring: " candidates
                 :action 'counsel-yank-pop-action
                 :caller 'counsel-yank-pop))))


### PR DESCRIPTION
IMHO, there is no need to hard-code `ivy-height` values into the commands when there
is already available an homonymous variable to customize that. If a user needs
to customize this for a particular command, he could use the advice system.