### PR TITLE
Fix ivy-previous-line-or-history behaviour on non-initial result

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -959,7 +959,7 @@ If the input is empty, select the previous history element instead."
   "Move cursor vertically up ARG candidates.
 If the input is empty, select the previous history element instead."
   (interactive "p")
-  (when (string= ivy-text "")
+  (when (and (zerop ivy--index) (string= ivy-text ""))
     (ivy-previous-history-element 1))
   (ivy-previous-line arg))
 


### PR DESCRIPTION
ivy-previous-line-or-history should not insert the last history item unless the currently-selected completion candidate is the first in the list, otherwise it's impossible to navigate back up with successive applications of this command.

See https://github.com/purcell/emacs.d/issues/473