### PR TITLE
Limit rg results to 150 columns

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1836,7 +1836,7 @@ This uses `counsel-ag' with `counsel-pt-base-command' replacing
     (counsel-ag initial-input)))
 
 ;;** `counsel-rg'
-(defcustom counsel-rg-base-command "rg -i --no-heading --line-number %s ."
+(defcustom counsel-rg-base-command "rg -i --no-heading --line-number --max-columns 150 %s ."
   "Used to in place of `counsel-rg-base-command' to search with
 ripgrep using `counsel-rg'."
   :type 'string


### PR DESCRIPTION
Emacs doesn't handle long line lengths very well. If you accidentally rg a file
a file that has very long line lengths it can freeze emacs. This prevents rg
from returning any results with more than 150 characters. Instead, it will
indicate that there were results in that file but they were elided.