### PR TITLE
Simplify and improve counsel processes

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1334,22 +1334,20 @@ INITIAL-INPUT can be given as the initial minibuffer input."
 
 (defun counsel--gg-sentinel (process _msg)
   "Sentinel function for a `counsel-git-grep' PROCESS."
-  (if (and (eq (process-status process) 'exit)
-           (memq (process-exit-status process) '(0 141)))
-      (progn
-        (with-current-buffer (process-buffer process)
-          (setq ivy--all-candidates
-                (or (split-string (buffer-string) "\n" t)
-                    '("")))
-          (setq ivy--old-cands ivy--all-candidates))
-        (when (= 0 (cl-incf counsel-gg-state))
-          (ivy--exhibit)))
-    (if (and (eq (process-status process) 'exit)
-             (= (process-exit-status process) 1))
-        (progn
-          (setq ivy--all-candidates '("Error"))
-          (setq ivy--old-cands ivy--all-candidates)
-          (ivy--exhibit)))))
+  (when (eq (process-status process) 'exit)
+    (cl-case (process-exit-status process)
+      ((0 141)
+       (with-current-buffer (process-buffer process)
+         (setq ivy--all-candidates
+               (or (split-string (buffer-string) "\n" t)
+                   '("")))
+         (setq ivy--old-cands ivy--all-candidates))
+       (when (zerop (cl-incf counsel-gg-state))
+         (ivy--exhibit)))
+      (1
+       (setq ivy--all-candidates '("Error"))
+       (setq ivy--old-cands ivy--all-candidates)
+       (ivy--exhibit)))))
 
 (defun counsel--gg-count (regex &optional no-async)
   "Count the number of results matching REGEX in `counsel-git-grep'.

--- a/counsel.el
+++ b/counsel.el
@@ -3936,13 +3936,13 @@ Any desktop entries that fail to parse are recorded in
 
 (defun counsel-linux-app-action-default (desktop-shortcut)
   "Launch DESKTOP-SHORTCUT."
-  (call-process "gtk-launch" nil nil nil (cdr desktop-shortcut)))
+  (let ((app (cdr desktop-shortcut)))
+    (start-process app nil "gtk-launch" app)))
 
 (defun counsel-linux-app-action-file (desktop-shortcut)
   "Launch DESKTOP-SHORTCUT with a selected file."
-  (call-process "gtk-launch" nil nil nil
-                (cdr desktop-shortcut)
-                (read-file-name "File: ")))
+  (let ((app (cdr desktop-shortcut)))
+    (start-process app nil "gtk-launch" app (read-file-name "File: "))))
 
 (defun counsel-linux-app-action-open-desktop (desktop-shortcut)
   "Open DESKTOP-SHORTCUT."

--- a/counsel.el
+++ b/counsel.el
@@ -203,29 +203,23 @@ Update the minibuffer with the amount of lines collected every
 `counsel-async-filter-update-time' microseconds since the last update."
   (with-current-buffer (process-buffer process)
     (insert str))
-  (let (size)
-    (when (time-less-p
-           `(0 0 ,counsel-async-filter-update-time 0)
-           (time-since counsel--async-time))
+  (when (time-less-p (list 0 0 counsel-async-filter-update-time)
+                     (time-since counsel--async-time))
+    (let (numlines)
       (with-current-buffer (process-buffer process)
-        (goto-char (point-min))
-        (setq size (- (buffer-size) (forward-line (buffer-size))))
+        (setq numlines (count-lines (point-min) (point-max)))
         (ivy--set-candidates
-         (let ((strings (split-string (buffer-string)
-                                      counsel-async-split-string-re
-                                      t)))
-           (if (and counsel-async-ignore-re
-                    (stringp counsel-async-ignore-re))
-               (cl-remove-if
-                (lambda (str)
-                  (string-match-p counsel-async-ignore-re str))
-                strings)
-             strings))))
-      (let ((ivy--prompt (format
-                          (concat "%d++ " (ivy-state-prompt ivy-last))
-                          size)))
-        (ivy--insert-minibuffer
-         (ivy--format ivy--all-candidates)))
+         (let ((lines (split-string (buffer-string)
+                                    counsel-async-split-string-re
+                                    t)))
+           (if (stringp counsel-async-ignore-re)
+               (cl-remove-if (lambda (line)
+                               (string-match-p counsel-async-ignore-re line))
+                             lines)
+             lines))))
+      (let ((ivy--prompt (format (concat "%d++ " (ivy-state-prompt ivy-last))
+                                 numlines)))
+        (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))
       (setq counsel--async-time (current-time)))))
 
 (defcustom counsel-prompt-function #'counsel-prompt-function-default


### PR DESCRIPTION
#### Summary

(`counsel--async-filter`): Simplify. Fix time comparison for Emacs < 24.3.
(`counsel-delete-process`): Take optional process name argument.
(`counsel--async-command`): Allow specifying process name, and default sentinel and filter functions via new `:default` argument value.
(`counsel--async-sentinel`, `counsel-cmd-to-dired`, `counsel--gg-sentinel`): Simplify.  Inspect `process-status` and `process-exit-status` instead of user-facing description.
(`counsel--gg-candidates`, `counsel--gg-count`): Reuse `counsel--async-command`.

These should all be backward compatible, but extend the APIs of `counsel-delete-process` and `counsel--async-command`. Please see each commit individually for details.

#### Discussion

* `counsel--async-command` could have taken mandatory `sentinel` and `filter` arguments to allow the distinction between `nil` meaning `internal-default-process-{sentinel,filter}` and `counsel--async-{sentinel,filter}`, respectively, but it has already been documented in the manual as requiring only a single argument.
* `internal-default-process-{sentinel,filter}` were only added in Emacs 24.4 and are non-trivial to backport, hence the new `:default` argument to `counsel--async-command`.
* Is it better to duplicate `counsel-delete-process` and `counsel--async-command` than extend their argument lists?