### PR TITLE
Makefile: Execute checkdoc on lisp files when executing `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ all: test
 test:
 	$(emacs) -batch $(LOAD) -l ivy-test.el -f ert-run-tests-batch-and-exit
 
+checkdoc:
+	$(emacs) -batch -l targets/checkdoc.el
+
 compile:
 	$(emacs) -batch --eval "(progn (add-to-list 'load-path default-directory) (mapc #'byte-compile-file '(\"ivy.el\" \"swiper.el\" \"counsel.el\" \"colir.el\" \"ivy-overlay.el\")))"
 
@@ -24,4 +27,4 @@ update-issues:
 clean:
 	rm -f *.elc
 
-.PHONY: all compile clean test update-issues
+.PHONY: all compile clean test update-issues checkdoc

--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ The copyright assignment isn't a big deal, it just says that the copyright for y
 
 The basic code style guide is to use `(setq indent-tabs-mode nil)`. It is provided for you in [.dir-locals.el](https://github.com/abo-abo/swiper/blob/master/.dir-locals.el), please obey it.
 
-Before submitting the change, run `make compile` and `make test` to make sure that it doesn't introduce new compile warnings or test failures. Also run <kbd>M-x</kbd> `checkdoc` to see that your changes obey the documentation guidelines.
+Before submitting the change, run `make compile` and `make test` to make sure that it doesn't introduce new compile warnings or test failures. Also run `make checkdoc` to see that your changes obey the documentation guidelines.
 
 Use your own judgment for the commit messages, I recommend a verbose style using `magit-commit-add-log`.

--- a/targets/checkdoc.el
+++ b/targets/checkdoc.el
@@ -1,0 +1,6 @@
+(checkdoc-file "colir.el")
+(checkdoc-file "counsel.el")
+(checkdoc-file "ivy-overlay.el")
+(checkdoc-file "ivy-test.el")
+(checkdoc-file "ivy.el")
+(checkdoc-file "swiper.el")


### PR DESCRIPTION
This is a follow-up PR to #1064 which let's you easily check if the code is still without checkdoc warnings by simply calling `make test`.