### PR TITLE
ivy.el (ivy-avy): Get rid of error message when exiting avy silently

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1294,10 +1294,11 @@ On error (read-only), call `ivy-on-del-error-function'."
             (avy--process
              (nreverse candidates)
              (avy--style-fn avy-style)))))
-    (goto-char candidate)
-    (ivy--done
-     (buffer-substring-no-properties
-      (point) (line-end-position)))))
+    (when (number-or-marker-p candidate)
+      (goto-char candidate)
+      (ivy--done
+       (buffer-substring-no-properties
+        (point) (line-end-position))))))
 
 (defun ivy-sort-file-function-default (x y)
   "Compare two files X and Y.


### PR DESCRIPTION
If you call `ivy-avy` and then exit with `C-g`, an error message `Wrong type argument: integer-or-marker-p, t` appears before the candidates are displayed again.

This PR gets rid of this message.