### PR TITLE
.dir-locals.el: Enforce sentence-end-double-space

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,4 +3,5 @@
 
 ((emacs-lisp-mode
   (indent-tabs-mode . nil)
-  (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")))
+  (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")
+  (sentence-end-double-space . t)))


### PR DESCRIPTION
Make the existing convention official.