### PR TITLE
Correct major-modes for Circe in swiper-font-lock-exclude

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -254,7 +254,9 @@
     twittering-mode
     vc-dir-mode
     rcirc-mode
-    circe-mode
+    circe-channel-mode
+    circe-server-mode
+    circe-query-mode
     sauron-mode
     w3m-mode)
   "List of major-modes that are incompatible with font-lock-ensure.")


### PR DESCRIPTION
The Circe IRC Client for Emacs, doesn't use a `circe-mode` but `circe-channel-mode`, `circe-server-mode` and `circe-query-mode`. See https://github.com/jorgenschaefer/circe/blob/a9df12a6e2f2c8e940722e151829d5dcf980c902/circe.el#L1757

Sorry for the complication...