### PR TITLE
Fix git worktree close action.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1446,17 +1446,18 @@ TREE is the selected candidate."
 (defun counsel-git-toplevel ()
   "Return the base directory of the current git repository."
   (let ((out (string-trim-right (shell-command-to-string "git rev-parse --show-toplevel"))))
-    (and (string-match-p "Not a git repository" out) (error "Not a git repository!"))
-    out))
+    (unless (string-match-p "Not a git repository" out) out)))
 
 (defun counsel-git-close-worktree-files-action (root-dir)
   "Close all buffers from the worktree located at ROOT-DIR."
   (save-excursion
     (dolist (buf (buffer-list))
       (set-buffer buf)
-      (and buffer-file-name
-           (string= "." (file-relative-name root-dir (counsel-git-toplevel)))
-           (kill-buffer buf)))))
+      (let (top)
+        (and buffer-file-name
+             (setq top (counsel-git-toplevel))
+             (string= "." (file-relative-name root-dir top))
+             (kill-buffer buf))))))
 
 (ivy-set-actions
  'counsel-git-change-worktree

--- a/counsel.el
+++ b/counsel.el
@@ -1450,6 +1450,7 @@ TREE is the selected candidate."
 
 (defun counsel-git-close-worktree-files-action (root-dir)
   "Close all buffers from the worktree located at ROOT-DIR."
+  (setq root-dir (counsel-git-worktree-parse-root root-dir))
   (save-excursion
     (dolist (buf (buffer-list))
       (set-buffer buf)


### PR DESCRIPTION
Following #1114 :

+ Don't trigger an error while walking all buffers
+ Parse the output of `git worktree list`, the step was missing.