### PR TITLE
counsel.el (counsel-yank-pop-action): Save window-start

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3197,6 +3197,7 @@ unique under `equal-including-properties'."
   "Like `yank-pop', but insert the kill corresponding to S."
   (with-ivy-window
     (setq last-command 'yank)
+    (setq yank-window-start (window-start))
     (yank-pop (counsel--yank-pop-position s))
     (setq ivy-completion-end (point))))
 


### PR DESCRIPTION
Otherwise, calling `yank-pop`, which expects a previous `yank` to have saved `window-start`, can result in intrusive recentering of the buffer.