### PR TITLE
ivy-test.el (ivy-with-r): Use with-output-to-string

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -574,17 +574,13 @@ will bring the behavior in line with the newer Emacsen."
            "bl")))
 
 (defmacro ivy-with-r (expr &rest keys)
-  `(let ((temp-buffer (generate-new-buffer " *temp*")))
-     (unwind-protect
-          (save-window-excursion
-            (switch-to-buffer temp-buffer)
-            ,expr
-            (ivy-mode)
-            (execute-kbd-macro
-             ,(apply 'vconcat (mapcar 'kbd keys)))
-            (buffer-string))
-       (and (buffer-name temp-buffer)
-            (kill-buffer temp-buffer)))))
+  `(with-output-to-string
+     (save-window-excursion
+       (switch-to-buffer standard-output t)
+       ,expr
+       (ivy-mode)
+       (execute-kbd-macro
+        ,(apply #'vconcat (mapcar #'kbd keys))))))
 
 (ert-deftest ivy-completion-in-region ()
   (should (string=


### PR DESCRIPTION
#### Changelog

- Reuse existing macro logic.
- Reduce side effects by passing non-nil `NORECORD` arg to `switch-to-buffer`.
- Consistently quote function symbols as such.

#### Question

The `ivy-completion-in-region` test which makes use of this macro emits a `"Sole match"` message amid `make test` results. Would it be desirable to bind `inhibit-message` to `t` around `execute-kbd-macro` or elsewhere in `ivy-with-r` to suppress this message, or would that be a bad idea?