### PR TITLE
Add text property `buffer` to swiper-multi candidates.

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -996,6 +996,7 @@ See `ivy-format-function' for further information."
                        ?\ )
                       (buffer-name))
                      s)
+                    (put-text-property 0 len 'buffer buf s)
                     s))
                 (swiper--candidates 4))
                res))


### PR DESCRIPTION
Fixes #1491.