### PR TITLE
counsel.el: Add a generic minibuffer history browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Ivy and Swiper wiki is here: [the wiki](https://github.com/abo-abo/swiper/wiki).
 (global-set-key (kbd "C-c k") 'counsel-ag)
 (global-set-key (kbd "C-x l") 'counsel-locate)
 (global-set-key (kbd "C-S-o") 'counsel-rhythmbox)
-(define-key read-expression-map (kbd "C-r") 'counsel-expression-history)
+(define-key minibuffer-local-map (kbd "C-r") 'counsel-minibuffer-history)
 ```
 
 # Counsel

--- a/counsel.el
+++ b/counsel.el
@@ -3103,6 +3103,18 @@ And insert it into the minibuffer.  Useful during `eval-expression'."
             :action #'insert
             :caller 'counsel-shell-command-history))
 
+;;** `counsel-minibuffer-history'
+;;;###autoload
+(defun counsel-minibuffer-history ()
+  "Browse minibuffer history."
+  (interactive)
+  (let ((enable-recursive-minibuffers t))
+    (ivy-read "Reverse-i-search: " (symbol-value minibuffer-history-variable)
+              :action #'insert
+              :caller 'counsel-minibuffer-history)))
+(make-obsolete 'counsel-expression-history 'counsel-minibuffer-history "20171011")
+(make-obsolete 'counsel-shell-command-history 'counsel-minibuffer-history "20171011")
+
 ;;** `counsel-esh-history'
 (defun counsel--browse-history (elements)
   "Use Ivy to navigate through ELEMENTS."
@@ -4090,10 +4102,8 @@ replacements. "
         (when (and (fboundp 'advice-add)
                    counsel-mode-override-describe-bindings)
           (advice-add #'describe-bindings :override #'counsel-descbinds))
-        (define-key minibuffer-local-shell-command-map (kbd "C-r")
-          'counsel-shell-command-history)
-        (define-key read-expression-map (kbd "C-r")
-          'counsel-expression-history))
+        (define-key minibuffer-local-map (kbd "C-r")
+          'counsel-minibuffer-history))
     (when (fboundp 'advice-remove)
       (advice-remove #'describe-bindings #'counsel-descbinds))))
 

--- a/ivy.el
+++ b/ivy.el
@@ -1658,7 +1658,7 @@ customizations apply to the current completion session."
                                        (delete item
                                                (cdr (symbol-value hist))))))))
                  (ivy-state-current ivy-last)))
-          (remove-hook 'post-command-hook #'ivy--exhibit)
+          (remove-hook 'post-command-hook #'ivy--queue-exhibit)
           (when (eq ivy-display-function 'ivy-display-function-overlay)
             (ivy-overlay-cleanup))
           (when (setq unwind (ivy-state-unwind ivy-last))
@@ -2339,7 +2339,7 @@ tries to ensure that it does not change depending on the number of candidates."
                                (if ivy-add-newline-after-prompt
                                    1
                                  0))))
-  (add-hook 'post-command-hook #'ivy--exhibit nil t)
+  (add-hook 'post-command-hook #'ivy--queue-exhibit nil t)
   ;; show completions with empty input
   (ivy--exhibit))
 
@@ -2555,10 +2555,31 @@ Possible choices are 'ivy-magic-slash-non-match-cd-selected,
 Otherwise, ~/ will move home."
   :type 'boolean)
 
+(defcustom ivy-dynamic-exhibit-delay-ms 500
+  "Delay in ms before dynamic collections are refreshed"
+  :type 'integer)
+
+(defvar ivy--exhibit-timer nil)
+
+(defun ivy--queue-exhibit ()
+  "Insert Ivy completions display, possibly after a timeout for
+dynamic collections.
+Should be run via minibuffer `post-command-hook'."
+  (if (and (> ivy-dynamic-exhibit-delay-ms 0)
+           (ivy-state-dynamic-collection ivy-last))
+      (progn
+        (when ivy--exhibit-timer (cancel-timer ivy--exhibit-timer))
+        (setq ivy--exhibit-timer
+              (run-with-timer
+               (/ ivy-dynamic-exhibit-delay-ms 1000.0)
+               nil
+               'ivy--exhibit)))
+    (ivy--exhibit)))
+
 (defun ivy--exhibit ()
   "Insert Ivy completions display.
 Should be run via minibuffer `post-command-hook'."
-  (when (memq 'ivy--exhibit post-command-hook)
+  (when (memq 'ivy--queue-exhibit post-command-hook)
     (let ((inhibit-field-text-motion nil))
       (constrain-to-field nil (point-max)))
     (setq ivy-text (ivy--input))


### PR DESCRIPTION
This supersedes counsel-shell-command-history and counsel-expression-history with a generic counsel-minibuffer-history function that works for all minibuffer situations.