### PR TITLE
Heed non-sort entries in ivy-sort-functions-alist

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1770,9 +1770,10 @@ INHERIT-INPUT-METHOD is currently ignored."
               :history history
               :keymap nil
               :sort
-              (let ((sort (or (ivy--sort-function this-command)
-                              (ivy--sort-function t))))
-                (or sort t)))))
+              (let ((sort (assoc this-command ivy-sort-functions-alist)))
+                (if sort
+                    (ivy--sort-function (car sort))
+                  (or (ivy--sort-function t) t))))))
 
 (defvar ivy-completion-beg nil
   "Completion bounds start.")


### PR DESCRIPTION
Currently, `ivy--sort-function` does not distinguish between collection functions that are not members of `ivy-sort-functions-alist` and ones whose associated sorting function is `nil`, i.e. no sorting.

In `ivy-completing-read`, this meant that the lookup in `ivy-sort-functions-alist` would always fall through to the default sorting function, even for existing collection functions whose `CDR` was explicitly set to `nil`.