### PR TITLE
swiper.el (swiper-font-lock-exclude): Add adoc-mode (AsciiDoc)

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -277,6 +277,7 @@
     bongo-mode
     bongo-library-mode
     magit-popup-mode
+    adoc-mode
     bongo-playlist-mode
     eww-mode
     treemacs-mode


### PR DESCRIPTION
Using swiper in adoc-mode results in

    Symbol’s value as variable is void: adoc-reserved

https://github.com/sensorflo/adoc-mode/issues/31