### PR TITLE
Simplify string splitting logic

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -153,10 +153,10 @@ will bring the behavior in line with the newer Emacsen."
 (ert-deftest ivy--split ()
   (should (equal (ivy--split "King of the who?")
                  '("King" "of" "the" "who?")))
-  (should (equal (ivy--split "The  Brittons.")
-                 '("The Brittons.")))
-  (should (equal (ivy--split "Who  are the  Brittons?")
-                 '("Who are" "the Brittons?")))
+  (should (equal (ivy--split "The  Britons.")
+                 '("The Britons.")))
+  (should (equal (ivy--split "Who  are the  Britons?")
+                 '("Who are" "the Britons?")))
   (should (equal (ivy--split "We're  all  Britons and   I   am your   king.")
                  '("We're all Britons"
                    "and  I  am"
@@ -168,6 +168,43 @@ will bring the behavior in line with the newer Emacsen."
   (should (equal (ivy--regex
                   "\\(?:interactive\\|swiper\\) \\(?:list\\|symbol\\)")
                  "\\(\\(?:interactive\\|swiper\\)\\).*?\\(\\(?:list\\|symbol\\)\\)")))
+
+(ert-deftest ivy--split-negation ()
+  (should (equal (ivy--split-negation "") ()))
+  (should (equal (ivy--split-negation "not") '("not")))
+  (should (equal (ivy--split-negation "!not") '("" "not")))
+  (should (equal (ivy--split-negation "not!") '("not")))
+  (should (equal (ivy--split-negation "!not!") '("" "not")))
+  (should (equal (ivy--split-negation "not!not!not") '("not" "not")))
+  (should (equal (ivy--split-negation "not!not\\!not") '("not" "not!not")))
+  (should (equal (ivy--split-negation "\\!not!not\\!not") '("!not" "not!not")))
+  (should (equal (ivy--split-negation "\\!not!notnot\\!") '("!not" "notnot!"))))
+
+(ert-deftest ivy--split-spaces ()
+  (should (equal (ivy--split-spaces "") ()))
+  (should (equal (ivy--split-spaces " ") ()))
+  (should (equal (ivy--split-spaces "  ") ()))
+
+  (should (equal (ivy--split-spaces "a ") '("a")))
+  (should (equal (ivy--split-spaces " a") '("a")))
+  (should (equal (ivy--split-spaces " a ") '("a")))
+  (should (equal (ivy--split-spaces "a  ") '("a")))
+  (should (equal (ivy--split-spaces "  a") '("a")))
+  (should (equal (ivy--split-spaces "  a  ") '("a")))
+
+  (should (equal (ivy--split-spaces "\\ ") '(" ")))
+  (should (equal (ivy--split-spaces "\\  ") '(" ")))
+  (should (equal (ivy--split-spaces " \\ ") '(" ")))
+  (should (equal (ivy--split-spaces "\\ \\ ") '("  ")))
+  (should (equal (ivy--split-spaces "a\\ ") '("a ")))
+  (should (equal (ivy--split-spaces "\\ a") '(" a")))
+  (should (equal (ivy--split-spaces "\\ a\\ ") '(" a ")))
+
+  (should (equal (ivy--split-spaces "a b") '("a" "b")))
+  (should (equal (ivy--split-spaces "a\\ b") '("a b")))
+  (should (equal (ivy--split-spaces " a b\\ ") '("a" "b ")))
+  (should (equal (ivy--split-spaces "\\  a b ") '(" " "a" "b")))
+  (should (equal (ivy--split-spaces " a\\  \\ b ") '("a " " b"))))
 
 (ert-deftest ivy--regex-plus ()
   (should (equal (ivy--regex-plus "add path\\!") "\\(add\\).*?\\(path!\\)")))

--- a/ivy.el
+++ b/ivy.el
@@ -2300,68 +2300,50 @@ When GREEDY is non-nil, join words in a greedy way."
   (if (ivy--legal-regex-p str) str (regexp-quote str)))
 
 (defun ivy--split-negation (str)
-  "Split STR into text before and after !.
-Don't split if it's escaped with \\!.
+  "Split STR into text before and after ! delimiter.
+Do not split if the delimiter is escaped as \\!.
 
-Assumes there is at most one unescaped !."
-  (let (parts
-        (part ""))
-    (mapc
-     (lambda (char)
-       (let ((prev-char (if (zerop (length part))
-                            nil
-                          (elt part (1- (length part))))))
-         ;; Split on !, unless it's escaped.
-         (cond
-          ;; Store "\!" as "!".
-          ((and (eq char ?!) (eq prev-char ?\\))
-           (setq part (concat (substring part 0 (1- (length part)))
-                              "!")))
-          ;; Split on "!".
-          ((eq char ?!)
-           (push part parts)
-           (setq part ""))
-          ;; Otherwise, append the current character.
-          (t
-           (setq part (concat part (string char)))))))
-     str)
-    (unless (zerop (length part))
-      (push part parts))
-    (setq parts (nreverse parts))
-    ;; If we have more than unescaped !, just discard the extra parts
-    ;; rather than crashing. We can't warn or error because the
-    ;; minibuffer is already active.
-    (when (> (length parts) 2)
-      (setq parts (list (cl-first parts) (cl-second parts))))
-    parts))
+Assumes there is at most one unescaped delimiter and discards
+text after delimiter if it is empty.  Modifies match data."
+  (unless (string= str "")
+    (let ((delim "\\(?:\\`\\|[^\\]\\)\\(!\\)"))
+      (mapcar (lambda (split)
+                ;; Store "\!" as "!".
+                (replace-regexp-in-string "\\\\!" "!" split t t))
+              (if (string-match delim str)
+                  ;; Ignore everything past first unescaped ! rather than
+                  ;; crashing.  We can't warn or error because the minibuffer is
+                  ;; already active.
+                  (let* ((i (match-beginning 1))
+                         (j (and (string-match delim str (1+ i))
+                                 (match-beginning 1)))
+                         (neg (substring str (1+ i) j)))
+                    (cons (substring str 0 i)
+                          (and (not (string= neg ""))
+                               (list neg))))
+                (list str))))))
 
 (defun ivy--split-spaces (str)
   "Split STR on spaces, unless they're preceded by \\.
 No unescaped spaces are present in the output."
-  (let (parts
-        (part ""))
-    (mapc
-     (lambda (char)
-       (let ((prev-char (if (zerop (length part))
-                            nil
-                          (elt part (1- (length part))))))
-         (cond
+  (when str
+    (let ((i 0) ; End of last search.
+          (j 0) ; End of last delimiter.
+          parts)
+      (while (string-match "\\(\\\\ \\)\\| +" str i)
+        (setq i (match-end 0))
+        (if (not (match-beginning 1))
+            ;; Unescaped space(s).
+            (let ((delim (match-beginning 0)))
+              (when (< j delim)
+                (push (substring str j delim) parts))
+              (setq j i))
           ;; Store "\ " as " ".
-          ((and (eq char ?\s) (eq prev-char ?\\))
-           (setq part (concat (substring part 0 (1- (length part)))
-                              " ")))
-          ;; Split on " ".
-          ((eq char ?\s)
-           (unless (zerop (length part))
-             (push part parts))
-           (setq part ""))
-          ;; Otherwise, append the current character.
-          (t
-           (setq part (concat part (string char)))))))
-     str)
-    (unless (zerop (length part))
-      (push part parts))
-    (nreverse parts)))
+          (setq str (replace-match " " t t str 1))
+          (setq i (1- i))))
+      (when (< j (length str))
+        (push (substring str j) parts))
+      (nreverse parts))))
 
 (defun ivy--regex-ignore-order (str)
   "Re-build regex from STR by splitting at spaces and using ! for negation.


### PR DESCRIPTION
#### Changelog

`ivy.el` (`ivy--split-negation`, `ivy--split-spaces`): Simplify and optimize logic.
`ivy-test.el` (`ivy--split-negation`, `ivy--split-spaces`): Add tests.
(`ivy--split`): Fix spelling.

#### Discussion

* On my machine the regexp approach is 2-4x as fast.
* I find the regexp logic simpler, but that's probably because I got close to it.
* Are the variable names acceptable?