### PR TITLE
Add counsel-evil-registers

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3254,6 +3254,36 @@ Note: Duplicate elements of `kill-ring' are always deleted."
  '(("d" counsel-yank-pop-action-remove "delete")
    ("r" counsel-yank-pop-action-rotate "rotate")))
 
+;;** `counsel-evil-registers'
+
+(defcustom counsel-evil-registers-height 5
+  "The `ivy-height' of `counsel-evil-registers'."
+  :group 'ivy
+  :type 'integer)
+
+(defun counsel-evil-registers ()
+  "Ivy replacement for `evil-show-registers'."
+  (interactive)
+  (if (fboundp 'evil-register-list)
+      (let ((ivy-format-function #'counsel--yank-pop-format-function)
+            (ivy-height counsel-evil-registers-height))
+        (ivy-read "evil-registers: "
+                  (cl-loop for (key . val) in (evil-register-list)
+                           collect
+                           (format "[%c]: %s" key (if (stringp val) val "")))
+                  :require-match t
+                  :action #'counsel-evil-registers-action
+                  :caller 'counsel-evil-registers))
+    (user-error "Required feature `evil' not installed.")))
+
+(defun counsel-evil-registers-action (s)
+  "Paste contents of S, trimming the register part.
+
+S will be of the form \"[register]: content\"."
+  (with-ivy-window
+    (insert
+     (replace-regexp-in-string "\\`\\[.*?\\]: " "" s))))
+
 ;;** `counsel-imenu'
 (defvar imenu-auto-rescan)
 (defvar imenu-auto-rescan-maxout)


### PR DESCRIPTION

Wanted to get an interest check on this. It adds support for seeing evil-registers.

Kind of similar to https://github.com/abo-abo/swiper/issues/1117 but for evil registers (so more similar to counsel-yank-pop).

I can spin this off somewhere else if it's not appropriate for ivy.

Couple questions:

1. (ivy-format-function #'counsel--yank-pop-format-function) --> uses counsel-yank-pop's format function.

2. counsel-evil-registers-height 5 --> I know it was mentioned that 5 seemed to be a pretty good middleground given the *3 factor. We could probably bump that default up just a tad since the default is actually pretty small. (i.e. It seems rare someone would have exactly 5 rows of yanks with 3 lines in them).

3. I see we 'require features as we need them but that seems to assume they're there. We might want something like (counsel-require-program) but (counsel-require-feature) instead.

Lastly, a screenshot.

<img width="1552" alt="screenshot 2017-12-10 08 55 53" src="https://user-images.githubusercontent.com/1227856/33807392-1bccb038-dd8b-11e7-9340-267b110d6ca7.png">
