### PR TITLE
add ivy-insert-org-entity.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2986,6 +2986,38 @@ include attachments of other Org buffers."
             :action 'counsel-locate-action-dired
             :caller 'counsel-org-file))
 
+(defvar org-entities)
+(defvar org-entities-user)
+
+;;;###autoload
+(defun ivy-insert-org-entity ()
+  "Insert an org-entity using ivy."
+  (interactive)
+  (ivy-read "Entity: " (cl-loop for element in (append org-entities org-entities-user)
+				when (not (stringp element))
+				collect
+				(cons
+				 (format "%20s | %20s | %20s | %s"
+					 (cl-first element) ;name
+					 (cl-second element) ; latex
+					 (cl-fourth element) ; html
+					 (cl-seventh element)) ;utf-8
+				 element))
+	    :require-match t
+	    :action '(1
+		      ("u" (lambda (candidate)
+			     (insert (cl-seventh (cdr candidate)))) "utf-8")
+		      ("o" (lambda (candidate)
+			     (insert "\\" (cl-first (cdr candidate)))) "org-entity")
+		      ("l" (lambda (candidate)
+			     (insert (cl-second (cdr candidate)))) "latex")
+		      ("h" (lambda (candidate)
+			     (insert (cl-fourth (cdr candidate)))) "html")
+		      ("a" (lambda (candidate)
+			     (insert (cl-fifth (cdr candidate)))) "ascii")
+		      ("L" (lambda (candidate)
+			     (insert (cl-sixth (cdr candidate))) "Latin-1")))))
+
 ;;** `counsel-org-capture'
 (defvar org-capture-templates)
 (declare-function org-capture-goto-last-stored "org-capture")


### PR DESCRIPTION
This function provides an ivy frontend to adding org-entities as org, latex, html, ascii, utf-8 or Latin-1 characters. This would fulfill issue #1220.

This cleanly compiles and passes the tests. I don't think it adds any issues to checkdoc.