### PR TITLE
Allow ! and space to be escaped in ivy--regex-ignore-order

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -203,7 +203,15 @@ will bring the behavior in line with the newer Emacsen."
   (should (equal (ivy--regex-ignore-order "one two !three four")
                  '(("one" . t) ("two" . t) ("three") ("four"))))
   (should (equal (ivy--regex-ignore-order "!three four")
-                 '(("" . t) (("three") ("four")))))
+                 '(("three") ("four"))))
+  ;; Support escaping ! and spaces.
+  (should (equal (ivy--regex-ignore-order "one\\ two")
+                 '(("one two" . t))))
+  (should (equal (ivy--regex-ignore-order "one\\!two")
+                 '(("one!two" . t))))
+  ;; Don't crash on multiple !.
+  (ivy--regex-ignore-order "! ! !")
+  ;; Escape invalid regexps.
   (should (equal (ivy--regex-ignore-order "foo[ bar[xy]")
                  '(("foo\\[" . t) ("bar[xy]" . t)))))
 


### PR DESCRIPTION
This enables ivy--regex-ignore-order users to enter "foo\!" or "foo\ "
to match a literal ! or space. ivy--regex-plus attaches a different
meaning to spaces, so we do not support this escaping there.

It also fixes a crash if the user enters multiple !!!. We now just
discard these.

Fixes #976.