### PR TITLE
Uniformize interface of swiper and counsel-grep{,-or-swiper}.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2400,8 +2400,9 @@ substituted by the search regexp and file, respectively.  Neither
 (counsel-set-async-exit-code 'counsel-grep 1 "")
 
 ;;;###autoload
-(defun counsel-grep ()
-  "Grep for a string in the current file."
+(defun counsel-grep (&optional initial-input)
+  "Grep for a string in the current file.
+When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
   (counsel-require-program (car (split-string counsel-grep-base-command)))
   (setq counsel-grep-last-line nil)
@@ -2413,6 +2414,7 @@ substituted by the search regexp and file, respectively.  Neither
         res)
     (unwind-protect
          (setq res (ivy-read "grep: " 'counsel-grep-function
+                             :initial-input initial-input
                              :dynamic-collection t
                              :preselect (format "%d:%s"
                                                 (line-number-at-pos)
@@ -2439,8 +2441,9 @@ substituted by the search regexp and file, respectively.  Neither
   :group 'ivy)
 
 ;;;###autoload
-(defun counsel-grep-or-swiper ()
-  "Call `swiper' for small buffers and `counsel-grep' for large ones."
+(defun counsel-grep-or-swiper (&optional initial-input)
+  "Call `swiper' for small buffers and `counsel-grep' for large ones.
+When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
   (if (or (not buffer-file-name)
           (buffer-narrowed-p)
@@ -2450,10 +2453,10 @@ substituted by the search regexp and file, respectively.  Neither
           (<= (buffer-size)
               (/ counsel-grep-swiper-limit
                  (if (eq major-mode 'org-mode) 4 1))))
-      (swiper)
+      (swiper initial-input)
     (when (file-writable-p buffer-file-name)
       (save-buffer))
-    (counsel-grep)))
+    (counsel-grep initial-input)))
 
 ;;** `counsel-recoll'
 (defun counsel-recoll-function (string)


### PR DESCRIPTION
This makes sure that `counsel-grep-or-swiper` and `swiper` have the same type.