### PR TITLE
counsel.el (counsel-M-x): Don't rebuild cache on every invocation.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -773,8 +773,8 @@ Optional INITIAL-INPUT is the initial input in the minibuffer."
     (when (require 'smex nil 'noerror)
       (unless smex-initialized-p
         (smex-initialize))
-      (smex-detect-new-commands)
-      (smex-update)
+      (when (smex-detect-new-commands)
+        (smex-update))
       (setq cands smex-ido-cache)
       (setq pred nil)
       (setq sort nil))


### PR DESCRIPTION
`counsel-M-x` is really slow for me and I think it has something to do with the rebuild of the `smex-ido-cache` which happens on each invocation of `counsel-M-x`. 

By guarding the cache rebuilding only if new commands are detected we can increase the speed of `counsel-M-x` subsequent invocations. 

Thanks (and keep up the awesome work!)