### PR TITLE
Better behavior when initial-input contains ~/

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2457,6 +2457,8 @@ Should be run via minibuffer `post-command-hook'."
                         (and (string= "~" ivy-text)
                              ivy-magic-tilde))
                     (ivy--cd (expand-file-name "~/")))
+                   ((string-prefix-p "~/" ivy-text)
+                    (ivy--cd-maybe))
                    ((string-match "/\\'" ivy-text)
                     (ivy--magic-file-slash))))
             ((eq (ivy-state-collection ivy-last) 'internal-complete-buffer)


### PR DESCRIPTION
When setting initial-input, unexpected behavior can occur if the initial input relates to file completion relative to ~/. This simple patch seems to fix the problem without causing other issues. However, I am no expert on ivy, so I'm not sure this is the right place to fix the behvior (vs., for example, expanding the filename on entry somewhere else??)