### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ update-issues:
 clean:
 	$(RM) *.elc
 
-.PHONY: all compile clean test update-issues checkdoc
+.PHONY: all test checkdoc compile plain obsolete update-issues clean

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ checkdoc:
 	$(emacs) -batch -l targets/checkdoc.el
 
 compile:
-	$(emacs) -batch --eval "(progn (add-to-list 'load-path default-directory) (mapc #'byte-compile-file '(\"ivy.el\" \"swiper.el\" \"counsel.el\" \"colir.el\" \"ivy-overlay.el\")))"
+	$(emacs) -batch -L . -f batch-byte-compile colir.el ivy-overlay.el ivy.el swiper.el counsel.el
 
 plain:
 	$(emacs) --version

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ emacs ?= emacs
 elmake = $(emacs) -batch -l makefi.el -f
 
 LOAD = -l colir.el -l ivy-overlay.el -l ivy.el -l swiper.el -l counsel.el
+RM ?= rm -f
 
 all: test
 
@@ -25,6 +26,6 @@ update-issues:
 	$(elmake) update-issues
 
 clean:
-	rm -f *.elc
+	$(RM) *.elc
 
 .PHONY: all compile clean test update-issues checkdoc

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -77,10 +77,13 @@ Then attach the overlay the character before point."
 
 (declare-function org-current-level "org")
 (defvar org-indent-indentation-per-level)
+(defvar ivy-height)
 (defvar ivy-last)
 (defvar ivy-text)
 (defvar ivy-completion-beg)
 (declare-function ivy--get-window "ivy")
+(declare-function ivy-state-current "ivy")
+(declare-function ivy-state-window "ivy")
 
 (defun ivy-overlay-impossible-p ()
   (or


### PR DESCRIPTION
Please see the commit messages for a changelog.

#### Question

Would it be desirable to trade some portability for the convenience of the following?

```diff
diff --git a/Makefile b/Makefile
index c6f3eca..97eda91 100644
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 emacs ?= emacs
 elmake = $(emacs) -batch -l makefi.el -f
 
-LOAD = -l colir.el -l ivy-overlay.el -l ivy.el -l swiper.el -l counsel.el
+SOURCES = colir.el ivy-overlay.el ivy.el swiper.el counsel.el
+LOAD = $(SOURCES:%=-l %)
 RM ?= rm -f
 
 all: test
@@ -13,7 +14,7 @@ checkdoc:
 	$(emacs) -batch -l targets/checkdoc.el
 
 compile:
-	$(emacs) -batch -L . -f batch-byte-compile colir.el ivy-overlay.el ivy.el swiper.el counsel.el
+	$(emacs) -batch -L . -f batch-byte-compile $(SOURCES)
 
 plain:
 	$(emacs) --version
```