### PR TITLE
Raise own and pacify byte-compiler's warnings

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2434,9 +2434,11 @@ substituted by the search regexp and file, respectively.  Neither
 
 ;;;###autoload
 (defun counsel-grep (&optional initial-input)
-  "Grep for a string in the current file.
+  "Grep for a string in the file visited by the current buffer.
 When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
+  (unless buffer-file-name
+    (user-error "Current buffer is not visiting a file"))
   (counsel-require-program (car (split-string counsel-grep-base-command)))
   (setq counsel-grep-last-line nil)
   (setq counsel--git-dir default-directory)

--- a/ivy.el
+++ b/ivy.el
@@ -765,6 +765,12 @@ When ARG is t, exit with current text, ignoring the candidates."
         (t
          (ivy-done))))
 
+(defvar ivy-auto-select-single-candidate nil
+  "When non-nil, auto-select the candidate if it is the only one.
+When t, it is the same as if the user were prompted and selected the candidate
+by calling the default action.  This variable has no use unless the collection
+contains a single candidate.")
+
 (defun ivy--directory-done ()
   "Handle exit from the minibuffer when completing file names."
   (let (dir)
@@ -1555,12 +1561,6 @@ Directories come first."
       (if predicate
           (cl-remove-if-not predicate seq)
         seq))))
-
-(defvar ivy-auto-select-single-candidate nil
-  "When non-nil, auto-select the candidate if it is the only one.
-When t, it is the same as if the user were prompted and selected the candidate
-by calling the default action.  This variable has no use unless the collection
-contains a single candidate.")
 
 ;;** Entry Point
 ;;;###autoload


### PR DESCRIPTION
#### Changelog

* Reject non-file-visiting buffers in `counsel-grep` and clarify this in its docstring.
* Pacify the latest byte-compiler warnings.