### PR TITLE
[WIP] A customization mechanism for ivy-height

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -256,7 +256,6 @@ Update the minibuffer with the amount of lines collected every
                    (car bnd)
                    (cdr bnd))
                 ""))
-         (ivy-height 7)
          (pred (and (eq (char-before (car bnd)) ?\()
                     #'fboundp))
          symbol-names)
@@ -269,9 +268,12 @@ Update the minibuffer with the amount of lines collected every
              (push (symbol-name x) symbol-names))))
       (setq symbol-names (all-completions str obarray pred)))
     (ivy-read "Symbol name: " symbol-names
+              :caller 'counsel-el
               :predicate pred
               :initial-input str
               :action #'ivy-completion-in-region-action)))
+
+(add-to-list 'ivy-height-alist '(counsel-el . 7))
 
 ;;** `counsel-cl'
 (declare-function slime-symbol-start-pos "ext:slime")
@@ -331,13 +333,15 @@ Update the minibuffer with the amount of lines collected every
          (str (buffer-substring-no-properties
                (car bnd) (cdr bnd)))
          (candidates (funcall completion-fn str))
-         (ivy-height 7)
          (res (ivy-read (format "pattern (%s): " str)
-                        candidates)))
+                        candidates
+                        :caller 'counsel--generic)))
     (when (stringp res)
       (when bnd
         (delete-region (car bnd) (cdr bnd)))
       (insert res))))
+
+(add-to-list 'ivy-height-alist '(counsel--generic . 7))
 
 ;;;###autoload
 (defun counsel-clj ()
@@ -1573,13 +1577,14 @@ Does not list the currently checked out one."
   (let ((counsel-async-split-string-re counsel-git-log-split-string-re)
         (counsel-async-ignore-re "^[ \n]*$")
         (counsel-yank-pop-truncate-radius 5)
-        (ivy-format-function #'counsel--yank-pop-format-function)
-        (ivy-height 4))
+        (ivy-format-function #'counsel--yank-pop-format-function))
     (ivy-read "Grep log: " #'counsel-git-log-function
               :dynamic-collection t
               :action #'counsel-git-log-action
               :unwind #'counsel-delete-process
               :caller 'counsel-git-log)))
+
+(add-to-list 'ivy-height-alist '(counsel-git-log . 4))
 
 ;;* File
 ;;** `counsel-find-file'
@@ -3207,11 +3212,6 @@ A is the left hand side, B the right hand side."
   :group 'ivy
   :type 'string)
 
-(defcustom counsel-yank-pop-height 5
-  "The `ivy-height' of `counsel-yank-pop'."
-  :group 'ivy
-  :type 'integer)
-
 (defun counsel--yank-pop-format-function (cand-pairs)
   "Transform CAND-PAIRS into a string for `counsel-yank-pop'."
   (ivy--format-function-generic
@@ -3328,7 +3328,6 @@ Note: Duplicate elements of `kill-ring' are always deleted."
   ;; Do not specify `*' to allow browsing `kill-ring' in read-only buffers
   (interactive "P")
   (let ((ivy-format-function #'counsel--yank-pop-format-function)
-        (ivy-height counsel-yank-pop-height)
         (kills (counsel--yank-pop-kills)))
     (unless kills
       (error "Kill ring is empty or blank"))
@@ -3351,23 +3350,19 @@ Note: Duplicate elements of `kill-ring' are always deleted."
               :action #'counsel-yank-pop-action
               :caller 'counsel-yank-pop)))
 
+(add-to-list 'ivy-height-alist '(counsel-yank-pop . 5))
+
 (ivy-set-actions
  'counsel-yank-pop
  '(("d" counsel-yank-pop-action-remove "delete")
    ("r" counsel-yank-pop-action-rotate "rotate")))
 
 ;;** `counsel-evil-registers'
-(defcustom counsel-evil-registers-height 5
-  "The `ivy-height' of `counsel-evil-registers'."
-  :group 'ivy
-  :type 'integer)
-
 (defun counsel-evil-registers ()
   "Ivy replacement for `evil-show-registers'."
   (interactive)
   (if (fboundp 'evil-register-list)
-      (let ((ivy-format-function #'counsel--yank-pop-format-function)
-            (ivy-height counsel-evil-registers-height))
+      (let ((ivy-format-function #'counsel--yank-pop-format-function))
         (ivy-read "evil-registers: "
                   (cl-loop for (key . val) in (evil-register-list)
                      collect (format "[%c]: %s" key (if (stringp val) val "")))
@@ -3375,6 +3370,8 @@ Note: Duplicate elements of `kill-ring' are always deleted."
                   :action #'counsel-evil-registers-action
                   :caller 'counsel-evil-registers))
     (user-error "Required feature `evil' not installed.")))
+
+(add-to-list 'ivy-height-alist '(counsel-evil-registers . 5))
 
 (defun counsel-evil-registers-action (s)
   "Paste contents of S, trimming the register part.

--- a/counsel.el
+++ b/counsel.el
@@ -3212,6 +3212,16 @@ A is the left hand side, B the right hand side."
   :group 'ivy
   :type 'string)
 
+(defcustom counsel-yank-pop-height 5
+  "The `ivy-height' of `counsel-yank-pop'."
+  :group 'ivy
+  :type 'integer)
+
+(make-obsolete-variable
+ 'counsel-yank-pop-height
+ "use `ivy-height-alist' instead."
+ "<2018-04-14 Fri>") ;; TODO add version
+
 (defun counsel--yank-pop-format-function (cand-pairs)
   "Transform CAND-PAIRS into a string for `counsel-yank-pop'."
   (ivy--format-function-generic
@@ -3358,6 +3368,16 @@ Note: Duplicate elements of `kill-ring' are always deleted."
    ("r" counsel-yank-pop-action-rotate "rotate")))
 
 ;;** `counsel-evil-registers'
+(defcustom counsel-evil-registers-height 5
+  "The `ivy-height' of `counsel-evil-registers'."
+  :group 'ivy
+  :type 'integer)
+
+(make-obsolete-variable
+ 'counsel-evil-registers
+ "use `ivy-height-alist' instead."
+ "<2018-04-14 Fri>") ;; TODO add version
+
 (defun counsel-evil-registers ()
   "Ivy replacement for `evil-show-registers'."
   (interactive)

--- a/ivy.el
+++ b/ivy.el
@@ -134,7 +134,7 @@
 (defcustom ivy-height 10
   "Number of lines for the minibuffer window.
 
-Also see `ivy-height-alist'."
+See also `ivy-height-alist'."
   :type 'integer)
 
 (defcustom ivy-count-format "%-4d "
@@ -232,7 +232,7 @@ Examples of properties include associated `:cleanup' functions.")
 (defcustom ivy-height-alist nil
   "An alist to customize `ivy-height'.
 
-It is a list of (CALLER . HEIGHT).  CALLER is either a caller of
+It is a list of (CALLER . HEIGHT).  CALLER is a caller of
 `ivy-read' and HEIGHT is the number of lines displayed."
   :type '(alist :key-type function :value-type integer))
 
@@ -1712,8 +1712,8 @@ customizations apply to the current completion session."
                         (assq t ivy-display-functions-alist))))))
         (height
          (if caller
-             (let ((try-assoc (assoc caller ivy-height-alist)))
-               (if try-assoc (cdr try-assoc) ivy-height))
+             (let ((entry (assoc caller ivy-height-alist)))
+               (if entry (cdr entry) ivy-height))
            ivy-height)))
     (setq ivy-last
           (make-ivy-state

--- a/ivy.el
+++ b/ivy.el
@@ -132,7 +132,9 @@
 (setcdr (assoc load-file-name custom-current-group-alist) 'ivy)
 
 (defcustom ivy-height 10
-  "Number of lines for the minibuffer window."
+  "Number of lines for the minibuffer window.
+
+Also see `ivy-height-alist'."
   :type 'integer)
 
 (defcustom ivy-count-format "%-4d "
@@ -226,6 +228,13 @@ Examples of properties include associated `:cleanup' functions.")
     (webjump . ivy-completing-read-with-empty-string-def))
   "An alist of handlers to replace `completing-read' in `ivy-mode'."
   :type '(alist :key-type function :value-type function))
+
+(defcustom ivy-height-alist nil
+  "An alist to customize `ivy-height'.
+
+It is a list of (CALLER . HEIGHT).  CALLER is either a caller of
+`ivy-read' and HEIGHT is the number of lines displayed."
+  :type '(alist :key-type function :value-type integer))
 
 (defvar ivy-completing-read-ignore-handlers-depth -1
   "Used to avoid infinite recursion.
@@ -1700,7 +1709,12 @@ customizations apply to the current completion session."
          (unless (window-minibuffer-p)
            (or ivy-display-function
                (cdr (or (assq caller ivy-display-functions-alist)
-                        (assq t ivy-display-functions-alist)))))))
+                        (assq t ivy-display-functions-alist))))))
+        (height
+         (if caller
+             (let ((try-assoc (assoc caller ivy-height-alist)))
+               (if try-assoc (cdr try-assoc) ivy-height))
+           ivy-height)))
     (setq ivy-last
           (make-ivy-state
            :prompt prompt
@@ -1733,6 +1747,7 @@ customizations apply to the current completion session."
                (let* ((hist (or history 'ivy-history))
                       (minibuffer-completion-table collection)
                       (minibuffer-completion-predicate predicate)
+                      (ivy-height height)
                       (resize-mini-windows
                        (cond
                          ((display-graphic-p) nil)


### PR DESCRIPTION
fix #1527

### Summary of changes:

ivy.el:
* ivy-height-alist: new variable.

counsel.el:
* (counsel-el, counsel--generic, counsel-git-log): make height customizable.
* ~~(counsel-yank-pop-height, counsel-evil-registers-height): kill now useless variable.~~
* (counsel-yank-pop-height, counsel-evil-registers-height): make now useless variable obsolete.
* (counsel-yank-pop, counsel-evil-registers): adapt to ivy-height-alist.


### Discussion

~~It's always quite nice to get rid of magic numbers.~~
~~Should we get rid of the customization variables? (probably not, this is just proof of concept).~~


### TODO
- [ ] We should probably say something in the changelog about the change.
- [ ] #1146
- [ ] maybe #831
- [ ] add version number for the `make-obsolete-variable` calls

