### PR TITLE
Run post-command hooks on updates to ivy's overlay

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -126,7 +126,8 @@ Hide the minibuffer contents and cursor."
                       (current-column)))))))
           (add-face-text-property cursor-pos (1+ cursor-pos)
                                   'ivy-cursor t overlay-str)
-          (ivy-overlay-show-after overlay-str))))))
+          (ivy-overlay-show-after overlay-str)
+          (run-hooks 'post-command-hook))))))
 
 (provide 'ivy-overlay)
 ;;; ivy-overlay.el ends here


### PR DESCRIPTION
This gives `whitespace-mode` a chance to synchronize `whitespace-point` with `point` after updates to ivy's overlay.

Fixes #1488

Note that I opted for ~blindly~ boldly running all of the hooks in `post-command-hook` rather than calling into `whitespace-mode`'s hook only: after the conversation in the related issue, it made more sense to me to signal to the outside world that "something command-like happened" and let anybody who's interested in that pick it up.