### PR TITLE
counsel.el (counsel-locate-action-extern): handle cygwin

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1841,6 +1841,7 @@ string - the full shell command to run."
                   (format "%s %s"
                           (cl-case system-type
                             (darwin "open")
+                            (cygwin "cygstart")
                             (t "xdg-open"))
                           (shell-quote-argument x)))))
 


### PR DESCRIPTION
Cygwin has no `open` or `xdg-open` command but instead `cygstart` (opens file with default windows application).

(I received back my CA signed by the FSF on September 13th, but I don't know how to check if I'm in `copyright.list`.)