### PR TITLE
swiper.el (swiper-font-lock-exclude): Add nix-mode

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -232,6 +232,7 @@
     erc-mode
     forth-mode
     forth-block-mode
+    nix-mode
     org-agenda-mode
     dired-mode
     jabber-chat-mode


### PR DESCRIPTION
The first time `swiper` is invoked upon switching to a nix-mode buffer `swiper--candidates` will say `End of buffer` during the `save-excursion`.  Invoking it a second time `swiper--candidates` will return normally.

If this is what `swiper-font-lock-exclude` is used to prevent, please consider this PR!