### PR TITLE
counsel.el: counsel--git-grep-count-func-default submodule support

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1273,7 +1273,7 @@ files in a project.")
   "Default defun to calculate `counsel--git-grep-count'."
   (if (eq system-type 'windows-nt)
       0
-    (read (shell-command-to-string "du -s .git 2>/dev/null"))))
+    (read (shell-command-to-string "du -s \"$(git rev-parse --git-dir)\" 2>/dev/null"))))
 
 (defvar counsel--git-grep-count-func #'counsel--git-grep-count-func-default
   "Defun to calculate `counsel--git-grep-count' for `counsel-git-grep'.")


### PR DESCRIPTION
(counsel--git-grep-count-func-default): Ask Git where the .git directory
is for the repository in the current directory.

Modern Git puts all the git directories for submodules underneath the top
level `.git` directory and then leaves a "git-file" in the submodule which
points back to the repository inside the top-level .git directory. This
means, that within a submodule, the `.git` file contains something like:

 gitdir: ../../.git/modules/submodule-repo-name

counsel--git-grep-count-func-default runs "du -s .git 2>/dev/null" which is
bound to give a very small answer for just this small file.

So, let's ask Git to tell us where the real .git directory is and calculate
the size of that.