### PR TITLE
 add variable to customize behavior of the magic slash on non-existing directories

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1145,6 +1145,10 @@ If so, move to that directory, while keeping only the file name."
     (setq ivy-text "")
     (delete-minibuffer-contents)))
 
+(defun ivy--create-and-cd (dir)
+  (make-directory dir)
+  (ivy--cd dir))
+
 (defun ivy-backward-delete-char ()
   "Forward to `backward-delete-char'.
 On error (read-only), call `ivy-on-del-error-function'."
@@ -2314,12 +2318,31 @@ If SUBEXP is nil, the text properties are applied to the whole match."
                  (not (equal (ivy-state-current ivy-last) ""))
                  (file-directory-p (ivy-state-current ivy-last))
                  (file-exists-p (ivy-state-current ivy-last)))))
-         (ivy--cd
-          (expand-file-name (ivy-state-current ivy-last) ivy--directory)))
+           (when (eq ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-cd-selected)
+             (ivy--cd
+               (expand-file-name (ivy-state-current ivy-last) ivy--directory)))
+           (when 
+             (and (eq ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-create)
+                  (not (string= ivy-text "/")))
+             (ivy--create-and-cd (expand-file-name ivy-text ivy--directory))))
         ((and (file-exists-p ivy-text)
               (not (string= ivy-text "/"))
               (file-directory-p ivy-text))
-         (ivy--cd ivy-text))))
+           (ivy--cd ivy-text))
+        (t 
+          (when (and 
+                  (eq ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-create)
+                  (not (string= ivy-text "/")))
+             (ivy--create-and-cd (expand-file-name ivy-text ivy--directory))))))
+
+(defcustom ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-cd-selected
+  "Action to take when a slash is added to the end of a non existing directory.
+Possible choices are 'ivy-magic-slash-non-match-use-selected, 
+'ivy-magic-slash-non-match-create, or nil"
+  :type '(choice
+          (const :tag "Use currently selected directory" ivy-magic-slash-non-match-use-selected)
+          (const :tag "Create and use new directory" ivy-magic-slash-non-match-create)
+          (const :tag "Do nothing" nil)))
 
 (defcustom ivy-magic-tilde t
   "When non-nil, ~ will move home when selecting files.


### PR DESCRIPTION
Added variable ```ivy-magic-slash``` that controls whether or not the 'magic slash' is applied when selecting files. If non-nil (default) the magic slash will be applied, if set to nil then the magic slash will not be applied.

The personal pain point this solved for me is creating files in non-existing directories. As an example, with the 'magic-slash' enabled I found it impossible to create ```~/docs/todo.org``` when the folder ```~/docs``` did not exist and the folder ```~/Documents``` did exist. Adding the ```/``` after ```docs``` resulted in ```ivy--cd``` being called with the ```Documents``` directory.