### PR TITLE
counsel.el (counsel-org-goto--add-face): Keep text properties

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2408,7 +2408,7 @@ The face can be customized through `counsel-org-goto-face-style'."
             name
             'face
             (nth (1- level) counsel-org-goto-custom-faces)))
-      (substring-no-properties name)))
+      (propertize name 'face 'minibuffer-prompt)))
 
 ;;** `counsel-mark-ring'
 (defun counsel--pad (string length)


### PR DESCRIPTION
If `counsel-org-goto-face-style` was set to `nil`, the headlines were stripped of all their text properties. This caused text to appear which was intentionally hidden by `org-mode` e.g. the uri of a link.

The fixed function now just applies the default minibuffer face on top of the existing properties, which looks like the entries have not been styled at all but preserves the other properties.