### PR TITLE
Prevent opening an already open file in counsel-grep

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1929,21 +1929,27 @@ the command."
                    (setq file-name (match-string-no-properties 1 x))
                    (setq line-number (match-string-no-properties 2 x)))
                   (t nil))
-        (find-file file-name)
-        (setq line-number (string-to-number line-number))
-        (if (null counsel-grep-last-line)
-            (progn
-              (goto-char (point-min))
-              (forward-line (1- (setq counsel-grep-last-line line-number))))
-          (forward-line (- line-number counsel-grep-last-line))
-          (setq counsel-grep-last-line line-number))
-        (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
-        (run-hooks 'counsel-grep-post-action-hook)
-        (if (eq ivy-exit 'done)
-            (swiper--ensure-visible)
-          (isearch-range-invisible (line-beginning-position)
-                                   (line-end-position))
-          (swiper--add-overlays (ivy--regex ivy-text)))))))
+        ;; If the file buffer is already open, just get it. Prevent doing
+        ;; `find-file', as that file could have already been opened using
+        ;; `find-file-literally'.
+        (let ((buf (get-file-buffer file-name)))
+          (unless buf
+            (setq buf (find-file file-name)))
+          (with-current-buffer buf
+            (setq line-number (string-to-number line-number))
+            (if (null counsel-grep-last-line)
+                (progn
+                  (goto-char (point-min))
+                  (forward-line (1- (setq counsel-grep-last-line line-number))))
+              (forward-line (- line-number counsel-grep-last-line))
+              (setq counsel-grep-last-line line-number))
+            (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
+            (run-hooks 'counsel-grep-post-action-hook)
+            (if (eq ivy-exit 'done)
+                (swiper--ensure-visible)
+              (isearch-range-invisible (line-beginning-position)
+                                       (line-end-position))
+              (swiper--add-overlays (ivy--regex ivy-text)))))))))
 
 (defun counsel-grep-occur ()
   "Generate a custom occur buffer for `counsel-grep'."


### PR DESCRIPTION
* counsel.el (counsel-grep-action): If a file is already open in
  a buffer, get that buffer's handle using get-file-buffer.  This
  is to prevent the scenario where a file is already opened using
  find-file-literally.  In that case, if find-file is attempted for
  the same file, user is nagged with question if they intended to
  switch to opening the file normally from "literally".  Situation
  escalates when the file is huge (100's of MB).

  Do find-file only if the searched file is not yet opened in any
  buffer.