### PR TITLE
Minor counsel grep tweaks

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2274,10 +2274,11 @@ RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
    "rg -i --no-heading --line-number --color never -- %s ."))
 
 ;;** `counsel-grep'
-(defcustom counsel-grep-base-command "grep -nE -- %s %s"
-  "Format string to use in `cousel-grep-function' to construct the command.
-
-Note: don't use single quotes for either the regex or the file name."
+(defcustom counsel-grep-base-command "grep -E -n -e %s %s"
+  "Format string used by `counsel-grep' to build a shell command.
+It should contain two %-sequences (see function `format') to be
+substituted by the search regexp and file, respectively.  Neither
+%-sequence should be contained in single quotes."
   :type 'string
   :group 'ivy)
 
@@ -2349,11 +2350,9 @@ Note: don't use single quotes for either the regex or the file name."
   (counsel-require-program (car (split-string counsel-grep-base-command)))
   (setq counsel-grep-last-line nil)
   (setq counsel--git-dir default-directory)
-  (if (string-match "%s$" counsel-grep-base-command)
-      (setq counsel-grep-command
-            (concat (substring counsel-grep-base-command 0 (match-beginning 0))
-                    (shell-quote-argument (buffer-file-name))))
-    (error "expected `counsel-grep-base-command' to end in %%s"))
+  (setq counsel-grep-command
+        (format counsel-grep-base-command
+                "%s" (shell-quote-argument buffer-file-name)))
   (let ((init-point (point))
         res)
     (unwind-protect

--- a/counsel.el
+++ b/counsel.el
@@ -2356,23 +2356,24 @@ substituted by the search regexp and file, respectively.  Neither
   (let ((init-point (point))
         res)
     (unwind-protect
-         (setq res (ivy-read "grep: " 'counsel-grep-function
-                             :dynamic-collection t
-                             :preselect (format "%d:%s"
-                                                (line-number-at-pos)
-                                                (regexp-quote
-                                                 (buffer-substring-no-properties
-                                                  (line-beginning-position)
-                                                  (line-end-position))))
-                             :history 'counsel-git-grep-history
-                             :update-fn (lambda ()
-                                          (counsel-grep-action (ivy-state-current ivy-last)))
-                             :re-builder #'ivy--regex
-                             :action #'counsel-grep-action
-                             :unwind (lambda ()
-                                       (counsel-delete-process)
-                                       (swiper--cleanup))
-                             :caller 'counsel-grep))
+        (setq res (ivy-read "grep: " #'counsel-grep-function
+                            :dynamic-collection t
+                            :preselect (format "%d:%s"
+                                               (line-number-at-pos)
+                                               (regexp-quote
+                                                (buffer-substring-no-properties
+                                                 (line-beginning-position)
+                                                 (line-end-position))))
+                            :history 'counsel-git-grep-history
+                            :update-fn (lambda ()
+                                         (counsel-grep-action
+                                          (ivy-state-current ivy-last)))
+                            :re-builder #'ivy--regex
+                            :action #'counsel-grep-action
+                            :unwind (lambda ()
+                                      (counsel-delete-process)
+                                      (swiper--cleanup))
+                            :caller 'counsel-grep))
       (unless res
         (goto-char init-point)))))
 

--- a/counsel.el
+++ b/counsel.el
@@ -2306,29 +2306,25 @@ substituted by the search regexp and file, respectively.  Neither
                    (setq line-number (match-string-no-properties 1 x)))
                   ((string-match "\\`\\([^:]+\\):\\([0-9]+\\):\\(.*\\)\\'" x)
                    (setq file-name (match-string-no-properties 1 x))
-                   (setq line-number (match-string-no-properties 2 x)))
-                  (t nil))
+                   (setq line-number (match-string-no-properties 2 x))))
         ;; If the file buffer is already open, just get it. Prevent doing
         ;; `find-file', as that file could have already been opened using
         ;; `find-file-literally'.
-        (let ((buf (get-file-buffer file-name)))
-          (unless buf
-            (setq buf (find-file file-name)))
-          (with-current-buffer buf
-            (setq line-number (string-to-number line-number))
-            (if (null counsel-grep-last-line)
-                (progn
-                  (goto-char (point-min))
-                  (forward-line (1- (setq counsel-grep-last-line line-number))))
+        (with-current-buffer (or (get-file-buffer file-name)
+                                 (find-file file-name))
+          (setq line-number (string-to-number line-number))
+          (if counsel-grep-last-line
               (forward-line (- line-number counsel-grep-last-line))
-              (setq counsel-grep-last-line line-number))
-            (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
-            (run-hooks 'counsel-grep-post-action-hook)
-            (if (eq ivy-exit 'done)
-                (swiper--ensure-visible)
-              (isearch-range-invisible (line-beginning-position)
-                                       (line-end-position))
-              (swiper--add-overlays (ivy--regex ivy-text)))))))))
+            (goto-char (point-min))
+            (forward-line (1- line-number)))
+          (setq counsel-grep-last-line line-number)
+          (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
+          (run-hooks 'counsel-grep-post-action-hook)
+          (if (eq ivy-exit 'done)
+              (swiper--ensure-visible)
+            (isearch-range-invisible (line-beginning-position)
+                                     (line-end-position))
+            (swiper--add-overlays (ivy--regex ivy-text))))))))
 
 (defun counsel-grep-occur ()
   "Generate a custom occur buffer for `counsel-grep'."


### PR DESCRIPTION
User-visible changes:

* Document the format of `counsel-grep-base-command`.
* Do not barf in `counsel-grep` if `counsel-grep-base-command` does not contain a `%s` format specifier immediately preceding a newline character or end-of-string.
* Detect compressed filenames in `counsel-grep-or-swiper` even after customising `jka-compr-compression-info-list`.

The rest of the changes are mostly formatting and logic simplifications (I'll be more than happy to revert any such "simplifications" which come across as style changes). Please see the commit messages for further details.