### PR TITLE
Add "insert buffer name" action similar to eshell-insert-buffer-name.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3671,6 +3671,12 @@ BUFFER may be a string or nil."
        (setq ivy--index 0)
        (ivy--reset-state ivy-last))
     "kill")
+   ("n"
+    ,(lambda (x)
+       (insert-and-inherit "#<buffer "
+                           (if (stringp x) x (car x))
+                           ">"))
+    "insert buffer name")
    ("r"
     ivy--rename-buffer-action
     "rename")))


### PR DESCRIPTION
There's already a eshell-insert-buffer-name function, but I think it's good to have its functionality in ivy-switch-buffer actions.