### PR TITLE
Rename ivy--preferred-re-builders without hyphens

### DIFF
--- a/doc/Changelog.org
+++ b/doc/Changelog.org
@@ -3482,7 +3482,7 @@ Allow to quit with ~ESC~ for better work with evil, see [[https://github.com/abo
 :PROPERTIES:
 :CUSTOM_ID: 0-10-0-nf-ivy-rotate-preferred-builders
 :END:
-Bound to ~C-o m~. Customize with =ivy--preferred-re-builders=.
+Bound to ~C-o m~. Customize with =ivy-preferred-re-builders=.
 See [[https://github.com/abo-abo/swiper/issues/1093][#1093]], [[https://github.com/abo-abo/swiper/issues/1094][#1094]].
 -----
 *** ivy-switch-buffer

--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -35,7 +35,7 @@
 
 (defun ivy--matcher-desc ()
   "Return description of `ivy--regex-function'."
-  (let ((cell (assoc ivy--regex-function ivy--preferred-re-builders)))
+  (let ((cell (assq ivy--regex-function ivy-preferred-re-builders)))
     (if cell
         (cdr cell)
       "other")))

--- a/ivy.el
+++ b/ivy.el
@@ -3793,24 +3793,26 @@ Don't finish completion."
       (insert (substring (ivy-state-current ivy-last) 0 -1))
     (insert (ivy-state-current ivy-last))))
 
-(defcustom ivy--preferred-re-builders
+(define-obsolete-variable-alias 'ivy--preferred-re-builders
+  'ivy-preferred-re-builders "0.10.0")
+
+(defcustom ivy-preferred-re-builders
   '((ivy--regex-plus . "ivy")
     (ivy--regex-ignore-order . "order")
     (ivy--regex-fuzzy . "fuzzy"))
   "Alist of preferred re-builders with display names.
 This list can be rotated with `ivy-rotate-preferred-builders'."
-  :type '(alist :key-type function :value-type string)
-  :group 'ivy)
+  :type '(alist :key-type function :value-type string))
 
 (defun ivy-rotate-preferred-builders ()
-  "Switch to the next re builder in `ivy--preferred-re-builders'."
+  "Switch to the next re builder in `ivy-preferred-re-builders'."
   (interactive)
-  (when ivy--preferred-re-builders
+  (when ivy-preferred-re-builders
     (setq ivy--old-re nil)
     (setq ivy--regex-function
-          (let ((cell (assoc ivy--regex-function ivy--preferred-re-builders)))
-            (car (or (cadr (memq cell ivy--preferred-re-builders))
-                     (car ivy--preferred-re-builders)))))))
+          (let ((cell (assq ivy--regex-function ivy-preferred-re-builders)))
+            (car (or (cadr (memq cell ivy-preferred-re-builders))
+                     (car ivy-preferred-re-builders)))))))
 
 (defun ivy-toggle-fuzzy ()
   "Toggle the re builder between `ivy--regex-fuzzy' and `ivy--regex-plus'."


### PR DESCRIPTION
* `ivy.el` (`ivy--preferred-re-builders`): Rename `defcustom` without double hyphens to `ivy-preferred-re-builders`.  Add obsolete varalias.
(`ivy-rotate-preferred-builders`):
* `ivy-hydra.el` (`ivy--matcher-desc`):
* `doc/Changelog.org` (`ivy-rotate-preferred-builders`): Use new name and `assq` in place of `assoc` where applicable.