### PR TITLE
Touch-up some defcustom types

### DIFF
--- a/colir.el
+++ b/colir.el
@@ -32,13 +32,12 @@
 
 (require 'color)
 
-(defcustom colir-compose-method 'colir-compose-alpha
+(defcustom colir-compose-method #'colir-compose-alpha
   "Select a method to compose two color channels."
-  :type '(choice
-          (const colir-compose-alpha)
-          (const colir-compose-overlay)
-          (const colir-compose-soft-light))
-  :group 'ivy)
+  :group 'ivy
+  :type '(radio (function-item colir-compose-alpha)
+                (function-item colir-compose-overlay)
+                (function-item colir-compose-soft-light)))
 
 (defun colir-compose-soft-light (a b)
   "Compose A and B channels."

--- a/counsel.el
+++ b/counsel.el
@@ -240,14 +240,13 @@ Update the minibuffer with the amount of lines collected every
          (ivy--format ivy--all-candidates)))
       (setq counsel--async-time (current-time)))))
 
-(defcustom counsel-prompt-function 'counsel-prompt-function-default
+(defcustom counsel-prompt-function #'counsel-prompt-function-default
   "A function to return a full prompt string from a basic prompt string."
-  :type
-  '(choice
-    (const :tag "Plain" counsel-prompt-function-default)
-    (const :tag "Directory" counsel-prompt-function-dir)
-    (function :tag "Custom"))
-  :group 'ivy)
+  :group 'ivy
+  :type '(radio
+          (function-item counsel-prompt-function-default)
+          (function-item counsel-prompt-function-dir)
+          (function :tag "Custom")))
 
 (make-obsolete-variable
  'counsel-prompt-function
@@ -485,7 +484,7 @@ COUNT defaults to 1."
          (push (symbol-name vv) cands))))
     (delete "" cands)))
 
-(defcustom counsel-describe-variable-function 'describe-variable
+(defcustom counsel-describe-variable-function #'describe-variable
   "Function to call to describe a variable passed as parameter."
   :type 'function
   :group 'ivy)
@@ -525,7 +524,7 @@ Variables declared using `defcustom' are highlighted according to
  '(("I" counsel-info-lookup-symbol "info")
    ("d" counsel--find-symbol "definition")))
 
-(defcustom counsel-describe-function-function 'describe-function
+(defcustom counsel-describe-function-function #'describe-function
   "Function to call to describe a function passed as parameter."
   :type 'function
   :group 'ivy)
@@ -543,13 +542,11 @@ Variables declared using `defcustom' are highlighted according to
   (let ((f (function-called-at-point)))
     (and f (symbol-name f))))
 
-(defcustom counsel-describe-function-preselect 'ivy-thing-at-point
+(defcustom counsel-describe-function-preselect #'ivy-thing-at-point
   "Determine what `counsel-describe-function' should preselect."
-  :type
-  '(choice
-    (const ivy-thing-at-point)
-    (const ivy-function-called-at-point))
-  :group 'ivy)
+  :group 'ivy
+  :type '(radio (function-item ivy-thing-at-point)
+                (function-item ivy-function-called-at-point)))
 
 ;;;###autoload
 (defun counsel-describe-function ()
@@ -3821,7 +3818,7 @@ TREEP is used to expand internal nodes."
   :group 'ivy
   :type '(list directory))
 
-(defcustom counsel-linux-app-format-function 'counsel-linux-app-format-function-default
+(defcustom counsel-linux-app-format-function #'counsel-linux-app-format-function-default
   "Function to format Linux application names the `counsel-linux-app' menu.
 The format function will be passed the application's name, comment, and command
 as arguments."

--- a/ivy.el
+++ b/ivy.el
@@ -168,7 +168,7 @@ earlier versions of Emacs."
           (const :tag "Plain" nil)
           (const :tag "Fancy" fancy)))
 
-(defcustom ivy-on-del-error-function 'minibuffer-keyboard-quit
+(defcustom ivy-on-del-error-function #'minibuffer-keyboard-quit
   "The handler for when `ivy-backward-delete-char' throws.
 Usually a quick exit out of the minibuffer."
   :type 'function)
@@ -1395,7 +1395,7 @@ On error (read-only), call `ivy-on-del-error-function'."
 (declare-function avy--process "ext:avy")
 (declare-function avy--style-fn "ext:avy")
 
-(defcustom ivy-format-function 'ivy-format-function-default
+(defcustom ivy-format-function #'ivy-format-function-default
   "Function to transform the list of candidates into a string.
 This string is inserted into the minibuffer."
   :type '(choice
@@ -2598,7 +2598,7 @@ If nil, the text properties are applied to the whole match."
             (cl-sort (copy-sequence collection) sort-fn)
           collection)))))
 
-(defcustom ivy-magic-slash-non-match-action 'ivy-magic-slash-non-match-cd-selected
+(defcustom ivy-magic-slash-non-match-action #'ivy-magic-slash-non-match-cd-selected
   "Action to take when a slash is added to the end of a non existing directory.
 Possible choices are 'ivy-magic-slash-non-match-cd-selected,
 'ivy-magic-slash-non-match-create, or nil"
@@ -2920,7 +2920,7 @@ The alist VAL is a sorting function with the signature of
           :value-type
           (choice
            (const :tag "Don't sort" nil)
-           (const :tag "Put prefix matches ahead" 'ivy--prefix-sort)
+           (const :tag "Put prefix matches ahead" ivy--prefix-sort)
            (function :tag "Custom sort function"))))
 
 (defun ivy--sort-files-by-date (_name candidates)

--- a/swiper.el
+++ b/swiper.el
@@ -66,7 +66,7 @@
                           swiper-match-face-4)
   "List of `swiper' faces for group matches."
   :group 'ivy-faces
-  :type 'list)
+  :type '(repeat face))
 
 (defcustom swiper-min-highlight 2
   "Only highlight matches for regexps at least this long."


### PR DESCRIPTION
`colir.el` (`colir-compose-method`):
`counsel.el` (`counsel-prompt-function`)
(`counsel-describe-function-preselect`): Show function docstrings.
`ivy.el` (`ivy-sort-matches-functions-alist`): Fix quoting.
`swiper.el` (`swiper-faces`): Fix type.