### PR TITLE
Prefer integer positions to markers

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -273,8 +273,7 @@ Update the minibuffer with the amount of lines collected every
   (interactive)
   (let* ((bnd (unless (and (looking-at ")")
                            (eq (char-before) ?\())
-                (bounds-of-thing-at-point
-                 'symbol)))
+                (bounds-of-thing-at-point 'symbol)))
          (str (if bnd
                   (buffer-substring-no-properties
                    (car bnd)
@@ -284,14 +283,8 @@ Update the minibuffer with the amount of lines collected every
          (pred (and (eq (char-before (car bnd)) ?\()
                     #'fboundp))
          symbol-names)
-    (if bnd
-        (progn
-          (setq ivy-completion-beg
-                (move-marker (make-marker) (car bnd)))
-          (setq ivy-completion-end
-                (move-marker (make-marker) (cdr bnd))))
-      (setq ivy-completion-beg nil)
-      (setq ivy-completion-end nil))
+    (setq ivy-completion-beg (car bnd))
+    (setq ivy-completion-end (cdr bnd))
     (if (string= str "")
         (mapatoms
          (lambda (x)
@@ -329,35 +322,28 @@ Update the minibuffer with the amount of lines collected every
   "Python completion at point."
   (interactive)
   (let ((bnd (bounds-of-thing-at-point 'symbol)))
-    (if bnd
-        (progn
-          (setq ivy-completion-beg (car bnd))
-          (setq ivy-completion-end (cdr bnd)))
-      (setq ivy-completion-beg nil)
-      (setq ivy-completion-end nil)))
+    (setq ivy-completion-beg (car bnd))
+    (setq ivy-completion-end (cdr bnd)))
   (deferred:sync!
       (jedi:complete-request))
   (ivy-read "Symbol name: " (jedi:ac-direct-matches)
             :action #'counsel--py-action))
 
-(defun counsel--py-action (symbol)
-  "Insert SYMBOL, erasing the previous one."
-  (when (stringp symbol)
+(defun counsel--py-action (symbol-name)
+  "Insert SYMBOL-NAME, erasing the previous one."
+  (when (stringp symbol-name)
     (with-ivy-window
       (when ivy-completion-beg
         (delete-region
          ivy-completion-beg
          ivy-completion-end))
-      (setq ivy-completion-beg
-            (move-marker (make-marker) (point)))
-      (insert symbol)
-      (setq ivy-completion-end
-            (move-marker (make-marker) (point)))
-      (when (equal (get-text-property 0 'symbol symbol) "f")
+      (setq ivy-completion-beg (point))
+      (insert symbol-name)
+      (setq ivy-completion-end (point))
+      (when (equal (get-text-property 0 'symbol symbol-name) "f")
         (insert "()")
-        (setq ivy-completion-end
-              (move-marker (make-marker) (point)))
-        (backward-char 1)))))
+        (setq ivy-completion-end (point))
+        (backward-char)))))
 
 ;;** `counsel-clj'
 (declare-function cider-sync-request:complete "ext:cider-client")

--- a/ivy.el
+++ b/ivy.el
@@ -2008,15 +2008,11 @@ The previous string is between `ivy-completion-beg' and `ivy-completion-end'."
           (pt (point))
           (beg ivy-completion-beg)
           (end ivy-completion-end))
-      (when ivy-completion-beg
-        (delete-region
-         ivy-completion-beg
-         ivy-completion-end))
-      (setq ivy-completion-beg
-            (move-marker (make-marker) (point)))
+      (when beg
+        (delete-region beg end))
+      (setq ivy-completion-beg (point))
       (insert (substring-no-properties str))
-      (setq ivy-completion-end
-            (move-marker (make-marker) (point)))
+      (setq ivy-completion-end (point))
       (save-excursion
         (dolist (cursor fake-cursors)
           (goto-char (overlay-start cursor))
@@ -2025,8 +2021,8 @@ The previous string is between `ivy-completion-beg' and `ivy-completion-end'."
           (insert (substring-no-properties str))
           ;; manually move the fake cursor
           (move-overlay cursor (point) (1+ (point)))
-          (move-marker (overlay-get cursor 'point) (point))
-          (move-marker (overlay-get cursor 'mark) (point)))))))
+          (set-marker (overlay-get cursor 'point) (point))
+          (set-marker (overlay-get cursor 'mark) (point)))))))
 
 (defun ivy-completion-common-length (str)
   "Return the length of the first `completions-common-part' face in STR."


### PR DESCRIPTION
#### Question

Is there a reason why `ivy-completion-beg` and `ivy-completion-end` were sometimes (but more often not) set to markers, rather than integer positions? I don't see any uses of these variables where a marker is needed.