### PR TITLE
Preselect current file when showing list of files

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1717,7 +1717,10 @@ Skip some dotfiles unless `ivy-text' requires them."
       (find-file (expand-file-name x ivy--directory)))))
 
 (defun counsel--preselect-file ()
-  "Chooses the file to preselect in find-file like completions depending on customizations"
+  "Return candidate to preselect during filename completion.
+The preselect behaviour can be customized via user options
+`counsel-find-file-at-point' and
+`counsel-preselect-current-file', which see."
   (or
     (when counsel-find-file-at-point
       (require 'ffap)


### PR DESCRIPTION
Motivation is when you're browsing files in a directory one by one you want an easy way to go to the next one. With this change you only press <kbd>ctrl-n</kbd>.
Even without this example seems like a better default compared to `.`.

This commit also does tiny refactor to remove duplicate code.