### PR TITLE
Make counsel-async filter update time configurable

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -195,16 +195,21 @@ EVENT is a string describing the change."
            (setq ivy--old-cands ivy--all-candidates)
            (ivy--exhibit)))))
 
+(defcustom counsel-async-filter-update-time 500000
+  "The amount of time in microseconds to wait until updating
+`counsel--async-filter'."
+  :type 'integer
+  :group 'ivy)
+
 (defun counsel--async-filter (process str)
   "Receive from PROCESS the output STR.
 Update the minibuffer with the amount of lines collected every
-0.5 seconds since the last update."
+`counsel-async-filter-update-time' microseconds since the last update."
   (with-current-buffer (process-buffer process)
     (insert str))
   (let (size)
     (when (time-less-p
-           ;; 0.5s
-           '(0 0 500000 0)
+           `(0 0 ,counsel-async-filter-update-time 0)
            (time-since counsel--async-time))
       (with-current-buffer (process-buffer process)
         (goto-char (point-min))


### PR DESCRIPTION
It seems like even .5 seconds is pretty conservative. (Probably accounting for slower hardware)

I set it to
```
(setq counsel-async-filter-update-time 100000)
```
and it felt much more responsive (typing to seeing results response). That number can probably go even lower on faster computers.