### PR TITLE
Regexp-quote characters in ivy--regex-fuzzy

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -184,6 +184,8 @@ will bring the behavior in line with the newer Emacsen."
 (ert-deftest ivy--regex-fuzzy ()
   (should (string= (ivy--regex-fuzzy "tmux")
                    "\\(t\\).*?\\(m\\).*?\\(u\\).*?\\(x\\)"))
+  (should (string= (ivy--regex-fuzzy ".tmux")
+                   "\\(\\.\\).*?\\(t\\).*?\\(m\\).*?\\(u\\).*?\\(x\\)"))
   (should (string= (ivy--regex-fuzzy "^tmux")
                    "^\\(t\\).*?\\(m\\).*?\\(u\\).*?\\(x\\)"))
   (should (string= (ivy--regex-fuzzy "^tmux$")

--- a/ivy.el
+++ b/ivy.el
@@ -2381,7 +2381,7 @@ Insert .* between each char."
           (concat (match-string 1 str)
                   (mapconcat
                    (lambda (x)
-                     (format "\\(%c\\)" x))
+                     (format "\\(%s\\)" (regexp-quote (string x))))
                    (string-to-list (match-string 2 str))
                    ".*?")
                   (match-string 3 str))


### PR DESCRIPTION
This greatly improves performance when searching large code bases for things like `.env.foo`.