### PR TITLE
Prevent "void-function colir-color-parse" in ivy-test.el

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -26,6 +26,7 @@
 
 ;;; Code:
 (require 'ert)
+(require 'colir)
 
 ;; useful for #'ivy-read-remap. It must arrive before (require 'ivy)
 (define-key global-map (kbd "<S-right>") #'end-of-buffer)


### PR DESCRIPTION
Hi,

In Debian we need this for our Emacs test suite to run.  Would you please consider applying it in the hopes that it will be useful elsewhere.

Sincerely,
Nicholas