### PR TITLE
counsel.el (counsel-git-grep-recenter): fix warning by `recenter`

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1364,8 +1364,8 @@ When REVERT is non-nil, regenerate the current *ivy-occur* buffer."
 (defun counsel-git-grep-recenter ()
   "Recenter window according to the selected candidate."
   (interactive)
+  (counsel-git-grep-action (ivy-state-current ivy-last))
   (with-ivy-window
-    (counsel-git-grep-action (ivy-state-current ivy-last))
     (recenter-top-bottom)))
 
 ;;** `counsel-git-stash'


### PR DESCRIPTION
Without this fix, C-l (in counsel-git-grep-map) would print the warning:
`recenter'ing a window that does not display current-buffer.