### PR TITLE
counsel.el: remove unnecessary with-ivy-window macro call

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1383,13 +1383,12 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
             :initial-input initial-input
             :action
             (lambda (x)
-              (with-ivy-window
-                (let ((find-file-hook (if (and
-                                           counsel-find-file-speedup-remote
-                                           (file-remote-p ivy--directory))
-                                          nil
-                                        find-file-hook)))
-                  (find-file (expand-file-name x ivy--directory)))))
+              (let ((find-file-hook (if (and
+                                         counsel-find-file-speedup-remote
+                                         (file-remote-p ivy--directory))
+                                        nil
+                                      find-file-hook)))
+                (find-file (expand-file-name x ivy--directory))))
             :preselect (when counsel-find-file-at-point
                          (require 'ffap)
                          (let ((f (ffap-guesser)))


### PR DESCRIPTION
* from counsel-find-file
* it causes problem in my environment
* it is a no-op anyways