### PR TITLE
counsel.el: Allow async commands on Tramp buffers

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -137,7 +137,8 @@ for handling the output of the process instead of `counsel--async-filter'."
       (delete-process proc))
     (when buff
       (kill-buffer buff))
-    (setq proc (start-process-shell-command
+    (setq buff (generate-new-buffer counsel--process))
+    (setq proc (start-file-process-shell-command
                 counsel--process
                 counsel--process
                 cmd))
@@ -2049,10 +2050,8 @@ If non-nil, append EXTRA-AG-ARGS to BASE-CMD."
                                      " -- "
                                      (shell-quote-argument regex)
                                      file))))
-        (if (file-remote-p default-directory)
-            (split-string (shell-command-to-string ag-cmd) "\n" t)
-          (counsel--async-command ag-cmd)
-          nil)))))
+        (counsel--async-command ag-cmd)
+        nil))))
 
 ;;;###autoload
 (defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt)


### PR DESCRIPTION
Makes `counsel--async-command` work on remote buffers. This removes the need for the workaround introduced in `counsel-ag-function` with #669 and should fix similar issues in other commands or plugins.

Fixes #1229