### PR TITLE
counsel.el (counsel-ag, counsel-rg): store command persistently

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2248,35 +2248,24 @@ regex string."
   :type 'string
   :group 'ivy)
 
+(defvar counsel-ag-command nil)
+
 (counsel-set-async-exit-code 'counsel-ag 1 "No matches found")
 (ivy-set-occur 'counsel-ag 'counsel-ag-occur)
 (ivy-set-display-transformer 'counsel-ag 'counsel-git-grep-transformer)
 
-(defun counsel-ag-function (string base-cmd extra-ag-args)
+(defun counsel-ag-function (string)
   "Grep in the current directory for STRING using BASE-CMD.
 If non-nil, append EXTRA-AG-ARGS to BASE-CMD."
-  (when (null extra-ag-args)
-    (setq extra-ag-args ""))
   (if (< (length string) 3)
       (counsel-more-chars 3)
     (let ((default-directory (ivy-state-directory ivy-last))
           (regex (counsel-unquote-regex-parens
                   (setq ivy--old-re
                         (ivy--regex string)))))
-      (let* ((args-end (string-match " -- " extra-ag-args))
-             (file (if args-end
-                       (substring-no-properties extra-ag-args (+ args-end 3))
-                     ""))
-             (extra-ag-args (if args-end
-                                (substring-no-properties extra-ag-args 0 args-end)
-                              extra-ag-args))
-             (ag-cmd (format base-cmd
-                             (concat extra-ag-args
-                                     " -- "
-                                     (shell-quote-argument regex)
-                                     file))))
-        (counsel--async-command ag-cmd)
-        nil))))
+      (counsel--async-command (format counsel-ag-command
+                                      (shell-quote-argument regex)))
+      nil)))
 
 ;;;###autoload
 (defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt)
@@ -2286,25 +2275,39 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
 EXTRA-AG-ARGS string, if non-nil, is appended to `counsel-ag-base-command'.
 AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   (interactive)
-  (counsel-require-program (car (split-string counsel-ag-base-command)))
+  (setq counsel-ag-command counsel-ag-base-command)
+  (counsel-require-program (car (split-string counsel-ag-command)))
   (when current-prefix-arg
     (setq initial-directory
           (or initial-directory
               (read-directory-name (concat
-                                    (car (split-string counsel-ag-base-command))
+                                    (car (split-string counsel-ag-command))
                                     " in directory: "))))
     (setq extra-ag-args
           (or extra-ag-args
-              (let* ((pos (cl-position ?  counsel-ag-base-command))
-                     (command (substring-no-properties counsel-ag-base-command 0 pos))
-                     (ag-args (replace-regexp-in-string
-                               "%s" "" (substring-no-properties counsel-ag-base-command pos))))
-                (read-string (format "(%s) args:" command) ag-args)))))
+              (read-from-minibuffer (format
+                                     "%s args: "
+                                     (car (split-string counsel-ag-command)))))))
+  (when (null extra-ag-args)
+    (setq extra-ag-args ""))
+  (let* ((args-end (string-match " -- " extra-ag-args))
+         (file (if args-end
+                   (substring-no-properties extra-ag-args (+ args-end 3))
+                 ""))
+         (extra-ag-args (if args-end
+                            (substring-no-properties extra-ag-args 0 args-end)
+                          extra-ag-args)))
+    (setq counsel-ag-command (format counsel-ag-command
+                                      (concat extra-ag-args
+                                              " -- "
+                                              "%s"
+                                              file))))
   (ivy-set-prompt 'counsel-ag counsel-prompt-function)
-  (let ((default-directory (or initial-directory default-directory)))
-    (ivy-read (or ag-prompt (car (split-string counsel-ag-base-command)))
-              (lambda (string)
-                (counsel-ag-function string counsel-ag-base-command extra-ag-args))
+  (let ((default-directory (or initial-directory
+                               (locate-dominating-file default-directory ".git")
+                               default-directory)))
+    (ivy-read (or ag-prompt (car (split-string counsel-ag-command)))
+              #'counsel-ag-function
               :initial-input initial-input
               :dynamic-collection t
               :keymap counsel-ag-map
@@ -2339,7 +2342,7 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
 (defun counsel-ag-occur ()
   "Generate a custom occur buffer for `counsel-ag'."
   (counsel-grep-like-occur
-   "ag --nocolor --nogroup -- %s"))
+   counsel-ag-command))
 
 ;;** `counsel-pt'
 (defcustom counsel-pt-base-command "pt --nocolor --nogroup -e %s"
@@ -2387,7 +2390,7 @@ Note: don't use single quotes for the regex."
   :group 'ivy)
 
 (counsel-set-async-exit-code 'counsel-rg 1 "No matches found")
-(ivy-set-occur 'counsel-rg 'counsel-rg-occur)
+(ivy-set-occur 'counsel-rg 'counsel-ag-occur)
 (ivy-set-display-transformer 'counsel-rg 'counsel-git-grep-transformer)
 
 ;;;###autoload
@@ -2397,36 +2400,9 @@ INITIAL-INPUT can be given as the initial minibuffer input.
 INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
 EXTRA-RG-ARGS string, if non-nil, is appended to `counsel-rg-base-command'.
 RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
-  (interactive
-   (list nil
-         (when current-prefix-arg
-           (read-directory-name (concat
-                                 (car (split-string counsel-rg-base-command))
-                                 " in directory: ")))
-         (when current-prefix-arg
-           (read-from-minibuffer "rg args: "))))
-  (counsel-require-program (car (split-string counsel-rg-base-command)))
-  (ivy-set-prompt 'counsel-rg counsel-prompt-function)
-  (let ((default-directory (or initial-directory
-                               (locate-dominating-file default-directory ".git")
-                               default-directory)))
-    (ivy-read (or rg-prompt (car (split-string counsel-rg-base-command)))
-              (lambda (string)
-                (counsel-ag-function string counsel-rg-base-command extra-rg-args))
-              :initial-input initial-input
-              :dynamic-collection t
-              :keymap counsel-ag-map
-              :history 'counsel-git-grep-history
-              :action #'counsel-git-grep-action
-              :unwind (lambda ()
-                        (counsel-delete-process)
-                        (swiper--cleanup))
-              :caller 'counsel-rg)))
-
-(defun counsel-rg-occur ()
-  "Generate a custom occur buffer for `counsel-rg'."
-  (counsel-grep-like-occur
-   "rg -i --no-heading --line-number --color never -- %s ."))
+  (interactive)
+  (let ((counsel-ag-base-command counsel-rg-base-command))
+    (counsel-ag initial-input initial-directory extra-rg-args rg-prompt)))
 
 ;;** `counsel-grep'
 (defcustom counsel-grep-base-command "grep -E -n -e %s %s"


### PR DESCRIPTION
This adds a new variable `counsel-ag-command` which stores `counsel-ag-base-command` including the optional `extra-ag-args` and is used by `counsel-ag-occur`. Also simplifies `counsel-rg` which now simply let-binds `counsel-ag-base-command` and calls `counsel-ag` (similarly to `counsel-pt` and `counsel-ack`).

This seem to solve issue #777 :  `counsel-pt` and `counsel-ack` now work consistently when `ivy-resume` or `ivy-occur` is called (`counsel-rg` was not affected by this issue because it was duplicating the code from `counsel-ag` rather than calling it inside a let-binding).

It also solves issue #1462 which was closed because submitted about `counsel-projectile-rg` but actually affected `counsel-rg` and `counsel-ag` : extra args are now remembered when calling `ivy-occur`.

A couple of things to note:
- `counsel-rg` was not exactly duplicating the code from `counsel-ag`, there were small differences in the way extra args were read or initial directory was set. I've resolved them in the way that made more sense to me, but maybe they were intentional. Also in `counsel-rg`, the caller was set to `counsel-rg` but now it is `counsel-ag`, I don't know if that's an issue.
- In a way these changes make `counsel-ag` more similar to `counsel-grep` and it may be possible to make one rely on the other (eg `counsel-ag-function` / `counsel-grep-function`), but I didn't touch anything there. I noticed that the command used in `counsel-grep-occur` is different from `counsel-grep-base-command`, I don't know if that's on purpose.

Let me know if you would like me to make further changes.

