### PR TITLE
Simplify string padding and truncation

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -36,20 +36,16 @@
 (defvar ivy-overlay-at nil
   "Overlay variable for `ivy-display-function-overlay'.")
 
+(declare-function ivy--truncate-string "ivy")
+
 (defun ivy-left-pad (str width)
-  "Pad STR from left with WIDTH spaces."
-  (let ((padding (make-string width ?\ )))
+  "Return STR, but with each line indented by WIDTH spaces.
+Lines are truncated to the window width."
+  (let ((padding (make-string width ?\s)))
     (mapconcat (lambda (x)
-                 (setq x (concat padding x))
-                 (if (> (length x) (window-width))
-                     (concat
-                      (substring x 0 (- (window-width) 4))
-                      "...")
-                   x))
+                 (ivy--truncate-string (concat padding x) (1- (window-width))))
                (split-string str "\n")
                "\n")))
-
-(declare-function company-abort "ext:company")
 
 (defun ivy-overlay-cleanup ()
   "Clean up after `ivy-display-function-overlay'."

--- a/ivy.el
+++ b/ivy.el
@@ -3127,10 +3127,7 @@ no sorting is done.")
 
 (defun ivy--truncate-string (str width)
   "Truncate STR to WIDTH."
-  (if (> (string-width str) width)
-      (concat (substring str 0 (min (- width 3)
-                                    (- (length str) 3))) "...")
-    str))
+  (truncate-string-to-width str width nil nil t))
 
 (defun ivy--format-function-generic (selected-fn other-fn cands separator)
   "Transform candidates into a string for minibuffer.


### PR DESCRIPTION
* ivy.el (`ivy--truncate-string`): Delegate to
  `truncate-string-to-width`.
* ivy-overlay.el (`ivy-left-pad`): Use `ivy--truncate-string`.