### PR TITLE
Avoid setting ivy window as minibuffer

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1915,7 +1915,8 @@ The previous string is between `ivy-completion-beg' and `ivy-completion-end'."
         (if (null (cdr comps))
             (if (string= str (car comps))
                 (message "Sole match")
-              (setf (ivy-state-window ivy-last) (selected-window))
+              (unless (minibuffer-window-active-p (selected-window))
+                (setf (ivy-state-window ivy-last) (selected-window)))
               (ivy-completion-in-region-action
                (substring-no-properties
                 (car comps))))


### PR DESCRIPTION
* ivy.el (ivy-completion-in-region): Don't set ivy window to minibuffer window

Fixes #1051