### PR TITLE
ivy.el (ivy-magic-slash-non-match-action): Fix val naming duplicity

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2295,12 +2295,15 @@ If SUBEXP is nil, the text properties are applied to the whole match."
 
 (defcustom ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-cd-selected
   "Action to take when a slash is added to the end of a non existing directory.
-Possible choices are 'ivy-magic-slash-non-match-use-selected,
+Possible choices are 'ivy-magic-slash-non-match-cd-selected,
 'ivy-magic-slash-non-match-create, or nil"
   :type '(choice
-          (const :tag "Use currently selected directory" ivy-magic-slash-non-match-use-selected)
-          (const :tag "Create and use new directory" ivy-magic-slash-non-match-create)
-          (const :tag "Do nothing" nil)))
+          (const :tag "Use currently selected directory"
+                 ivy-magic-slash-non-match-cd-selected)
+          (const :tag "Create and use new directory"
+                 ivy-magic-slash-non-match-create)
+          (const :tag "Do nothing"
+                 nil)))
 
 (defun ivy--create-and-cd (dir)
   (make-directory dir)


### PR DESCRIPTION
* `ivy-magic-slash-non-match-cd-selected' and
  `ivy-magic-slash-non-match-use-selected' were erroneously both
  used to refer to the same value in different places--retain the
  former since it's more descriptive