### PR TITLE
ivy.el: Make prompt line selectable

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -426,4 +426,80 @@
             "RET")
            "default")))
 
+(ert-deftest ivy-read-prompt ()
+  (let ((prompt "pattern: ")
+        (collection '("blue" "yellow")))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-m")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-p C-m")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-j")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-p C-j")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-M-j")
+             "bl"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt nil))
+                 (ivy-read prompt collection))
+              "bl C-p C-M-j")
+             "bl"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-m")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-p C-m")
+             "bl"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-j")
+             "blue"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-p C-j")
+             "bl"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-M-j")
+             "bl"))
+    (should (equal
+             (ivy-with
+              '(let ((ivy-use-selectable-prompt t))
+                 (ivy-read prompt collection))
+              "bl C-p C-M-j")
+             "bl"))))
+
 (provide 'ivy-test)


### PR DESCRIPTION
This is an attempt to make selecting a custom input more intuitive by letting the user select the prompt line, as suggested by @Stebalien in https://github.com/abo-abo/swiper/issues/933#issue-216622975.

Calling `ivy-done` (`C-m`) or `ivy-alt-done` (`C-j`) on a selected prompt exits with the current user input and is thus equivalent to calling `ivy-immediate-done` (`C-M-j`) when any candidate is selected. Therefore, remembering `C-M-j` is not necessary anymore. If no candidate matches the current input, the prompt line is selected automatically, as this is the only option left for the user.

To activate this behaviour, set the new variable `ivy-use-selectable-prompt` to `t`. Note that selecting the prompt line is not possible if `ivy-read` is called with predicate `:require-match` set to `t`, since a custom input is not allowed in this case. Customize face `ivy-prompt-match` to adjust the look of the selected prompt if you want it to differ from a selected candidate.