### PR TITLE
swiper.el (swiper--ivy) Add integration with evil s expressions

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -531,6 +531,11 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
         (goto-char swiper--opoint))
       (when (and (null res) (> (length ivy-text) 0))
         (cl-pushnew ivy-text swiper-history))
+      ;; This allows evil mode to use
+      ;; swiper searches as defaults in
+      ;; s expressions
+      (when (bound-and-true-p evil-mode)
+        (setq isearch-string (substring-no-properties ivy-text)))
       (when swiper--reveal-mode
         (reveal-mode 1)))))
 


### PR DESCRIPTION
I.e. searching for apple with swiper and then running
`:s//orange/g` will replace all apples on the line with oranges as
expected. Evil uses the value of `isearch-string' for this
completion, hence it's inclusion.