### PR TITLE
Improve counsel-M-x-transformer key lookup

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -763,13 +763,15 @@ By default `counsel-bookmark' opens a dired buffer for directories."
   (let ((key (where-is-internal (intern cmd) nil t)))
     (if (not key)
         cmd
-      (setq key (key-description key))
       ;; Prefer `<f2>' over `C-x 6' where applicable
-      (let ((dup (replace-regexp-in-string "C-x 6" "<f2>" key t t))
-            (map (current-global-map)))
-        (when (equal (lookup-key map (kbd key))
-                     (lookup-key map (kbd dup)))
-          (setq key dup)))
+      (let ((i (cl-search [?\C-x ?6] key)))
+        (when i
+          (let ((dup (vconcat (substring key 0 i) [f2] (substring key (+ i 2))))
+                (map (current-global-map)))
+            (when (equal (lookup-key map key)
+                         (lookup-key map dup))
+              (setq key dup)))))
+      (setq key (key-description key))
       (put-text-property 0 (length key) 'face 'font-lock-keyword-face key)
       (format "%s (%s)" cmd key))))
 

--- a/counsel.el
+++ b/counsel.el
@@ -759,11 +759,16 @@ By default `counsel-bookmark' opens a dired buffer for directories."
     "open as root")))
 
 (defun counsel-M-x-transformer (cmd)
-  "Return CMD appended with the corresponding binding in the current window."
+  "Return CMD annotated with its active key binding, if any."
   (let ((binding (substitute-command-keys (format "\\[%s]" cmd))))
-    (setq binding (replace-regexp-in-string "C-x 6" "<f2>" binding))
-    (if (string-match "^M-x" binding)
+    (if (string-match-p "\\`M-x" binding)
         cmd
+      ;; Prefer `<f2>' over `C-x 6' where applicable
+      (let ((dup (replace-regexp-in-string "C-x 6" "<f2>" binding t t))
+            (map (current-global-map)))
+        (when (equal (lookup-key map (kbd binding))
+                     (lookup-key map (kbd dup)))
+          (setq binding dup)))
       (format "%s (%s)"
               cmd (propertize binding 'face 'font-lock-keyword-face)))))
 

--- a/counsel.el
+++ b/counsel.el
@@ -760,17 +760,18 @@ By default `counsel-bookmark' opens a dired buffer for directories."
 
 (defun counsel-M-x-transformer (cmd)
   "Return CMD annotated with its active key binding, if any."
-  (let ((binding (substitute-command-keys (format "\\[%s]" cmd))))
-    (if (string-match-p "\\`M-x" binding)
+  (let ((key (where-is-internal (intern cmd) nil t)))
+    (if (not key)
         cmd
+      (setq key (key-description key))
       ;; Prefer `<f2>' over `C-x 6' where applicable
-      (let ((dup (replace-regexp-in-string "C-x 6" "<f2>" binding t t))
+      (let ((dup (replace-regexp-in-string "C-x 6" "<f2>" key t t))
             (map (current-global-map)))
-        (when (equal (lookup-key map (kbd binding))
+        (when (equal (lookup-key map (kbd key))
                      (lookup-key map (kbd dup)))
-          (setq binding dup)))
-      (format "%s (%s)"
-              cmd (propertize binding 'face 'font-lock-keyword-face)))))
+          (setq key dup)))
+      (put-text-property 0 (length key) 'face 'font-lock-keyword-face key)
+      (format "%s (%s)" cmd key))))
 
 (defvar smex-initialized-p)
 (defvar smex-ido-cache)


### PR DESCRIPTION
#### Issue

`counsel-M-x-transformer` unconditionally replaces <kbd>C-x</kbd><kbd>6</kbd> with <kbd>F2</kbd> in the key description, without checking that the latter is still a valid binding.

#### Recipe

1. `make plain`
2. ```el
   (global-set-key [f2] #'ignore)
   ```
3. <kbd>C-j</kbd>
4. <kbd>M-x</kbd>`2C-command`
   - Expected annotation: <kbd>C-x</kbd><kbd>6</kbd>
     ![Screenshot after](https://user-images.githubusercontent.com/9121222/39140183-bd4a8120-471b-11e8-927d-5816c7ca56ff.png)
   - Actual annotation: <kbd>F2</kbd>
     ![Screenshot before](https://user-images.githubusercontent.com/9121222/39138325-94e3a198-4717-11e8-8ff9-6bc112d6b2c5.png)

#### Performance

Compared to the incumbent `counsel-M-x-transformer`, the final version in this PR is up to twice as fast and never slower, regardless of <kbd>C-x</kbd><kbd>6</kbd> replacement. The `key-description` -> `kbd` round trip, by contrast, is up to twice as slow as the incumbent. I think this justifies the only slight increase in algorithmic complexity.