### PR TITLE
ivy.el (ivy--exhibit): Update prompt even if there are no candidates

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2595,7 +2595,8 @@ Should be run via minibuffer `post-command-hook'."
                     (ivy--sort-maybe
                      (funcall (ivy-state-collection ivy-last) ivy-text)))
               (setq ivy--old-text ivy-text)))
-          (when ivy--all-candidates
+          (when (or ivy--all-candidates
+                    (not (get-process " *counsel*")))
             (ivy--insert-minibuffer
              (ivy--format ivy--all-candidates))))
       (cond (ivy--directory


### PR DESCRIPTION
Previously, the minibuffer prompt was not refreshed in case a dynamic collection returned no candidates.
For async commands this makes sense as `nil` could be interpreted both as the empty list, meaning no candidates found, or as a sign that the process is still running.
For sync functions however, it is clear that `nil` stands for no candidates found and thus the minibuffer should be refreshed. This should fix the following problems:

- Candidates were displayed even though they did not match the filter.
- The prompt was not selectable.

Fixes #1183