### PR TITLE
Add compatibility with evil-ex-search.

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -680,7 +680,13 @@ WND, when specified is the window."
         (add-to-history
          'regexp-search-ring
          re
-         regexp-search-ring-max)))))
+         regexp-search-ring-max)
+        (when (and (bound-and-true-p evil-mode)
+                   (eq evil-search-module 'evil-search))
+          (add-to-history
+           'evil-ex-search-history
+           re)
+          (setq evil-ex-search-pattern (list re t t)))))))
 
 (defun swiper-from-isearch ()
   "Invoke `swiper' from isearch."


### PR DESCRIPTION
Allows for continuing a swiper search with `evil-ex-search-next` and adds searches to `evil-ex-search-history` for the case where `evil-search-module` is set to `evil-search`.