### PR TITLE
Refactor the linux application menu

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2750,7 +2750,17 @@ And insert it into the minibuffer. Useful during
               (end (re-search-forward "^\\[" nil t))
               name comment exec)
           (catch 'break
-            (unless start (throw 'break))
+            (unless start (throw 'break nil))
+
+            (goto-char start)
+            (when (re-search-forward "^\\(Hidden\\|NoDisplay\\) *= *\\(1\\|true\\) *$" end t)
+              (throw 'break nil))
+            (setq name (match-string 1))
+
+            (goto-char start)
+            (unless (re-search-forward "^Type *= *Application *$" end t)
+              (throw 'break nil))
+            (setq name (match-string 1))
 
             (goto-char start)
             (unless (re-search-forward "^Name *= *\\(.+\\)$" end t)

--- a/counsel.el
+++ b/counsel.el
@@ -2778,6 +2778,12 @@ And insert it into the minibuffer. Useful during
               (throw 'break nil))
             (setq exec (match-string 1))
 
+            (goto-char start)
+            (when (re-search-forward "^TryExec *= *\\(.+\\)$" end t)
+              (let ((try-exec (match-string 1)))
+                (unless (locate-file try-exec exec-path nil #'file-executable-p)
+                  (throw 'break nil))))
+
             (push
              (cons (format "% -45s: %s%s"
                            (propertize exec 'face 'font-lock-builtin-face)

--- a/counsel.el
+++ b/counsel.el
@@ -2791,16 +2791,14 @@ And insert it into the minibuffer. Useful during
 (defun counsel-linux-app-action-default (desktop-shortcut)
   "Launch DESKTOP-SHORTCUT."
   (setq desktop-shortcut (cdr desktop-shortcut))
-  (call-process-shell-command
-   (format "gtk-launch %s" desktop-shortcut)))
+  (call-process "gtk-launch" nil nil nil desktop-shortcut))
 
 (defun counsel-linux-app-action-file (desktop-shortcut)
   "Launch DESKTOP-SHORTCUT with a selected file."
   (setq desktop-shortcut (cdr desktop-shortcut))
   (let ((file (read-file-name "Open: ")))
     (if file
-        (call-process-shell-command
-         (format "gtk-launch %s \"%s\"" desktop-shortcut file))
+        (call-process "gtk-launch" nil nil nil desktop-shortcut file)
       (user-error "cancelled"))))
 
 (ivy-set-actions

--- a/counsel.el
+++ b/counsel.el
@@ -2745,20 +2745,25 @@ And insert it into the minibuffer. Useful during
     (dolist (file files result)
       (with-temp-buffer
         (insert-file-contents (cdr file))
-        (let (name comment exec)
+        (goto-char (point-min))
+        (let ((start (re-search-forward "^\\[Desktop Entry\\] *$" nil t))
+              (end (re-search-forward "^\\[" nil t))
+              name comment exec)
           (catch 'break
-            (goto-char (point-min))
-            (unless (re-search-forward "^Name *= *\\(.+\\)$" nil t)
+            (unless start (throw 'break))
+
+            (goto-char start)
+            (unless (re-search-forward "^Name *= *\\(.+\\)$" end t)
               (message "Warning: File %s has no Name" (cdr file))
               (throw 'break nil))
             (setq name (match-string 1))
 
-            (goto-char (point-min))
-            (when (re-search-forward "^Comment *= *\\(.+\\)$" nil t)
+            (goto-char start)
+            (when (re-search-forward "^Comment *= *\\(.+\\)$" end t)
               (setq comment (match-string 1)))
 
-            (goto-char (point-min))
-            (unless (re-search-forward "^Exec *= *\\(.+\\)$" nil t)
+            (goto-char start)
+            (unless (re-search-forward "^Exec *= *\\(.+\\)$" end t)
               ;; Don't warn because this can technically be a valid desktop file.
               (throw 'break nil))
             (setq exec (match-string 1))

--- a/counsel.el
+++ b/counsel.el
@@ -2747,16 +2747,16 @@ And insert it into the minibuffer. Useful during
         (insert-file-contents (cdr file))
         (let (name comment exec)
           (goto-char (point-min))
-          (if (null (re-search-forward "^Name *= *\\(.*\\)$" nil t))
+          (if (null (re-search-forward "^Name *= *\\(.+\\)$" nil t))
               (message "Warning: File %s has no Name" (cdr file))
             (setq name (match-string 1))
             (goto-char (point-min))
-            (when (re-search-forward "^Comment *= *\\(.*\\)$" nil t)
+            (when (re-search-forward "^Comment *= *\\(.+\\)$" nil t)
               (setq comment (match-string 1)))
             (goto-char (point-min))
-            (when (re-search-forward "^Exec *= *\\(.*\\)$" nil t)
+            (when (re-search-forward "^Exec *= *\\(.+\\)$" nil t)
               (setq exec (match-string 1)))
-            (when (and exec (not (equal exec "")))
+            (when exec
               (push
                (cons (format "% -45s: %s%s"
                              (propertize exec 'face 'font-lock-builtin-face)

--- a/counsel.el
+++ b/counsel.el
@@ -2733,10 +2733,11 @@ And insert it into the minibuffer. Useful during
     (dolist (dir (reverse counsel-linux-apps-directories))
       (when (file-exists-p dir)
         (let ((dir (file-name-as-directory dir)))
-          (dolist (file (directory-files dir nil ".*\\.desktop$"))
-            (let ((id (subst-char-in-string ?/ ?- file))
-                  (file (concat dir file)))
-              (puthash id file hash))))))
+          (dolist (file (directory-files-recursively dir ".*\\.desktop$"))
+            (puthash
+             (subst-char-in-string ?/ ?- (file-relative-name file dir))
+             file
+             hash)))))
     (maphash (lambda (key value)
                (push (cons key value) result))
              hash)


### PR DESCRIPTION
So, I've put this all into one PR for now so you can see it all at once but I'd be happy to break it into one PR per commit.

For details of the changes, please read the individual commit messages.

**To Discuss:**

* [x] Caching: ~I removed caching the application list because properly invalidating the cache is complicated and I didn't notice *any* slowdown (the menu is instantaneous).~ *Added back with invalidation (the invalidation scheme could probably be made faster but I'm being conservative).*
* [x] Open with prompt (counsel-linux-app-action-file): I removed the application "name" from this prompt because:

  - It was the first word of the `Exec` field which may not be meaningful (it's `env` in desktop files generated by WINE).

  - Given that I got rid of the application cache, I'd have to plumb through this information somehow. It's not hard, I'd just like to discuss what to do here before acting.