### PR TITLE
counsel.el (counsel-file-register): Use Ivy to open file registers

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -643,6 +643,32 @@ input corresponding to the chosen variable."
  'counsel-M-x
  'counsel-M-x-transformer)
 
+;;;###autoload
+(defun counsel-file-register ()
+  (interactive)
+  (ivy-read "File Register: "
+            ;; Use the `register-alist' variable to filter out file
+            ;; registers.  Each entry for a file registar will have the
+            ;; following layout:initj
+            ;;
+            ;;     (NUMBER 'file . "string/path/to/file")
+            ;;
+            ;; So we go through each entry and see if the `cadr' is
+            ;; `eq' to the symbol `file'.  If so then add the filename
+            ;; (`cddr') which `ivy-read' will use for its choices.
+            (mapcar (lambda (register-alist-entry)
+                      (if (eq 'file (cadr register-alist-entry))
+                          (cddr register-alist-entry)))
+                      register-alist)
+            :sort t
+            :require-match t
+            :history 'counsel-file-register
+            :caller 'counsel-file-register
+            :action (lambda (register-file)
+                      (with-ivy-window (find-file register-file)))
+            :history 'counsel-file-register
+            :caller 'counsel-file-register))
+
 (declare-function bookmark-all-names "bookmark")
 (declare-function bookmark-location "bookmark")
 


### PR DESCRIPTION
GNU Emacs allows you to keep file registers, i.e. registers to quickly
open commonly used files (see the link below for more information).

Truth be told the `counsel-file-register` command will sometimes place
the list of files in an undesired position, e.g. covering up important
windows.  Nonetheless I find it useful as someone with many file
registers.

Future improvements will be to create a file register from a given
open file.

See-Also: https://www.gnu.org/software/emacs/manual/html_node/emacs/File-Registers.html#File-Registers

**Note:** Maybe wait on merging until I experiment with ways to create new file registers use `counsel-file-register` in a file that has no associated file register.