### PR TITLE
ivy.el (ivy--exhibit): Update prompt even if there are no candidates

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2595,9 +2595,8 @@ Should be run via minibuffer `post-command-hook'."
                     (ivy--sort-maybe
                      (funcall (ivy-state-collection ivy-last) ivy-text)))
               (setq ivy--old-text ivy-text)))
-          (when ivy--all-candidates
-            (ivy--insert-minibuffer
-             (ivy--format ivy--all-candidates))))
+          (ivy--insert-minibuffer
+           (ivy--format ivy--all-candidates)))
       (cond (ivy--directory
              (cond ((or (string= "~/" ivy-text)
                         (and (string= "~" ivy-text)


### PR DESCRIPTION
Previously, the minibuffer prompt was not refreshed in case a dynamic collection returned no candidates. This triggered the following problems:

- Candidates were displayed even though they did not match the filter.
- The prompt was not selectable.

This should fix #1183