### PR TITLE
Add a command to switch to shell buffers.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3485,11 +3485,27 @@ MODE is a symbol."
   "Switch to a shell buffer, or create one."
   (interactive)
   (require 'pcase)
-  (switch-to-buffer
+  (counsel-switch-to-buffer-or-window
    (pcase (counsel-list-buffers-with-mode 'shell-mode)
      (`() (progn (shell) "*shell*"))
      (`(,buf) buf)
      ((and `(,_ . ,_) bufs) (ivy-read "Switch to shell buffer: " bufs)))))
+
+(defun counsel-switch-to-buffer-or-window (buffer-or-name)
+  "Display buffer BUFFER-OR-NAME and select its window.
+
+This behaves as `switch-to-buffer', except when the buffer is
+already visible; in that case, select the window corresponding to
+the buffer."
+  (let ((buffer (window-normalize-buffer-to-switch-to buffer-or-name)))
+    (let (window-of-buffer-visible)
+      (catch 'found
+        (walk-windows (lambda (window)
+                        (and (equal (window-buffer window) buffer)
+                             (throw 'found (setq window-of-buffer-visible window))))))
+      (if window-of-buffer-visible
+          (select-window window-of-buffer-visible)
+        (switch-to-buffer buffer)))))
 
 ;;;###autoload
 (define-minor-mode counsel-mode

--- a/counsel.el
+++ b/counsel.el
@@ -3482,12 +3482,16 @@ MODE is a symbol."
 
 ;;;###autoload
 (defun counsel-switch-to-shell-buffer ()
-  "Switch to a shell buffer, or create one."
+  "Switch to a shell buffer, or create one.
+
+List all the buffers in `shell-mode'. Is there is none, create
+one; if there is exactly one, switch to it; otherwise, select one
+of them and switch to it."
   (interactive)
   (require 'pcase)
   (counsel-switch-to-buffer-or-window
    (pcase (counsel-list-buffers-with-mode 'shell-mode)
-     (`() (progn (shell) "*shell*"))
+     (`() (shell))
      (`(,buf) buf)
      ((and `(,_ . ,_) bufs) (ivy-read "Switch to shell buffer: " bufs)))))
 

--- a/counsel.el
+++ b/counsel.el
@@ -3481,17 +3481,19 @@ MODE is a symbol."
              (push (buffer-name buf) bufs))))))
 
 ;;;###autoload
-(defun counsel-switch-to-shell-buffer ()
+(defun counsel-switch-to-shell-buffer (force-create)
   "Switch to a shell buffer, or create one.
 
-List all the buffers in `shell-mode'. Is there is none, create
-one; if there is exactly one, switch to it; otherwise, select one
-of them and switch to it."
-  (interactive)
+List all the buffers in `shell-mode'. Is there is none or
+if FORCE-CREATE is non nil, create one; if there is exactly one,
+switch to it; otherwise, select one of them and switch to it."
+  (interactive "P")
   (require 'pcase)
   (counsel-switch-to-buffer-or-window
    (pcase (counsel-list-buffers-with-mode 'shell-mode)
-     (`() (shell))
+     ((or (guard force-create) `())
+      (shell (read-string "Buffer name: "
+                          (generate-new-buffer-name "*shell*"))))
      (`(,buf) buf)
      ((and `(,_ . ,_) bufs) (ivy-read "Switch to shell buffer: " bufs)))))
 

--- a/counsel.el
+++ b/counsel.el
@@ -3469,6 +3469,26 @@ active."
   :group 'ivy
   :type 'boolean)
 
+(defun counsel-list-buffers-with-mode (mode)
+  "List all buffers with major-mode MODE.
+
+MODE is a symbol."
+  (let (bufs)
+    (dolist (buf (buffer-list) bufs)
+      (and (equal (with-current-buffer buf major-mode) mode)
+           (push (buffer-name buf) bufs)))))
+
+;;;###autoload
+(defun counsel-switch-to-shell-buffer ()
+  "Switch to a shell buffer, or create one."
+  (interactive)
+  (require 'pcase)
+  (switch-to-buffer
+   (pcase (counsel-list-buffers-with-mode 'shell-mode)
+     (`() (progn (shell) "*shell*"))
+     (`(,buf) buf)
+     ((and `(,_ . ,_) bufs) (ivy-read "Switch to shell buffer: " bufs)))))
+
 ;;;###autoload
 (define-minor-mode counsel-mode
   "Toggle Counsel mode on or off.

--- a/counsel.el
+++ b/counsel.el
@@ -3473,10 +3473,12 @@ active."
   "List all buffers with major-mode MODE.
 
 MODE is a symbol."
-  (let (bufs)
-    (dolist (buf (buffer-list) bufs)
-      (and (equal (with-current-buffer buf major-mode) mode)
-           (push (buffer-name buf) bufs)))))
+  (save-current-buffer
+    (let (bufs)
+      (dolist (buf (buffer-list) bufs)
+        (set-buffer buf)
+        (and (equal major-mode mode)
+             (push (buffer-name buf) bufs))))))
 
 ;;;###autoload
 (defun counsel-switch-to-shell-buffer ()


### PR DESCRIPTION
The command improves the `shell' command, as it offers an overview of all shell buffers when appropriate.