### PR TITLE
Use fboundp and functionp correctly for great good

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -281,7 +281,8 @@ Update the minibuffer with the amount of lines collected every
                    (cdr bnd))
                 ""))
          (ivy-height 7)
-         (funp (eq (char-before (car bnd)) ?\())
+         (pred (and (eq (char-before (car bnd)) ?\()
+                    #'fboundp))
          symbol-names)
     (if bnd
         (progn
@@ -296,15 +297,9 @@ Update the minibuffer with the amount of lines collected every
          (lambda (x)
            (when (symbolp x)
              (push (symbol-name x) symbol-names))))
-      (setq symbol-names
-            (all-completions str obarray
-                             (and funp
-                                  (lambda (x)
-                                    (or (functionp x)
-                                        (macrop x)
-                                        (special-form-p x)))))))
+      (setq symbol-names (all-completions str obarray pred)))
     (ivy-read "Symbol name: " symbol-names
-              :predicate (and funp #'functionp)
+              :predicate pred
               :initial-input str
               :action #'ivy-completion-in-region-action)))
 

--- a/ivy.el
+++ b/ivy.el
@@ -1948,15 +1948,13 @@ behavior."
    prompt collection predicate require-match initial-input
    history (or def "") inherit-input-method))
 
-(declare-function mc/all-fake-cursors "ext:multiple-cursors-core")
-
 (defun ivy-completion-in-region-action (str)
   "Insert STR, erasing the previous one.
 The previous string is between `ivy-completion-beg' and `ivy-completion-end'."
   (when (consp str)
     (setq str (cdr str)))
   (when (stringp str)
-    (let ((fake-cursors (and (featurep 'multiple-cursors)
+    (let ((fake-cursors (and (fboundp 'mc/all-fake-cursors)
                              (mc/all-fake-cursors)))
           (pt (point))
           (beg ivy-completion-beg)
@@ -3570,7 +3568,7 @@ BUFFER may be a string or nil."
               (default-directory
                 (or (and b (buffer-local-value 'default-directory b))
                     default-directory)))
-         (call-interactively (if (fboundp 'counsel-find-file)
+         (call-interactively (if (functionp 'counsel-find-file)
                                  #'counsel-find-file
                                #'find-file))))
     "find file")


### PR DESCRIPTION
#### Changelog

* counsel.el (`counsel-el`): Simplify predicate to `fboundp`.
* ivy.el (`ivy-completion-in-region-action`): Use `fboundp` to make
feature detection more robust while silencing byte-compiler.
(`ivy-switch-buffer`): Commands must satisfy `functionp`, not `fboundp`.

#### Question

```el
(or (functionp x)
    (macrop x)
    (special-form-p x))
```

Is there some edge case where this is not equivalent to `fboundp`, at least for our intentions?