### PR TITLE
Apply search highlighting for evil when applicable

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -684,7 +684,9 @@ WND, when specified is the window."
         (when (and (bound-and-true-p evil-mode)
                    (eq evil-search-module 'evil-search))
           (add-to-history 'evil-ex-search-history re)
-          (setq evil-ex-search-pattern (list re t t)))))))
+          (setq evil-ex-search-pattern (list re t t))
+          (when evil-ex-search-persistent-highlight
+            (evil-ex-search-activate-highlight (list re t t))))))))
 
 (defun swiper-from-isearch ()
   "Invoke `swiper' from isearch."

--- a/swiper.el
+++ b/swiper.el
@@ -686,7 +686,7 @@ WND, when specified is the window."
           (add-to-history 'evil-ex-search-history re)
           (setq evil-ex-search-pattern (list re t t))
           (when evil-ex-search-persistent-highlight
-            (evil-ex-search-activate-highlight (list re t t))))))))
+            (evil-ex-search-activate-highlight evil-ex-search-pattern)))))))
 
 (defun swiper-from-isearch ()
   "Invoke `swiper' from isearch."


### PR DESCRIPTION
Seems I was a bit hasty in my last pull request, this minor change allows for highlighting the matches on swiper exit if `evil-ex-search-persistent-highlight` is set to `t`