### PR TITLE
Fix ivy-resume for counsel-find-file

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1853,14 +1853,16 @@ This is useful for recursive `ivy-read'."
                             (file-name-nondirectory initial-input)))))
              (require 'dired)
              (when preselect
-               (let ((preselect-directory (file-name-directory preselect)))
+               (let ((preselect-directory (file-name-directory
+                                           (directory-file-name preselect))))
                  (unless (or (null preselect-directory)
                              (string= preselect-directory
                                       default-directory))
                    (setq ivy--directory preselect-directory))
                  (setf
                   (ivy-state-preselect state)
-                  (setq preselect (file-name-nondirectory preselect)))))
+                  (setq preselect (file-relative-name preselect
+                                                      preselect-directory)))))
              (setq coll (ivy--sorted-files ivy--directory))
              (when initial-input
                (unless (or require-match

--- a/ivy.el
+++ b/ivy.el
@@ -1312,6 +1312,7 @@ If so, move to that directory, while keeping only the file name."
     (setq ivy--all-candidates
           (ivy--sorted-files (setq ivy--directory dir)))
     (setq ivy-text "")
+    (setf (ivy-state-directory ivy-last) dir)
     (delete-minibuffer-contents)))
 
 (defun ivy-backward-delete-char ()


### PR DESCRIPTION
Should fix #1095 (the issue was opened about `counsel-ag` and `counsel-rg` but the discussion moved to `counsel-find-file`).

Resuming would not work when the current candidate was a directory or after navigating to a different directory inside `counsel-find-file`.