### PR TITLE
counsel.el: increase org-goto/org-agenda-headlines UI consistency

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2669,8 +2669,7 @@ otherwise continue prompting for tags."
       (fset 'org-set-tags store))))
 
 (defcustom counsel-org-goto-display-style 'path
-  "The style for displaying headlines in `counsel-org-goto' and \
-`counsel-org-agenda-headlines' functions.
+  "The style used when displaying matched `org-mode'-headlines.
 
 If headline, the title and the leading stars are displayed.
 
@@ -2688,27 +2687,25 @@ display tags and todo keywords respectively."
   :group 'ivy)
 
 (defcustom counsel-org-goto-separator "/"
-  "Character(s) to separate path entries in `counsel-org-goto' functions.
+  "Character(s) to separate path entries in matched `org-mode'-headlines.
+
 This variable has no effect unless `counsel-org-goto-display-style' is
 set to path."
   :type 'string
   :group 'ivy)
 
 (defcustom counsel-org-goto-display-tags nil
-  "If non-nil, display tags in `counsel-org-goto' and \
-`counsel-org-agenda-headlines' functions."
+  "If non-nil, display tags in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
 (defcustom counsel-org-goto-display-todo nil
-  "If non-nil, display todo keywords in `counsel-org-goto' and \
-`counsel-org-agenda-headlines' functions."
+  "If non-nil, display todo keywords in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
 (defcustom counsel-org-goto-display-priority nil
-  "If non-nil, display priorities in `counsel-org-goto' and \
-`counsel-org-agenda-headlines' functions."
+  "If non-nil, display priorities in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 

--- a/counsel.el
+++ b/counsel.el
@@ -4096,21 +4096,21 @@ candidate."
   (org-map-entries
    (lambda ()
      (let* ((components (org-heading-components))
-            (level (when (eq counsel-org-goto-display-style 'headline)
-                     (make-string
-                      (if org-odd-levels-only
-                          (nth 1 components)
-                        (nth 0 components))
-                      ?*)))
-            (todo (when counsel-org-goto-display-todo
-                    (nth 2 components)))
-            (path (when (eq counsel-org-goto-display-style 'path)
-                    (org-get-outline-path)))
-            (priority (when counsel-org-goto-display-priority
-                        (nth 3 components)))
+            (level (and (eq counsel-org-goto-display-style 'headline)
+                        (make-string
+                         (if org-odd-levels-only
+                             (nth 1 components)
+                           (nth 0 components))
+                         ?*)))
+            (todo (and counsel-org-goto-display-todo
+                       (nth 2 components)))
+            (path (and (eq counsel-org-goto-display-style 'path)
+                       (org-get-outline-path)))
+            (priority (and counsel-org-goto-display-priority
+                           (nth 3 components)))
             (text (nth 4 components))
-            (tags (when counsel-org-goto-display-tags
-                    (nth 5 components))))
+            (tags (and counsel-org-goto-display-tags
+                       (nth 5 components))))
        (list
         (mapconcat
          'identity
@@ -4118,7 +4118,7 @@ candidate."
                        (list
                         level
                         todo
-                        (if priority (format "[#%c]" priority))
+                        (and priority (format "[#%c]" priority))
                         (mapconcat 'identity
                                    (append path (list text))
                                    counsel-org-goto-separator)

--- a/counsel.el
+++ b/counsel.el
@@ -2668,6 +2668,9 @@ otherwise continue prompting for tags."
            (org-agenda-set-tags nil nil))
       (fset 'org-set-tags store))))
 
+(define-obsolete-variable-alias 'counsel-org-goto-display-style
+  'counsel-org-headline-display-style)
+
 (defcustom counsel-org-headline-display-style 'path
   "The style used when displaying matched `org-mode'-headlines.
 
@@ -2687,8 +2690,8 @@ Use `counsel-org-headline-display-tags' and
           (const :tag "Path" path))
   :group 'ivy)
 
-(defvaralias 'counsel-org-goto-display-style
-  'counsel-org-headline-display-style)
+(define-obsolete-variable-alias 'counsel-org-goto-separator
+  'counsel-org-headline-path-separator)
 
 (defcustom counsel-org-headline-path-separator "/"
   "Character(s) to separate path entries in matched `org-mode'-headlines.
@@ -2698,24 +2701,21 @@ set to path."
   :type 'string
   :group 'ivy)
 
-(defvaralias 'counsel-org-goto-separator
-  'counsel-org-headline-path-separator)
+(define-obsolete-variable-alias 'counsel-org-goto-display-tags
+  'counsel-org-headline-display-tags)
 
 (defcustom counsel-org-headline-display-tags nil
   "If non-nil, display tags in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
-(defvaralias 'counsel-org-goto-display-tags
-  'counsel-org-headline-display-tags)
+(define-obsolete-variable-alias 'counsel-org-goto-display-todo
+  'counsel-org-headline-display-todo)
 
 (defcustom counsel-org-headline-display-todo nil
   "If non-nil, display todo keywords in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
-
-(defvaralias 'counsel-org-goto-display-todo
-  'counsel-org-headline-display-todo)
 
 (defcustom counsel-org-headline-display-priority nil
   "If non-nil, display priorities in matched `org-mode' headlines."

--- a/counsel.el
+++ b/counsel.el
@@ -2668,43 +2668,56 @@ otherwise continue prompting for tags."
            (org-agenda-set-tags nil nil))
       (fset 'org-set-tags store))))
 
-(defcustom counsel-org-goto-display-style 'path
+(defcustom counsel-org-headline-display-style 'path
   "The style used when displaying matched `org-mode'-headlines.
 
 If headline, the title and the leading stars are displayed.
 
 If path, the path hierarchy is displayed.  For each entry the title is shown.
-`counsel-org-goto-separator' is used as separator between entries.
+`counsel-org-headline-path-separator' is used as separator between entries.
 
 If title or any other value, only the title of the headline is displayed.
 
-Use `counsel-org-goto-display-tags' and `counsel-org-goto-display-todo' to
-display tags and todo keywords respectively."
+Use `counsel-org-headline-display-tags' and
+ `counsel-org-headline-display-todo' to display tags and todo keywords
+ respectively."
   :type '(choice
           (const :tag "Title only" title)
           (const :tag "Headline" headline)
           (const :tag "Path" path))
   :group 'ivy)
 
-(defcustom counsel-org-goto-separator "/"
+(defvaralias 'counsel-org-goto-display-style
+  'counsel-org-headline-display-style)
+
+(defcustom counsel-org-headline-path-separator "/"
   "Character(s) to separate path entries in matched `org-mode'-headlines.
 
-This variable has no effect unless `counsel-org-goto-display-style' is
+This variable has no effect unless `counsel-org-headline-display-style' is
 set to path."
   :type 'string
   :group 'ivy)
 
-(defcustom counsel-org-goto-display-tags nil
+(defvaralias 'counsel-org-goto-separator
+  'counsel-org-headline-path-separator)
+
+(defcustom counsel-org-headline-display-tags nil
   "If non-nil, display tags in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
-(defcustom counsel-org-goto-display-todo nil
+(defvaralias 'counsel-org-goto-display-tags
+  'counsel-org-headline-display-tags)
+
+(defcustom counsel-org-headline-display-todo nil
   "If non-nil, display todo keywords in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
-(defcustom counsel-org-goto-display-priority nil
+(defvaralias 'counsel-org-goto-display-todo
+  'counsel-org-headline-display-todo)
+
+(defcustom counsel-org-headline-display-priority nil
   "If non-nil, display priorities in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
@@ -2732,8 +2745,9 @@ for a certain level, headlines on that level will not be styled.
 
 If nil or any other value, no face is applied to the headline.
 
-See `counsel-org-goto-display-tags' and `counsel-org-goto-display-todo' if
-you want to display tags and todo keywords in your headlines."
+See `counsel-org-headline-display-tags' and
+`counsel-org-headline-display-todo' if you want to display tags and todo
+keywords in your headlines."
   :type '(choice
           (const :tag "Same as org-mode" org)
           (const :tag "Verbatim" verbatim)
@@ -2801,14 +2815,14 @@ to custom."
                           (outline-next-heading)))
       (while start-pos
         (let ((name (org-get-heading
-                     (not counsel-org-goto-display-tags)
-                     (not counsel-org-goto-display-todo)))
+                     (not counsel-org-headline-display-tags)
+                     (not counsel-org-headline-display-todo)))
               level)
           (search-forward " ")
           (setq level
                 (- (length (buffer-substring-no-properties start-pos (point)))
                    1))
-          (cond ((eq counsel-org-goto-display-style 'path)
+          (cond ((eq counsel-org-headline-display-style 'path)
                  ;; Update stack. The empty entry guards against incorrect
                  ;; headline hierarchies e.g. a level 3 headline immediately
                  ;; following a level 1 entry.
@@ -2822,9 +2836,9 @@ to custom."
                  (setq name (mapconcat
                              #'identity
                              (reverse stack)
-                             counsel-org-goto-separator)))
+                             counsel-org-headline-path-separator)))
                 (t
-                 (when (eq counsel-org-goto-display-style 'headline)
+                 (when (eq counsel-org-headline-display-style 'headline)
                    (setq name (concat (make-string level ?*) " " name)))
                  (setq name (counsel-org-goto--add-face name level))))
           (push (cons name (point-marker)) entries))
@@ -4096,20 +4110,20 @@ candidate."
   (org-map-entries
    (lambda ()
      (let* ((components (org-heading-components))
-            (level (and (eq counsel-org-goto-display-style 'headline)
+            (level (and (eq counsel-org-headline-display-style 'headline)
                         (make-string
                          (if org-odd-levels-only
                              (nth 1 components)
                            (nth 0 components))
                          ?*)))
-            (todo (and counsel-org-goto-display-todo
+            (todo (and counsel-org-headline-display-todo
                        (nth 2 components)))
-            (path (and (eq counsel-org-goto-display-style 'path)
+            (path (and (eq counsel-org-headline-display-style 'path)
                        (org-get-outline-path)))
-            (priority (and counsel-org-goto-display-priority
+            (priority (and counsel-org-headline-display-priority
                            (nth 3 components)))
             (text (nth 4 components))
-            (tags (and counsel-org-goto-display-tags
+            (tags (and counsel-org-headline-display-tags
                        (nth 5 components))))
        (list
         (mapconcat
@@ -4121,7 +4135,7 @@ candidate."
                         (and priority (format "[#%c]" priority))
                         (mapconcat 'identity
                                    (append path (list text))
-                                   counsel-org-goto-separator)
+                                   counsel-org-headline-path-separator)
                         tags))
          " ")
         (buffer-file-name) (point))))

--- a/counsel.el
+++ b/counsel.el
@@ -4120,10 +4120,9 @@ candidate."
                         level
                         todo
                         (if priority (format "[#%c]" priority))
-                        (if path (mapconcat 'identity
-                                            (append path (list text))
-                                            counsel-org-goto-separator)
-                          text)
+                        (mapconcat 'identity
+                                   (append path (list text))
+                                   counsel-org-goto-separator)
                         tags))
          " ")
         (buffer-file-name) (point))))

--- a/counsel.el
+++ b/counsel.el
@@ -2802,8 +2802,7 @@ to custom."
       (while start-pos
         (let ((name (org-get-heading
                      (not counsel-org-goto-display-tags)
-                     (not counsel-org-goto-display-todo)
-                     (not counsel-org-goto-display-priority)))
+                     (not counsel-org-goto-display-todo)))
               level)
           (search-forward " ")
           (setq level


### PR DESCRIPTION
* counsel.el (counsel-org-goto): obey new ‘counsel-org-goto-display-priority’
(counsel-org-agenda-headlines): obey ‘counsel-org-goto-foo’ variables (except
for ‘…-face-style’, ‘…-custom-faces’)