### PR TITLE
Update documentation: ivy-toggle-fuzzy is no more the keybinding

### DIFF
--- a/doc/ivy-help.org
+++ b/doc/ivy-help.org
@@ -132,7 +132,7 @@ Additionally, here are the keys that are otherwise not bound:
 - ~<~ and ~>~ adjust the height of the minibuffer.
 - ~c~ (=ivy-toggle-calling=) - toggle calling the current action each
   time a different candidate is selected.
-- ~m~ (=ivy-toggle-fuzzy=) - toggle regex matcher.
+- ~m~ (=ivy-rotate-preferred-builders=) - rotate regex matcher.
 - ~w~ and ~s~ scroll the actions list.
 
 Minibuffer editing is disabled when Hydra is active.

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -508,8 +508,8 @@ Hydra menu offers these additioanl bindings:
      Toggle calling the action after each candidate change. It
      modifies ~j~ to ~jg~, ~k~ to ~kg~ etc.
 
-- ~m~ (=ivy-toggle-fuzzy=) ::
-     Toggle the current regexp matcher.
+- ~m~ (=ivy-rotate-preferred-builders=) ::
+     Rotate the current regexp matcher.
 
 - ~>~ (=ivy-minibuffer-grow=) ::
      Increase =ivy-height= for the current minibuffer.

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -695,11 +695,11 @@ Hydra menu offers these additioanl bindings:
 Toggle calling the action after each candidate change. It
 modifies @kbd{j} to @kbd{jg}, @kbd{k} to @kbd{kg} etc.
 @end indentedblock
-@subsubheading @kbd{m} (@code{ivy-toggle-fuzzy})
-@vindex ivy-toggle-fuzzy
+@subsubheading @kbd{m} (@code{ivy-rotate-preferred-builders})
+@vindex ivy-rotate-preferred-builders
 @kindex m
 @indentedblock
-Toggle the current regexp matcher.
+Rotate the current regexp matcher.
 @end indentedblock
 @subsubheading @kbd{>} (@code{ivy-minibuffer-grow})
 @vindex ivy-minibuffer-grow


### PR DESCRIPTION
Vaguely related to https://github.com/abo-abo/swiper/issues/1213.

I also wanted to point out that having to modify 3 places in the docs suggest that there's too much duplication. I'm not actually sure what's the difference between ivy-help.org and ivy.org and ivy.texi.