### PR TITLE
Windows

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1687,7 +1687,7 @@ If non-nil, EXTRA-AG-ARGS string is appended to BASE-CMD."
       (let* ((args-end (string-match " -- " extra-ag-args))
              (file (if args-end
                        (substring-no-properties extra-ag-args (+ args-end 3))
-                     ""))
+                     default-directory))
              (extra-ag-args (if args-end
                                 (substring-no-properties extra-ag-args 0 args-end)
                               extra-ag-args))
@@ -1695,6 +1695,7 @@ If non-nil, EXTRA-AG-ARGS string is appended to BASE-CMD."
                              (concat extra-ag-args
                                      " -- "
                                      (shell-quote-argument regex)
+                                     " "
                                      file))))
         (if (file-remote-p default-directory)
             (split-string (shell-command-to-string ag-cmd) "\n" t)

--- a/counsel.el
+++ b/counsel.el
@@ -1077,9 +1077,11 @@ INITIAL-INPUT can be given as the initial minibuffer input."
         (error "Not in a git repository")
       (unless proj
         (setq counsel--git-grep-count
-              (if (eq system-type 'windows-nt)
-                  0
-                (counsel--gg-count "" t))))
+              (counsel--gg-count "" t)
+              ;; (if (eq system-type 'windows-nt)
+              ;;     0
+              ;;   (counsel--gg-count "" t))
+              ))
       (ivy-read "git grep" (if proj
                                'counsel-git-grep-proj-function
                              'counsel-git-grep-function)

--- a/ivy.el
+++ b/ivy.el
@@ -2234,7 +2234,9 @@ If SUBEXP is nil, the text properties are applied to the whole match."
 (defun ivy--magic-file-slash ()
   (cond ((member ivy-text ivy--all-candidates)
          (ivy--cd (expand-file-name ivy-text ivy--directory)))
-        ((string-match "//\\'" ivy-text)
+        ((and (string-match "//\\'" ivy-text)
+              (= 0 (string-match "//\\'" ivy-text))))
+        ((string-match "///\\'" ivy-text)
          (if (and default-directory
                   (string-match "\\`[[:alpha:]]:/" default-directory))
              (ivy--cd (match-string 0 default-directory))


### PR DESCRIPTION
- I don't think counsel--git-grep-count need to be set to 0 under windows-nt
- the MSYS2/MinGW64 version of ag has a problem: it does not search inside the current directory, it is waiting on stdin instead. Under windows-nt, the default-directory argument is mandatory. It is also harmless for other platforms
- the last change is to tolerate UNC path, aka //server/share/...