### PR TITLE
counsel.el (counsel-package-action): Add defvar

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2232,6 +2232,7 @@ INITIAL-INPUT can be given as the initial minibuffer input."
 
 ;;** `counsel-package'
 (defvar package--initialized)
+(defvar package-alist)
 (defvar package-archive-contents)
 (declare-function package-installed-p "package")
 (declare-function package-delete "package")


### PR DESCRIPTION
Declare free variable `package-alist` from `package.el` to silence byte-compiler.