### PR TITLE
 counsel.el: Require compile.el faces before use 

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -43,6 +43,7 @@
 (require 'swiper)
 (require 'etags)
 (require 'esh-util)
+(require 'compile)
 
 ;;* Utility
 (defun counsel-more-chars (n)

--- a/counsel.el
+++ b/counsel.el
@@ -1166,14 +1166,14 @@ Typical value: '(recenter)."
 (defun counsel-git-grep-transformer (str)
   "Higlight file and line number in STR."
   (when (string-match "\\`\\([^:]+\\):\\([^:]+\\):" str)
-    (set-text-properties (match-beginning 1)
-                         (match-end 1)
-                         '(face compilation-info)
-                         str)
-    (set-text-properties (match-beginning 2)
-                         (match-end 2)
-                         '(face compilation-line-number)
-                         str))
+    (add-face-text-property (match-beginning 1)
+                            (match-end 1)
+                            'compilation-info
+                            nil str)
+    (add-face-text-property (match-beginning 2)
+                            (match-end 2)
+                            'compilation-line-number
+                            nil str))
   str)
 
 (defvar counsel-git-grep-projects-alist nil


### PR DESCRIPTION
The first commit avoids `Invalid face reference` errors and non-propertised results for commands using `counsel-git-grep-transformer` when the `compile` library has not yet been loaded. I considered placing `require` calls wherever these faces are used, but there are several such instances and no clean way of covering them all. I would rather not put the `require` call in the transformer, for instance.

The second commit optimises the aforementioned transformer ever so slightly.