### PR TITLE
Extend dir-locals-file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,10 +3,10 @@
 
 ((nil
   (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
-  (bug-reference-url-format . "https://github.com/abo-abo/swiper/issues/%s"))
+  (bug-reference-url-format . "https://github.com/abo-abo/swiper/issues/%s")
+  (sentence-end-double-space . t))
  (emacs-lisp-mode
   (indent-tabs-mode . nil)
   (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")
-  (sentence-end-double-space . t)
   ;; (lisp-indent-function . common-lisp-indent-function)
   ))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,10 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((emacs-lisp-mode
+((nil
+  (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
+  (bug-reference-url-format . "https://github.com/abo-abo/swiper/issues/%s"))
+ (emacs-lisp-mode
   (indent-tabs-mode . nil)
   (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")
   (sentence-end-double-space . t)


### PR DESCRIPTION
* Support `bug-reference-mode` and `bug-reference-prog-mode`. Those who enable these modes will be able to quickly jump from issue references in, say, commit messages, to their corresponding project page.
* Enable `sentence-end-double-space` in all modes.