### PR TITLE
ivy.el: Add buffer->file completion switch action

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3557,14 +3557,24 @@ BUFFER may be a string or nil."
 
 (ivy-set-actions
  'ivy-switch-buffer
- '(("k"
-    (lambda (x)
-      (kill-buffer x)
-      (ivy--reset-state ivy-last))
-    "kill")
+ `(("f"
+    ,(lambda (x)
+       (let* ((b (get-buffer x))
+              (default-directory
+                (or (and b (buffer-local-value 'default-directory b))
+                    default-directory)))
+         (call-interactively (if (fboundp 'counsel-find-file)
+                                 #'counsel-find-file
+                               #'find-file))))
+    "find file")
    ("j"
     ivy--switch-buffer-other-window-action
     "other window")
+   ("k"
+    ,(lambda (x)
+       (kill-buffer x)
+       (ivy--reset-state ivy-last))
+    "kill")
    ("r"
     ivy--rename-buffer-action
     "rename")))


### PR DESCRIPTION
#### Changelog

* Allow switching from buffer to file completion within the current candidate's `default-directory` (see #1295 for discussion).
* Sort `ivy-switch-buffer` actions lexicographically.
* Prefer function objects to quoted forms.