### PR TITLE
Overhaul counsel-yank-pop

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3133,15 +3133,14 @@ A is the left hand side, B the right hand side."
               (search-backward (car kill-ring)))
           (point)))
   (setq ivy-completion-end (point))
-  (let ((candidates
-         (mapcar #'ivy-cleanup-string
-                 (cl-remove-if
-                  (lambda (s)
-                    (string-match "\\`[\n\r[:blank:]]*\\'" s))
-                  (delete-dups kill-ring))))
+  (let ((cands (delete-dups
+                (cl-mapcan (lambda (s)
+                             (unless (string-match-p "\\`[\n\r[:blank:]]*\\'" s)
+                               (list (ivy-cleanup-string (copy-sequence s)))))
+                           kill-ring)))
         (ivy-format-function #'counsel--yank-pop-format-function)
         (ivy-height 5))
-    (ivy-read "kill-ring: " candidates
+    (ivy-read "kill-ring: " cands
               :action 'counsel-yank-pop-action
               :caller 'counsel-yank-pop)))
 

--- a/counsel.el
+++ b/counsel.el
@@ -3127,26 +3127,23 @@ A is the left hand side, B the right hand side."
 (defun counsel-yank-pop ()
   "Ivy replacement for `yank-pop'."
   (interactive)
-  (if (eq last-command 'yank)
-      (progn
-        (setq ivy-completion-end (point))
-        (setq ivy-completion-beg
-              (save-excursion
-                (search-backward (car kill-ring))
-                (point))))
-    (setq ivy-completion-beg (point))
-    (setq ivy-completion-end (point)))
+  (setq ivy-completion-beg
+        (if (eq last-command 'yank)
+            (save-excursion
+              (search-backward (car kill-ring)))
+          (point)))
+  (setq ivy-completion-end (point))
   (let ((candidates
          (mapcar #'ivy-cleanup-string
                  (cl-remove-if
                   (lambda (s)
-                    (string-match "\\`[\n[:blank:]]*\\'" s))
-                  (delete-dups kill-ring)))))
-    (let ((ivy-format-function #'counsel--yank-pop-format-function)
-          (ivy-height 5))
-      (ivy-read "kill-ring: " candidates
-                :action 'counsel-yank-pop-action
-                :caller 'counsel-yank-pop))))
+                    (string-match "\\`[\n\r[:blank:]]*\\'" s))
+                  (delete-dups kill-ring))))
+        (ivy-format-function #'counsel--yank-pop-format-function)
+        (ivy-height 5))
+    (ivy-read "kill-ring: " candidates
+              :action 'counsel-yank-pop-action
+              :caller 'counsel-yank-pop)))
 
 (ivy-set-actions
  'counsel-yank-pop

--- a/counsel.el
+++ b/counsel.el
@@ -1501,7 +1501,7 @@ done") "\n" t)))
   (message "%S" (kill-new x)))
 
 (defcustom counsel-yank-pop-truncate-radius 2
-  "When non-nil, truncate the display of long strings."
+  "Number of context lines around `counsel-yank-pop' candidates."
   :type 'integer
   :group 'ivy)
 


### PR DESCRIPTION
#### Changelog

Please see each commit message in order. The last and most significant commit in particular addresses [this Emacs SE question](https://emacs.stackexchange.com/q/37351/15748) and closes #1190.

#### Before merging

The function `counsel--yank-pop-position` is also useful in #1133. If that PR lands first, the function should be removed from this PR. Conversely, if this PR lands first, then #1133 should be rebased to avail of the function.

#### Question

Is completely ignoring blank kills really that useful? Thoughts on lifting this restriction or making it configurable?