### PR TITLE
Counsel open file externally asynchronously

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1835,14 +1835,11 @@ string - the full shell command to run."
   (if (and (eq system-type 'windows-nt)
            (fboundp 'w32-shell-execute))
       (w32-shell-execute "open" x)
-    (call-process shell-file-name nil
-                  nil nil
-                  shell-command-switch
-                  (format "%s %s"
-                          (cl-case system-type
-                            (darwin "open")
-                            (t "xdg-open"))
-                          (shell-quote-argument x)))))
+    (start-process-shell-command "counsel-external-process" nil
+                                 (format "%s %s" (cl-case system-type
+                                                   (darwin "open")
+                                                   (t "xdg-open"))
+                                         (shell-quote-argument x)))))
 
 (defalias 'counsel-find-file-extern 'counsel-locate-action-extern)
 


### PR DESCRIPTION
call-process blocks emacs, this is a fix (and it also works well in EXWM).