### PR TITLE
Run wgrep-setup when entering ivy-occur-grep-mode

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3437,6 +3437,8 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
 \\{ivy-occur-grep-mode-map}"
   (setq-local view-read-only nil))
 
+(add-hook 'ivy-occur-grep-mode-hook 'wgrep-setup)
+
 (defvar ivy--occurs-list nil
   "A list of custom occur generators per command.")
 


### PR DESCRIPTION
wgrep-setup saves the local keymap when entering wgrep mode and
restores it when exiting. By adding a hook to run it when entering
ivy-occur-grep-mode we prevent the keymap from being lost after one
edit.

Fixes #711 