### PR TITLE
counsel.el (counsel-yank-pop): ignore entirely empty candidates

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2657,7 +2657,7 @@ Additional Actions:
          (mapcar #'ivy-cleanup-string
                  (cl-remove-if
                   (lambda (s)
-                    (string-match "\\`[\n[:blank:]]+\\'" s))
+                    (string-match "\\`[\n[:blank:]]*\\'" s))
                   (delete-dups kill-ring)))))
     (let ((ivy-format-function #'counsel--yank-pop-format-function)
           (ivy-height 5))


### PR DESCRIPTION
* whose most noticeable effect -- when present in `kill-ring` and
  not ignored here -- is their preselection upon every new call to
  `counsel-yank-pop` (since they exactly match an empty initial
  input); empty initial input could perhaps be special-cased w/r/t
  preselection, but, regardless:

* pasting an entirely empty string is a no-op, so `counsel-yank-pop`
  should likely exclude such candidates (are entirely empty strings
  ever useful ivy candidates?)