### PR TITLE
Fix typos

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -45,7 +45,7 @@ exports.
 ** Exporting to texinfo
 
 ivy.texi is generated from ivy.org. To update the .texi file, eval
-ivy-ox.el then ~C-c C-e i t~ in the ivy.org bufer.
+ivy-ox.el then ~C-c C-e i t~ in the ivy.org buffer.
 * Copying
 :PROPERTIES:
 :COPYING:  t
@@ -502,7 +502,7 @@ display short aliases:
 Hydra reduces key strokes, for example: ~C-n C-n C-n C-n~ is ~C-o
 jjjj~ in Hydra.
 
-Hydra menu offers these additioanl bindings:
+Hydra menu offers these additional bindings:
 
 - ~c~ (=ivy-toggle-calling=) ::
      Toggle calling the action after each candidate change. It

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -686,7 +686,7 @@ display short aliases:
 Hydra reduces key strokes, for example: @kbd{C-n C-n C-n C-n} is @kbd{C-o
 jjjj} in Hydra.
 
-Hydra menu offers these additioanl bindings:
+Hydra menu offers these additional bindings:
 
 @subsubheading @kbd{c} (@code{ivy-toggle-calling})
 @vindex ivy-toggle-calling


### PR DESCRIPTION
Interestingly, the section `Exporting to texinfo` is not present in `ivy.texi`.

I don't know .texi much, so I'll let you decide wether this is normal or not :wink: 