### PR TITLE
ivy.el (ivy--prompt-selectable-p): Fix require-match condition

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -550,7 +550,8 @@ candidate, not the prompt."
 (defun ivy--prompt-selectable-p ()
   "Return t if the prompt line is selectable."
   (and ivy-use-selectable-prompt
-       (not (ivy-state-require-match ivy-last))))
+       (memq (ivy-state-require-match ivy-last)
+             '(nil confirm confirm-after-completion))))
 
 (defun ivy--prompt-selected-p ()
   "Return t if the prompt line is selected."


### PR DESCRIPTION
The prompt was not selectable, if predicate `:require-match` was set to `'confirm` or `'confirm-after-completion`.