### PR TITLE
Add variable to set :dynamic-collection on ivy-completing-read.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -212,6 +212,9 @@ Examples of properties include associated `:cleanup' functions.")
   '((ivy-completion-in-region . ivy-display-function-overlay))
   "An alist for customizing `ivy-display-function'.")
 
+(defvar ivy-completing-read-dynamic-collection nil
+  "Run `ivy-completing-read' with `:dynamic-collection t`.")
+
 (defcustom ivy-completing-read-handlers-alist
   '((tmm-menubar . completing-read-default)
     (tmm-shortcut . completing-read-default)
@@ -2031,6 +2034,7 @@ INHERIT-INPUT-METHOD is currently ignored."
                 :history history
                 :keymap nil
                 :sort t
+                :dynamic-collection ivy-completing-read-dynamic-collection
                 :caller (cond ((called-interactively-p 'any)
                                this-command)
                               ((and collection (symbolp collection))


### PR DESCRIPTION
Some functions with completing-read require :dynamic-collection t so that the collection function is run again. Helm and Ido have these options which the functions can override using (let ...). This commit adds a similar option to Ivy.