### PR TITLE
Improve swiper handling of invalid regexes

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -171,7 +171,10 @@ will bring the behavior in line with the newer Emacsen."
                  "\\(defun\\).*?\\([^ ]+\\)"))
   (should (equal (ivy--regex
                   "\\(?:interactive\\|swiper\\) \\(?:list\\|symbol\\)")
-                 "\\(\\(?:interactive\\|swiper\\)\\).*?\\(\\(?:list\\|symbol\\)\\)")))
+                 "\\(\\(?:interactive\\|swiper\\)\\).*?\\(\\(?:list\\|symbol\\)\\)"))
+  (should (equal (ivy--regex
+                  "foo[")
+                 "foo\\[")))
 
 (ert-deftest ivy--split-negation ()
   (should (equal (ivy--split-negation "") ()))
@@ -208,7 +211,11 @@ will bring the behavior in line with the newer Emacsen."
   (should (equal (ivy--split-spaces "a\\ b") '("a b")))
   (should (equal (ivy--split-spaces " a b\\ ") '("a" "b ")))
   (should (equal (ivy--split-spaces "\\  a b ") '(" " "a" "b")))
-  (should (equal (ivy--split-spaces " a\\  \\ b ") '("a " " b"))))
+  (should (equal (ivy--split-spaces " a\\  \\ b ") '("a " " b")))
+
+  (should (equal (ivy--split-spaces "foo[") '("foo\\[")))
+  (should (equal (ivy--split-spaces "foo[a]") '("foo[a]")))
+  (should (equal (ivy--split-spaces "foo[ ]") '("foo\\[" "]"))))
 
 (ert-deftest ivy--regex-plus ()
   (should (equal (ivy--regex-plus "add path\\!") "\\(add\\).*?\\(path!\\)")))

--- a/ivy.el
+++ b/ivy.el
@@ -2296,7 +2296,7 @@ Each part is regex escaped if it is not a valid regex."
       (setq s (substring str start1))
       (unless (= (length s) 0)
         (push s res)))
-    (mapcar 'ivy--regex-or-literal (nreverse res))))
+    (mapcar #'ivy--regex-or-literal (nreverse res))))
 
 (defun ivy--regex (str &optional greedy)
   "Re-build regex pattern from STR in case it has a space.

--- a/ivy.el
+++ b/ivy.el
@@ -2259,10 +2259,12 @@ This concept is used to generalize regular expressions for
   "Store pre-computed regex.")
 
 (defun ivy--split (str)
-  "Split STR into a list by single spaces.
-The remaining spaces stick to their left.
-This allows to \"quote\" N spaces by inputting N+1 spaces.
-Each part is regex escaped if it is not a valid regex."
+"Split STR into list of substrings bounded by spaces.
+Single spaces act as splitting points.  Consecutive spaces
+\"quote\" their preceding spaces, i.e., guard them from being
+split.  This allows the literal interpretation of N spaces by
+inputting N+1 spaces.  Any substring not constituting a valid
+regexp is passed to `regexp-quote'."
   (let ((len (length str))
         start0
         (start1 0)
@@ -2364,9 +2366,9 @@ text after delimiter if it is empty.  Modifies match data."
                 (list str))))))
 
 (defun ivy--split-spaces (str)
-  "Split STR on spaces, unless they're preceded by \\.
-No unescaped spaces are present in the output.
-Each part is regex escaped if it is not a valid regex."
+ "Split STR on spaces, unless they're preceded by \\.
+No unescaped spaces are left in the output.  Any substring not
+constituting a valid regexp is passed to `regexp-quote'."
   (when str
     (let ((i 0) ; End of last search.
           (j 0) ; End of last delimiter.

--- a/ivy.el
+++ b/ivy.el
@@ -2261,7 +2261,8 @@ This concept is used to generalize regular expressions for
 (defun ivy--split (str)
   "Split STR into a list by single spaces.
 The remaining spaces stick to their left.
-This allows to \"quote\" N spaces by inputting N+1 spaces."
+This allows to \"quote\" N spaces by inputting N+1 spaces.
+Each part is regex escaped if it is not a valid regex."
   (let ((len (length str))
         start0
         (start1 0)
@@ -2295,7 +2296,7 @@ This allows to \"quote\" N spaces by inputting N+1 spaces."
       (setq s (substring str start1))
       (unless (= (length s) 0)
         (push s res)))
-    (nreverse res)))
+    (mapcar 'ivy--regex-or-literal (nreverse res))))
 
 (defun ivy--regex (str &optional greedy)
   "Re-build regex pattern from STR in case it has a space.
@@ -2364,7 +2365,8 @@ text after delimiter if it is empty.  Modifies match data."
 
 (defun ivy--split-spaces (str)
   "Split STR on spaces, unless they're preceded by \\.
-No unescaped spaces are present in the output."
+No unescaped spaces are present in the output.
+Each part is regex escaped if it is not a valid regex."
   (when str
     (let ((i 0) ; End of last search.
           (j 0) ; End of last delimiter.
@@ -2382,7 +2384,7 @@ No unescaped spaces are present in the output."
           (setq i (1- i))))
       (when (< j (length str))
         (push (substring str j) parts))
-      (nreverse parts))))
+      (mapcar #'ivy--regex-or-literal (nreverse parts)))))
 
 (defun ivy--regex-ignore-order (str)
   "Re-build regex from STR by splitting at spaces and using ! for negation.
@@ -2398,17 +2400,14 @@ Escaping examples:
 foo\!bar -> matches \"foo!bar\"
 foo\ bar -> matches \"foo bar\"
 
-If STR isn't a valid input, fall back to exact matching:
-foo[     -> matches \"foo\[\" (invalid regex, so literal [ character)
-
 Returns a list suitable for `ivy-re-match'."
   (let* (regex-parts
          (raw-parts (ivy--split-negation str)))
     (dolist (part (ivy--split-spaces (car raw-parts)))
-      (push (cons (ivy--regex-or-literal part) t) regex-parts))
+      (push (cons part t) regex-parts))
     (when (cdr raw-parts)
       (dolist (part (ivy--split-spaces (cadr raw-parts)))
-        (push (cons (ivy--regex-or-literal part) nil) regex-parts)))
+        (push (cons part nil) regex-parts)))
     (if regex-parts (nreverse regex-parts)
       "")))
 


### PR DESCRIPTION
Now when splitting apart the input by space, we always regex escape
each part if it is an invalid regex.

For regex-ignore-order, this fixes a bug where in swiper you
couldn't hit RET to go to the line of the selected match if your input
was an invalid regex. ignore-order had logic to escape invalid
regexes, but swiper calls ivy--regex on the input, which previously
was not performing the same escaping.

For regex-plus, you now also get a literal search if you enter an
invalid regex (previously it silently failed to search). It seems like
this is an improvement in behavior, but perhaps it will annoy
regex-plus users.

Fixes #1516 