### PR TITLE
Minor touch-ups

### DIFF
--- a/colir.el
+++ b/colir.el
@@ -30,6 +30,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'color)
 
 (defcustom colir-compose-method #'colir-compose-alpha

--- a/ivy.el
+++ b/ivy.el
@@ -565,13 +565,15 @@ functionality, e.g. as seen in `isearch'."
 
 (defmacro ivy-quit-and-run (&rest body)
   "Quit the minibuffer and run BODY afterwards."
+  (declare (indent 0))
   `(progn
      (put 'quit 'error-message "")
      (run-at-time nil nil
                   (lambda ()
                     (put 'quit 'error-message "Quit")
-                    ,@body))
-     (minibuffer-keyboard-quit)))
+                    (with-demoted-errors "Error: %S"
+                      ,@body)))
+     (abort-recursive-edit)))
 
 (defun ivy-exit-with-action (action)
   "Quit the minibuffer and call ACTION afterwards."
@@ -792,11 +794,11 @@ When ARG is t, exit with current text, ignoring the candidates."
         ((eq (ivy-state-collection ivy-last) 'Info-read-node-name-1)
          (if (member (ivy-state-current ivy-last) '("(./)" "(../)"))
              (ivy-quit-and-run
-              (ivy-read "Go to file: " 'read-file-name-internal
-                        :action (lambda (x)
-                                  (Info-find-node
-                                   (expand-file-name x ivy--directory)
-                                   "Top"))))
+               (ivy-read "Go to file: " 'read-file-name-internal
+                         :action (lambda (x)
+                                   (Info-find-node
+                                    (expand-file-name x ivy--directory)
+                                    "Top"))))
            (ivy-done)))
         (t
          (ivy-done))))

--- a/swiper.el
+++ b/swiper.el
@@ -217,7 +217,7 @@
             (ivy-done)
             (ivy-call))
         (ivy-quit-and-run
-         (avy-action-goto (avy-candidate-beg candidate)))))))
+          (avy-action-goto (avy-candidate-beg candidate)))))))
 
 (declare-function mc/create-fake-cursor-at-point "ext:multiple-cursors-core")
 (declare-function multiple-cursors-mode "ext:multiple-cursors-core")


### PR DESCRIPTION
#### Changelog

* `colir.el`: Require `cl-lib` dependency.
* `ivy.el` (`ivy-quit-and-run`):
  - Add indentation spec.
  - Eagerly demote our own errors for clearer error messages.
  - Call `abort-recursive-edit` directly, irrespective of `delete-selection-mode`.
* (`ivy-alt-done`):
`swiper.el` (`swiper-avy`): Reindent its call sites.

#### Rationale

Demoting errors in the `ivy-quit-and-run` timer function means errors are reported along the lines of `Error: (error "foo")` rather than `Error running timer: (error "foo")`, the latter of which leaks the macro's abstraction.

#### Discussion

Further to https://github.com/abo-abo/swiper/issues/606#issuecomment-365033386, I have been trying to refactor `ivy-quit-and-run` to avoid:
1. changing the `error-message` of `quit`; and
2. using timers,

but I have not been successful.

For a second I thought (1) could be solved by temporarily disabling `command-error-function`, as described in [`(elisp) Processing of Errors`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Processing-of-Errors.html), but this variable does not take effect for local quits. I'm not sure whether increasing its scope would constitute a worthwhile feature request.

What to me seems to be the canonical alternative to (2) is using `post-command-hook`, e.g.
```el
(defmacro ivy-quit-and-run (&rest body)
  "Quit the minibuffer and run BODY afterwards."
  (declare (indent 0))
  (let ((nonce (make-symbol "nonce")))
    `(letrec ((,nonce (lambda ()
                        (remove-hook 'post-command-hook ,nonce)
                        (with-local-quit
                          (with-demoted-errors "Error: %S"
                            ,@body)))))
       (add-hook 'post-command-hook ,nonce)
       (abort-recursive-edit))))
```

The downside of which is the requirement of `lexical-binding` at the call site. I think the reason `minibuffer-with-setup-hook` works in a similar way, irrespective of `lexical-binding`, is because it runs entirely within the same dynamic scope/extent.

Perhaps another alternative would be to run `BODY` in a recursive edit, but I'm both unsure this is even possible and far from convinced it is any better than using timers.