### PR TITLE
Support multi-character action keys

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -694,10 +694,14 @@ selection, non-nil otherwise."
         t
       (let* ((hint (funcall ivy-read-action-format-function (cdr actions)))
              (resize-mini-windows t)
-             (key (string (read-key hint)))
-             (action-idx (cl-position-if
-                          (lambda (x) (equal (car x) key))
-                          (cdr actions))))
+	     (key "")
+	     action-idx)
+	(while (and (setq action-idx (cl-position-if
+				      (lambda (x)
+					(string-prefix-p key (car x)))
+				      (cdr actions)))
+		    (not (string= key (car (nth (1+ action-idx) actions)))))
+	  (setq key (concat key (string (read-key hint)))))
         (cond ((member key '("" ""))
                nil)
               ((null action-idx)


### PR DESCRIPTION
This is a simple modification to `ivy-read-action` to support action keys with more than one character.

Note that such keys are already supported if `ivy-hydra` is loaded, because `hydra` supports them out of the box. So with this PR, multi-character action keys can be set whether `ivy-hydra` is loaded or not.

Of course one should not set an action's key to be a prefix of another action's key. Otherwise, if `ivy-hydra` is loaded then `hydra` will throw an error, and if it not loaded then the action with the prefix key will be called before one has a chance to complete the other action's key.

I did some testing and did not find any issue.

Let me know if you would like me to change some things.

Thanks.