### PR TITLE
Add other-frame actions for some find-file variants

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1623,6 +1623,7 @@ Does not list the currently checked out one."
 (ivy-set-actions
  'counsel-find-file
  '(("j" find-file-other-window "other window")
+   ("f" find-file-other-frame "other frame")
    ("b" counsel-find-file-cd-bookmark-action "cd bookmark")
    ("x" counsel-find-file-extern "open externally")
    ("r" counsel-find-file-as-root "open as root")

--- a/counsel.el
+++ b/counsel.el
@@ -885,6 +885,19 @@ The libraries are offered from `load-path'."
  '(("d" counsel--find-symbol "definition")))
 
 ;;** `counsel-find-library'
+(ivy-set-actions
+ 'counsel-find-library
+ '(("j" (lambda (library)
+          (let ((buf (find-file-noselect (find-library-name library))))
+            (pop-to-buffer buf 'other-window)))
+    "other window")
+   ("f" (lambda (library)
+          (let ((buf (find-file-noselect (find-library-name library))))
+            (condition-case nil
+                (switch-to-buffer-other-frame buf)
+              (error (pop-to-buffer buf)))))
+    "other frame")))
+
 ;;;###autoload
 (defun counsel-find-library ()
   "Visit a selected the Emacs Lisp library.

--- a/counsel.el
+++ b/counsel.el
@@ -1889,6 +1889,7 @@ result as a URL."
 (ivy-set-actions
  'counsel-recentf
  '(("j" find-file-other-window "other window")
+   ("f" find-file-other-frame "other frame")
    ("x" counsel-find-file-extern "open externally")))
 
 ;;** `counsel-locate'


### PR DESCRIPTION
The last commit adds a other-frame *as well as a other-window* action to `counsel-find-library`. Emacs doesn't define `find-library-other-{frame,window}` so this is done using two lambdas. If you would rather add proper commands, you could [copy them](https://github.com/tarsius/fwb-cmds/blob/master/fwb-cmds.el#L130-L169) from my (very old) `fwb-cmds` library