### PR TITLE
Define ivy-help-file with defconst

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3637,14 +3637,14 @@ EVENT gives the mouse position."
   (ivy-occur-press)
   (select-window (ivy--get-window ivy-occur-last)))
 
-(defvar ivy-help-file (let ((default-directory
-                             (if load-file-name
-                                 (file-name-directory load-file-name)
-                               default-directory)))
-                        (if (file-exists-p "ivy-help.org")
-                            (expand-file-name "ivy-help.org")
-                          (if (file-exists-p "doc/ivy-help.org")
-                              (expand-file-name "doc/ivy-help.org"))))
+(defconst ivy-help-file (let ((default-directory
+                               (if load-file-name
+                                   (file-name-directory load-file-name)
+                                 default-directory)))
+                          (if (file-exists-p "ivy-help.org")
+                              (expand-file-name "ivy-help.org")
+                            (if (file-exists-p "doc/ivy-help.org")
+                                (expand-file-name "doc/ivy-help.org"))))
   "The file for `ivy-help'.")
 
 (defun ivy-help ()


### PR DESCRIPTION
After the Ivy package is upgraded and the old version removed, the defvar will not be redefined when the new package is loaded. With defconst, I believe it will.