### PR TITLE
Make counsel--yank-pop-position more robust

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3222,10 +3222,11 @@ A is the left hand side, B the right hand side."
    counsel-yank-pop-separator))
 
 (defun counsel--yank-pop-position (s)
-  "Return position of S in `kill-ring' relative to last yank.
-S must exist in `kill-ring'."
+  "Return position of S in `kill-ring' relative to last yank."
   (or (cl-position s kill-ring-yank-pointer :test #'equal-including-properties)
-      (+ (cl-position s kill-ring :test #'equal-including-properties)
+      (cl-position s kill-ring-yank-pointer :test #'equal)
+      (+ (or (cl-position s kill-ring :test #'equal-including-properties)
+             (cl-position s kill-ring :test #'equal))
          (- (length kill-ring-yank-pointer)
             (length kill-ring)))))
 


### PR DESCRIPTION
It is unlikely but somehow possible for the properties of `S` and those of its corresponding `kill-ring` item to not match.  In this case it is better to fall back to plain string equality than fail.

`counsel.el` (`counsel--yank-pop-position`): Gracefully degrade if `S` and its properties are not found in `kill-ring`.