### PR TITLE
Expand documentation of ivy-on-del-error-function

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2722,6 +2722,9 @@ otherwise continue prompting for tags."
            (org-agenda-set-tags nil nil))
       (fset 'org-set-tags store))))
 
+(define-obsolete-variable-alias 'counsel-org-goto-display-style
+    'counsel-org-headline-display-style "0.10.0")
+
 (defcustom counsel-org-headline-display-style 'path
   "The style used when displaying matched `org-mode'-headlines.
 
@@ -2741,8 +2744,8 @@ Use `counsel-org-headline-display-tags' and
           (const :tag "Path" path))
   :group 'ivy)
 
-(define-obsolete-variable-alias 'counsel-org-goto-display-style
-    'counsel-org-headline-display-style "0.10.0")
+(define-obsolete-variable-alias 'counsel-org-goto-separator
+    'counsel-org-headline-path-separator "0.10.0")
 
 (defcustom counsel-org-headline-path-separator "/"
   "Character(s) to separate path entries in matched `org-mode'-headlines.
@@ -2752,24 +2755,21 @@ set to path."
   :type 'string
   :group 'ivy)
 
-(define-obsolete-variable-alias 'counsel-org-goto-separator
-    'counsel-org-headline-path-separator "0.10.0")
+(define-obsolete-variable-alias 'counsel-org-goto-display-tags
+    'counsel-org-headline-display-tags "0.10.0")
 
 (defcustom counsel-org-headline-display-tags nil
   "If non-nil, display tags in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
 
-(define-obsolete-variable-alias 'counsel-org-goto-display-tags
-    'counsel-org-headline-display-tags "0.10.0")
+(define-obsolete-variable-alias 'counsel-org-goto-display-todo
+    'counsel-org-headline-display-todo "0.10.0")
 
 (defcustom counsel-org-headline-display-todo nil
   "If non-nil, display todo keywords in matched `org-mode' headlines."
   :type 'boolean
   :group 'ivy)
-
-(define-obsolete-variable-alias 'counsel-org-goto-display-todo
-    'counsel-org-headline-display-todo "0.10.0")
 
 (defcustom counsel-org-headline-display-priority nil
   "If non-nil, display priorities in matched `org-mode' headlines."

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -775,7 +775,10 @@ installed.
      Set =ivy-display-style= to =nil= for a plain minibuffer.
 
 - User Option =ivy-on-del-error-function= ::
-     Specify what when ~DEL~ (=ivy-backward-delete-char=) throws.
+     Specifies what to do when ~DEL~ (=ivy-backward-delete-char=) fails.
+
+     This is usually the case when there is no text left to delete,
+     i.e., when ~DEL~ is typed at the beginning of the minibuffer.
 
      The default behavior is to quit the completion after ~DEL~ -- a
      handy key to invoke after mistakenly triggering a completion.

--- a/ivy.el
+++ b/ivy.el
@@ -171,9 +171,14 @@ earlier versions of Emacs."
           (const :tag "Fancy" fancy)))
 
 (defcustom ivy-on-del-error-function #'minibuffer-keyboard-quit
-  "The handler for when `ivy-backward-delete-char' throws.
-Usually a quick exit out of the minibuffer."
-  :type 'function)
+  "Function to call when deletion fails during completion.
+The usual reason for `ivy-backward-delete-char' to fail is when
+there is no text left to delete, i.e., when it is called at the
+beginning of the minibuffer.
+The default setting provides a quick exit from completion."
+  :type '(choice (const :tag "Exit completion" minibuffer-keyboard-quit)
+                 (const :tag "Do nothing" ignore)
+                 (function :tag "Custom function")))
 
 (defcustom ivy-extra-directories '("../" "./")
   "Add this to the front of the list when completing file names.
@@ -1330,8 +1335,10 @@ If so, move to that directory, while keeping only the file name."
     (delete-minibuffer-contents)))
 
 (defun ivy-backward-delete-char ()
-  "Forward to `backward-delete-char'.
-On error (read-only), call `ivy-on-del-error-function'."
+  "Forward to `delete-backward-char'.
+Call `ivy-on-del-error-function' if an error occurs, usually when
+there is no more text to delete at the beginning of the
+minibuffer."
   (interactive)
   (if (and ivy--directory (= (minibuffer-prompt-end) (point)))
       (progn
@@ -1341,7 +1348,7 @@ On error (read-only), call `ivy-on-del-error-function'."
                     ivy--directory))))
         (ivy--exhibit))
     (condition-case nil
-        (backward-delete-char 1)
+        (delete-backward-char 1)
       (error
        (when ivy-on-del-error-function
          (funcall ivy-on-del-error-function))))))

--- a/ivy.el
+++ b/ivy.el
@@ -1347,8 +1347,9 @@ minibuffer."
                    (expand-file-name
                     ivy--directory))))
         (ivy--exhibit))
+    (setq prefix-arg current-prefix-arg)
     (condition-case nil
-        (delete-backward-char 1)
+        (call-interactively #'delete-backward-char)
       (error
        (when ivy-on-del-error-function
          (funcall ivy-on-del-error-function))))))


### PR DESCRIPTION
* `doc/ivy.org` (`Defcustoms`):
Fix typos and clarify documentation of `ivy-on-del-error-function`.
* `ivy.el` (`ivy-on-del-error-function`):
Clarify docstring and custom `:type`.
(`ivy-backward-delete-char`): Clarify docstring.
Refer to `delete-backward-char`, rather than its alias.

The second commit pacifies the byte-compiler and explains the nature of its warnings.