### PR TITLE
Add counsel-url-expand helper for ivy-ffap-url-functions

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1679,9 +1679,11 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
           (format "http://debbugs.gnu.org/cgi/bugreport.cgi?bug=%s"
                   (substring url 1)))))))
 
-(defvar counsel-url-expansions
-  nil
-  "List of (REGEXP . FORMAT) pairs.
+(defvar counsel-url-expansions nil
+  "Map of regular expressions to expansions.
+
+This variable should take the form of a list of (REGEXP . FORMAT)
+pairs.
 
 `counsel-url-expand' will expand the word at point according to
 FORMAT for the first matching REGEXP.  FORMAT can be either a
@@ -1691,13 +1693,13 @@ as the next argument.  If it is a function, it will be called
 with the word at point as the sole argument.
 
 For example, a pair of the form:
-  '(\"^BSERV-[0-9]+$\" . \"https://jira.atlassian.com/browse/%s\")
+  '(\"\\`BSERV-[[:digit:]]+\\'\" . \"https://jira.atlassian.com/browse/%s\")
 will expand to URL `https://jira.atlassian.com/browse/BSERV-100'
 when the word at point is BSERV-100.
 
 If the format element is a function, more powerful
 transformations are possible.  As an example,
-  '(\"^issue\\([0-9]+\\)$\" .
+  '(\"\\'issue\\([[:digit:]]+\\)\\'\" .
     (lambda (word)
       (concat \"http://debbugs.gnu.org/cgi/bugreport.cgi?bug=\"
               (match-string 1 word))))

--- a/counsel.el
+++ b/counsel.el
@@ -1516,7 +1516,7 @@ TREE is the selected candidate."
 
 (add-to-list 'ivy-ffap-url-functions 'counsel-github-url-p)
 (add-to-list 'ivy-ffap-url-functions 'counsel-emacs-url-p)
-(add-to-list 'ivy-ffap-url-functions 'counsel-url-expansions)
+(add-to-list 'ivy-ffap-url-functions 'counsel-url-expand)
 (defun counsel-find-file-cd-bookmark-action (_)
   "Reset `counsel-find-file' from selected directory."
   (ivy-read "cd: "

--- a/counsel.el
+++ b/counsel.el
@@ -1703,16 +1703,6 @@ transformations are possible.  As an example,
               (match-string 1 word))))
 trims the \"issue\" prefix from the word at point before creating the URL.")
 
-(defun compat-seq-some (pred lst)
-  "Call PRED on each element of LST and return first non-nil result.
-\(Implementation of seq-some for Emacs prior to version 25.)"
-  (catch 'result
-    (dolist (elt lst)
-      (let ((result (funcall pred elt)))
-        (when result
-          (throw 'result result))))
-    nil))
-
 (defun counsel-url-expand ()
   "Expand word at point using `counsel-url-expansions'.
 The first pair in the list whose regexp matches the word at point
@@ -1720,7 +1710,7 @@ will be expanded according to its format.  This function is
 intended to be used by `ivy-ffap-url-functions' to browse the
 result as a URL."
   (let ((word-at-point (current-word)))
-    (compat-seq-some
+    (cl-some
      (lambda (pair)
        (let ((regexp (car pair))
              (formatter (cdr pair)))

--- a/counsel.el
+++ b/counsel.el
@@ -1699,7 +1699,7 @@ when the word at point is BSERV-100.
 
 If the format element is a function, more powerful
 transformations are possible.  As an example,
-  '(\"\\'issue\\([[:digit:]]+\\)\\'\" .
+  '(\"\\`issue\\([[:digit:]]+\\)\\'\" .
     (lambda (word)
       (concat \"http://debbugs.gnu.org/cgi/bugreport.cgi?bug=\"
               (match-string 1 word))))

--- a/counsel.el
+++ b/counsel.el
@@ -1707,7 +1707,7 @@ trims the \"issue\" prefix from the word at point before creating the URL.")
   "Expand word at point using `counsel-url-expansions'.
 The first pair in the list whose regexp matches the word at point
 will be expanded according to its format.  This function is
-intended to be used by `ivy-ffap-url-functions' to browse the
+intended to be used in `ivy-ffap-url-functions' to browse the
 result as a URL."
   (let ((word-at-point (current-word)))
     (cl-some

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -244,7 +244,7 @@ will bring the behavior in line with the newer Emacsen."
 (ert-deftest counsel-url-expand ()
   "Test ffap expansion using counsel-url-expansions."
   ;; no expansions defined
-  (let ((counsel-url-expansions nil))
+  (let (counsel-url-expansions)
     (should (eq (counsel-url-expand) nil)))
   (let ((counsel-url-expansions
          `(("^foo$" . "https://foo.com/%s")

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -245,7 +245,7 @@ will bring the behavior in line with the newer Emacsen."
   "Test ffap expansion using counsel-url-expansions."
   ;; no expansions defined
   (let ((counsel-url-expansions nil))
-    (should (eql (counsel-url-expand) nil)))
+    (should (eq (counsel-url-expand) nil)))
   (let ((counsel-url-expansions
          `(("^foo$" . "https://foo.com/%s")
            ("^issue\\([0-9]+\\)" . ,(lambda (word)

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -241,12 +241,11 @@ will bring the behavior in line with the newer Emacsen."
                   (ivy--regex "(foo bar"))
                  "(\\(foo).*?(bar)")))
 
-(defmacro ivy--string-buffer (text body)
+(defmacro ivy--string-buffer (text &rest body)
   "Test helper that wraps TEXT in a temp buffer while running BODY."
   `(with-temp-buffer
     (insert ,text)
-    (goto-char (point-min))
-    ,body))
+    ,@body))
 
 (ert-deftest counsel-url-expand ()
   "Test ffap expansion using counsel-url-expansions."

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -241,6 +241,26 @@ will bring the behavior in line with the newer Emacsen."
                   (ivy--regex "(foo bar"))
                  "(\\(foo).*?(bar)")))
 
+(ert-deftest counsel-url-expand ()
+  "Test ffap expansion using counsel-url-expansions."
+  ;; no expansions defined
+  (let ((counsel-url-expansions nil))
+    (should (eql (counsel-url-expand) nil)))
+  (let ((counsel-url-expansions
+         `(("^foo$" . "https://foo.com/%s")
+           ("^issue\\([0-9]+\\)" . ,(lambda (word)
+                                      (concat "https://foo.com/issues/"
+                                              (match-string 1 word)))))))
+    ;; no match
+    (defun current-word () "foobar")
+    (should (equal (counsel-url-expand) nil))
+    ;; string expansion
+    (defun current-word () "foo")
+    (should (equal (counsel-url-expand) "https://foo.com/foo"))
+    ;; function expansion
+    (defun current-word () "issue123")
+    (should (equal (counsel-url-expand) "https://foo.com/issues/123"))))
+
 (ert-deftest colir-color-parse ()
   (should (equal (colir-color-parse "#ab1234")
                  ;; (color-name-to-rgb "#ab1234")

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -241,6 +241,13 @@ will bring the behavior in line with the newer Emacsen."
                   (ivy--regex "(foo bar"))
                  "(\\(foo).*?(bar)")))
 
+(defmacro ivy--string-buffer (text body)
+  "Test helper that wraps TEXT in a temp buffer while running BODY."
+  `(with-temp-buffer
+    (insert ,text)
+    (goto-char (point-min))
+    ,body))
+
 (ert-deftest counsel-url-expand ()
   "Test ffap expansion using counsel-url-expansions."
   ;; no expansions defined
@@ -252,14 +259,17 @@ will bring the behavior in line with the newer Emacsen."
                                       (concat "https://foo.com/issues/"
                                               (match-string 1 word)))))))
     ;; no match
-    (defun current-word () "foobar")
-    (should (equal (counsel-url-expand) nil))
+    (ivy--string-buffer
+     "foobar"
+     (should (equal (counsel-url-expand) nil)))
     ;; string expansion
-    (defun current-word () "foo")
-    (should (equal (counsel-url-expand) "https://foo.com/foo"))
+    (ivy--string-buffer
+     "foo"
+     (should (equal (counsel-url-expand) "https://foo.com/foo")))
     ;; function expansion
-    (defun current-word () "issue123")
-    (should (equal (counsel-url-expand) "https://foo.com/issues/123"))))
+    (ivy--string-buffer
+     "issue123"
+     (should (equal (counsel-url-expand) "https://foo.com/issues/123")))))
 
 (ert-deftest colir-color-parse ()
   (should (equal (colir-color-parse "#ab1234")


### PR DESCRIPTION
counsel-url-expand makes it easy to add keyword to URL expansions for ivy-ffap, simply by adding a (REGEXP . FORMAT) pair to counsel-url-expansions.