### PR TITLE
WIP: Add circe-mode to swiper-font-lock-exclude

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -254,6 +254,7 @@
     twittering-mode
     vc-dir-mode
     rcirc-mode
+    circe-mode
     sauron-mode
     w3m-mode)
   "List of major-modes that are incompatible with font-lock-ensure.")


### PR DESCRIPTION
This solves a bug reported for Circe, an IRC client for Emacs, at https://github.com/jorgenschaefer/circe/issues/303. This change was an idea of https://github.com/wasamasa. Also thanks to alphor from #emacs-circe@freenode.