### PR TITLE
counsel.el (counsel-unicode-char): Make lazy

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3285,14 +3285,14 @@ And insert it into the minibuffer.  Useful during `eval-expression'."
 (defcustom counsel-linux-apps-directories
   '("/usr/local/share/applications/" "/usr/share/applications/")
   "Directories in which to search for applications (.desktop files)."
-  :group 'counsel
+  :group 'ivy
   :type '(list directory))
 
 (defcustom counsel-linux-app-format-function 'counsel-linux-app-format-function-default
   "Function to format Linux application names the `counsel-linux-app' menu.
 The format function will be passed the application's name, comment, and command
 as arguments."
-  :group 'counsel
+  :group 'ivy
   :type '(choice
           (const :tag "Command : Name - Comment" counsel-linux-app-format-function-default)
           (const :tag "Name - Comment (Command)" counsel-linux-app-format-function-name-first)


### PR DESCRIPTION
#### Changelog

* On [2017-08-31](http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=96c2c098aeed5c85733577ebbdaf33af6fbb59e9), `ucs-names` was refactored as a hash-table in the Emacs development tree: support this
* Use lazy completion table to speed up subsequent invocations and ensure collection is sorted from the outset
* Improve completion transformer:
  - Ensure space between char name and glyph
  - Fit line width to default `fill-column` of 70, allowing for a maximum `char-width` of 4
* Remove no-op `minibuffer-allow-text-properties` binding
* Add `:caller` keyword to `counsel-unicode-char`
* Fix a couple of incorrect `:group` customisation keywords

#### Before merging

This PR is not copyright exempt and I have previously contributed changes amounting to ~15 LOC to this project. I recently contacted assign@gnu.org about the copyright assignment forms and am currently waiting to hear back.