### PR TITLE
Properly handle list and nil default in ivy-completing-read

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -518,6 +518,24 @@
               "bl C-p C-M-j")
              "bl"))))
 
+(ert-deftest ivy-completing-read-default ()
+  (should
+   (equal "b"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "b")
+                    "RET")))
+  (should
+   (equal "d"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "d")
+                    "RET")))
+  (should
+   (equal "e"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil '("e" "b"))
+                    "RET")))
+  (should
+   (equal ""
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
+                    "RET"))))
+
 (provide 'ivy-test)
 
 ;;; ivy-test.el ends here

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -518,33 +518,55 @@
               "bl C-p C-M-j")
              "bl"))))
 
-(ert-deftest ivy-completing-read-default ()
-  (should
+(ert-deftest ivy-completing-read-def-handling ()
    ;; DEF in COLLECTION
+  (should
    (equal "b"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "b")
                     "RET")))
+  ;; Also make sure that choosing a non-default item works
+  (should
+   (equal "c"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "b")
+                    "c RET")))
   ;; DEF not in COLLECTION
   (should
    (equal "d"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "d")
                     "RET")))
+  (should
+   (equal "c"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "d")
+                    "c RET")))
   ;; DEF list, some in COLLECTION
   (should
    (equal "e"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil '("e" "b"))
                     "RET")))
+  (should
+   (equal "c"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil '("e" "b"))
+                    "c RET")))
   ;; DEF nil
   (should
-   (equal ""
+   (equal "a"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
                     "RET")))
-  ;; DEF nil, and `ivy-completing-read-default-is-empty-string' also nil
   (should
-   (equal "a"
-          (let ((ivy-completing-read-default-is-empty-string nil))
-            (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
-                      "RET")))))
+   (equal "c"
+          (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
+                    "c RET")))
+  ;; DEF nil, and called via `ivy-completing-read-with-empty-string-def'
+  (should
+   (equal ""
+          (ivy-with '(ivy-completing-read-with-empty-string-def
+                      "Pick: " '("a" "b" "c") nil t nil nil nil)
+                    "RET")))
+  (should
+   (equal "c"
+          (ivy-with '(ivy-completing-read-with-empty-string-def
+                      "Pick: " '("a" "b" "c") nil t nil nil nil)
+                      "c RET"))))
 
 (provide 'ivy-test)
 

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -59,6 +59,18 @@
   (setq this-command cmd)
   (apply #'command-execute cmd args))
 
+(defadvice symbol-function (around no-void-function activate)
+  "Suppress void-function errors.
+
+This advice makes `symbol-function' return nil when called on a
+symbol with no function rather than throwing a void-fucntion
+error. On Emacs 24.4 and above, this has no effect, because
+`symbol-function' already does this, but on 24.3 and earlier, it
+will bring the behavior in line with the newer Emacsen."
+  (condition-case nil
+      ad-do-it
+    (void-function nil)))
+
 (ert-deftest ivy-partial ()
   (should (equal
            (ivy-with '(ivy-read "test: " '("case" "Case"))

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -520,21 +520,31 @@
 
 (ert-deftest ivy-completing-read-default ()
   (should
+   ;; DEF in COLLECTION
    (equal "b"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "b")
                     "RET")))
+  ;; DEF not in COLLECTION
   (should
    (equal "d"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil "d")
                     "RET")))
+  ;; DEF list, some in COLLECTION
   (should
    (equal "e"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil '("e" "b"))
                     "RET")))
+  ;; DEF nil
   (should
    (equal ""
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
-                    "RET"))))
+                    "RET")))
+  ;; DEF nil, and `ivy-completing-read-default-is-empty-string' also nil
+  (should
+   (equal "a"
+          (let ((ivy-completing-read-default-is-empty-string nil))
+            (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
+                      "RET")))))
 
 (provide 'ivy-test)
 

--- a/ivy.el
+++ b/ivy.el
@@ -273,14 +273,6 @@ Example:
 This is a global variable that is set by ivy functions for use in
 action functions.")
 
-(defvar ivy-completing-read-default-is-empty-string t
-  "If non-nil, emulate default arg handling of `completing-read-default'.
-
-Specifically, if `ivy-completing-read' is called with DEF nil, it
-will be treated as equivalent to specifying the empty string for
-DEF, since that is what `completing-read-default' does. If this
-is nil, then a nil DEF will really mean no default.")
-
 ;;* Keymap
 (require 'delsel)
 (defvar ivy-minibuffer-map
@@ -1864,8 +1856,6 @@ INHERIT-INPUT-METHOD is currently ignored."
           (setq initial-input (nth (1- (cdr history))
                                    (symbol-value (car history)))))
         (setq history (car history)))
-      (when (and (null def) ivy-completing-read-default-is-empty-string)
-        (setq def ""))
       (ivy-read (replace-regexp-in-string "%" "%%" prompt)
                 collection
                 :predicate predicate
@@ -1888,6 +1878,21 @@ INHERIT-INPUT-METHOD is currently ignored."
                                this-command)
                               ((and collection (symbolp collection))
                                collection))))))
+
+(defun ivy-completing-read-with-empty-string-def
+    (prompt collection
+            &optional predicate require-match initial-input
+            history def inherit-input-method)
+  "Same as `ivy-completing-read' but with different handling of DEF.
+
+Specifically, if DEF is nil, it is treated the same as if DEF was
+the empty string. This mimics the behavior of
+`completing-read-refault'. This function can therefore be used in
+place of `icy-completing-read' for commands that rely on this
+behavior."
+  (ivy-completing-read
+   prompt collection predicate require-match initial-input
+   history (or def "") inherit-input-method))
 
 (defvar ivy-completion-beg nil
   "Completion bounds start.")

--- a/ivy.el
+++ b/ivy.el
@@ -198,7 +198,16 @@ See https://github.com/abo-abo/swiper/wiki/ivy-display-function."
 
 (defcustom ivy-completing-read-handlers-alist
   '((tmm-menubar . completing-read-default)
-    (tmm-shortcut . completing-read-default))
+    (tmm-shortcut . completing-read-default)
+    (bbdb-create . ivy-completing-read-with-empty-string-def)
+    (auto-insert . ivy-completing-read-with-empty-string-def)
+    (Info-on-current-buffer . ivy-completing-read-with-empty-string-def)
+    (Info-follow-reference . ivy-completing-read-with-empty-string-def)
+    (Info-menu . ivy-completing-read-with-empty-string-def)
+    (Info-index . ivy-completing-read-with-empty-string-def)
+    (Info-virtual-index . ivy-completing-read-with-empty-string-def)
+    (info-display-manual . ivy-completing-read-with-empty-string-def)
+    (webjump . ivy-completing-read-with-empty-string-def))
   "An alist of handlers to replace `completing-read' in `ivy-mode'."
   :type '(alist :key-type function :value-type function))
 

--- a/ivy.el
+++ b/ivy.el
@@ -273,6 +273,14 @@ Example:
 This is a global variable that is set by ivy functions for use in
 action functions.")
 
+(defvar ivy-completing-read-default-is-empty-string t
+  "If non-nil, emulate default arg handling of `completing-read-default'.
+
+Specifically, if `ivy-completing-read' is called with DEF nil, it
+will be treated as equivalent to specifying the empty string for
+DEF, since that is what `completing-read-default' does. If this
+is nil, then a nil DEF will really mean no default.")
+
 ;;* Keymap
 (require 'delsel)
 (defvar ivy-minibuffer-map
@@ -1856,6 +1864,8 @@ INHERIT-INPUT-METHOD is currently ignored."
           (setq initial-input (nth (1- (cdr history))
                                    (symbol-value (car history)))))
         (setq history (car history)))
+      (when (and (null def) ivy-completing-read-default-is-empty-string)
+        (setq def ""))
       (ivy-read (replace-regexp-in-string "%" "%%" prompt)
                 collection
                 :predicate predicate


### PR DESCRIPTION
This pull request allows `ivy-completing-read` to handle a DEF argument that is a list or nil consistently with `completing-read-default`. It also adds tests for this behavior, including tests for the case where DEF is not an element of COLLECTION.