### PR TITLE
Add new command counsel-fzf

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1798,6 +1798,50 @@ INITIAL-INPUT can be given as the initial minibuffer input."
             :unwind #'counsel-delete-process
             :caller 'counsel-locate))
 
+;;** `counsel-fzf'
+(defvar counsel-fzf-cmd "fzf -f %s"
+  "Command for `counsel-fzf'.")
+
+(defvar counsel--fzf-dir nil
+  "Store the base fzf directory.")
+
+(defun counsel-fzf-function (str)
+  (let ((default-directory counsel--fzf-dir))
+    (counsel--async-command
+     (format counsel-fzf-cmd
+             (if (string-equal str "")
+                 "\"\""
+               (counsel-unquote-regex-parens
+                (ivy--regex str))))))
+  nil)
+
+;;;###autoload
+(defun counsel-fzf (&optional initial-input)
+  "Call the \"fzf\" shell command.
+INITIAL-INPUT can be given as the initial minibuffer input."
+  (interactive)
+  (counsel-require-program (car (split-string counsel-fzf-cmd)))
+  (setq counsel--fzf-dir (if (and
+                              (fboundp 'projectile-project-p)
+                              (fboundp 'projectile-project-root)
+                              (projectile-project-p))
+                             (projectile-project-root)
+                           default-directory))
+  (ivy-read "> " #'counsel-fzf-function
+            :initial-input initial-input
+            :dynamic-collection t
+            :action #'counsel-fzf-action
+            :unwind #'counsel-delete-process
+            :caller 'counsel-fzf))
+
+(defun counsel-fzf-action (x)
+  "Find file X in current fzf directory."
+  (with-ivy-window
+    (let ((default-directory counsel--fzf-dir))
+      (find-file x))))
+
+(counsel-set-async-exit-code 'counsel-fzf 1 "Nothing found")
+
 ;;** `counsel-dpkg'
 ;;;###autoload
 (defun counsel-dpkg ()


### PR DESCRIPTION
I have something like this in my exports.

```
# This can be anything else that can pipe to fzf.
export FZF_DEFAULT_COMMAND='(git ls-files --exclude-standard --others --cached ||
        find . -path "*/\.*" -prune -o -type f -print -o -type l -print |
           sed s/^..//) 2> /dev/null'
```

Can use this to pull that env in (probably another better way too).
```
(setenv "FZF_DEFAULT_COMMAND"
        (string-trim (shell-command-to-string ". ~/.zshrc; echo -n $FZF_DEFAULT_COMMAND")))
```

Along with a fast update time,
```
  (setq counsel-async-filter-update-time 100000)
```

provides a pretty good searching experience.

Not too sure about the projectile integration but seemingly reasonable.