### PR TITLE
Add /doc/dir, *.info and *-autoloads.el to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.elc
 *~
+/doc/dir
+*.info
+*-autoloads.el


### PR DESCRIPTION
Matching files are created (at least) by the Borg package manager.