### PR TITLE
swiper.el (swiper--action): Set evil search direction to forward

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -722,6 +722,7 @@ WND, when specified is the window."
                    (eq evil-search-module 'evil-search))
           (add-to-history 'evil-ex-search-history re)
           (setq evil-ex-search-pattern (list re t t))
+          (setq evil-ex-search-direction 'forward)
           (when evil-ex-search-persistent-highlight
             (evil-ex-search-activate-highlight evil-ex-search-pattern)))))))
 


### PR DESCRIPTION
Without setting evil-ex-search-direction, evil-search-next and
evil-search-previous (bound to `n` and `N` in evil-mode) will repeat
swiper's last search, but will use the direction of the pre-swiper
search. If there is no previous search before swiper, evil-search-next
and evil-search-previous will not work. swiper doesn't have a concept
of `backward` search, hence it makes sense to always set direction to
'forward.