### PR TITLE
Support older Org versions for counsel-org-goto

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2892,7 +2892,7 @@ version.  Argument values are based on the
                                (point))
                           (outline-next-heading)))
       (while start-pos
-        (let ((name (apply #'org-get-heading heading-args))
+        (let ((name (or (apply #'org-get-heading heading-args) ""))
               level)
           (search-forward " ")
           (setq level


### PR DESCRIPTION
The version of `org-get-heading` which ship with Emacs 24 and 25 can return `nil` when its two arguments are non-`nil`.

`counsel.el` (`counsel-org-goto--get-headlines`): Handle this.

Fixes #1422.