### PR TITLE
Address sorting woes

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1827,10 +1827,10 @@ This is useful for recursive `ivy-read'."
         (dynamic-collection (ivy-state-dynamic-collection state))
         (initial-input (ivy-state-initial-input state))
         (require-match (ivy-state-require-match state))
-        (caller (ivy-state-caller state))
+        (caller (or (ivy-state-caller state) this-command))
         (def (ivy-state-def state)))
     (unless initial-input
-      (setq initial-input (cdr (assoc (or caller this-command)
+      (setq initial-input (cdr (assoc caller
                                       ivy-initial-inputs-alist))))
     (setq ivy--directory nil)
     (setq ivy-case-fold-search ivy-case-fold-search-default)
@@ -1840,7 +1840,6 @@ This is useful for recursive `ivy-read'."
                    (cdr (assoc collection ivy-re-builders-alist)))
               (and caller
                    (cdr (assoc caller ivy-re-builders-alist)))
-              (cdr (assoc this-command ivy-re-builders-alist))
               (cdr (assoc t ivy-re-builders-alist))
               'ivy--regex))
     (setq ivy--subexps 0)

--- a/ivy.el
+++ b/ivy.el
@@ -1522,8 +1522,9 @@ See also `ivy-sort-max-size'."
 
 (defun ivy--sort-function (collection)
   "Retrieve sort function for COLLECTION from `ivy-sort-functions-alist'."
-  (cdr (or (assq collection ivy-sort-functions-alist)
-           (assq t ivy-sort-functions-alist))))
+  (let ((entry (cdr (or (assq collection ivy-sort-functions-alist)
+                        (assq t ivy-sort-functions-alist)))))
+    (or (car-safe entry) entry)))
 
 (defun ivy-rotate-sort ()
   "Rotate through sorting functions available for current collection.

--- a/ivy.el
+++ b/ivy.el
@@ -1399,7 +1399,7 @@ minibuffer."
         (forward-word -1)
         (delete-region (point) pt)))))
 
-(defvar ivy--regexp-quote 'regexp-quote
+(defvar ivy--regexp-quote #'regexp-quote
   "Store the regexp quoting state.")
 
 (defun ivy-toggle-regexp-quote ()
@@ -1817,33 +1817,31 @@ customizations apply to the current completion session."
 This is useful for recursive `ivy-read'."
   (unless (equal (selected-frame) (ivy-state-frame state))
     (select-window (active-minibuffer-window)))
-  (let ((prompt (or (ivy-state-prompt state) ""))
-        (collection (ivy-state-collection state))
-        (predicate (ivy-state-predicate state))
-        (history (ivy-state-history state))
-        (preselect (ivy-state-preselect state))
-        (sort (ivy-state-sort state))
-        (re-builder (ivy-state-re-builder state))
-        (dynamic-collection (ivy-state-dynamic-collection state))
-        (initial-input (ivy-state-initial-input state))
-        (require-match (ivy-state-require-match state))
-        (caller (or (ivy-state-caller state) this-command))
-        (def (ivy-state-def state)))
-    (unless initial-input
-      (setq initial-input (cdr (assoc caller
-                                      ivy-initial-inputs-alist))))
+  (let* ((prompt (or (ivy-state-prompt state) ""))
+         (collection (ivy-state-collection state))
+         (predicate (ivy-state-predicate state))
+         (history (ivy-state-history state))
+         (preselect (ivy-state-preselect state))
+         (sort (ivy-state-sort state))
+         (re-builder (ivy-state-re-builder state))
+         (dynamic-collection (ivy-state-dynamic-collection state))
+         (require-match (ivy-state-require-match state))
+         (caller (or (ivy-state-caller state) this-command))
+         (initial-input (or (ivy-state-initial-input state)
+                            (cdr (assq caller ivy-initial-inputs-alist))))
+         (def (ivy-state-def state)))
     (setq ivy--directory nil)
     (setq ivy-case-fold-search ivy-case-fold-search-default)
     (setq ivy--regex-function
           (or re-builder
               (and (functionp collection)
-                   (cdr (assoc collection ivy-re-builders-alist)))
+                   (cdr (assq collection ivy-re-builders-alist)))
               (and caller
-                   (cdr (assoc caller ivy-re-builders-alist)))
-              (cdr (assoc t ivy-re-builders-alist))
-              'ivy--regex))
+                   (cdr (assq caller ivy-re-builders-alist)))
+              (cdr (assq t ivy-re-builders-alist))
+              #'ivy--regex))
     (setq ivy--subexps 0)
-    (setq ivy--regexp-quote 'regexp-quote)
+    (setq ivy--regexp-quote #'regexp-quote)
     (setq ivy--old-text "")
     (setq ivy--full-length nil)
     (setq ivy-text "")
@@ -1851,7 +1849,7 @@ This is useful for recursive `ivy-read'."
     (setq ivy-calling nil)
     (setq ivy-use-ignore ivy-use-ignore-default)
     (setq ivy--highlight-function
-          (or (cdr (assoc ivy--regex-function ivy-highlight-functions-alist))
+          (or (cdr (assq ivy--regex-function ivy-highlight-functions-alist))
               #'ivy--highlight-default))
     (let (coll sort-fn)
       (cond ((eq collection 'Info-read-node-name-1)

--- a/ivy.el
+++ b/ivy.el
@@ -1485,6 +1485,12 @@ This function is suitable as a replacement for
       (ido-file-extension-lessp x y)
     (ivy-sort-file-function-default x y)))
 
+(defun ivy-string< (x y)
+  "Like `string<', but operate on CARs when given cons cells."
+  (if (consp x)
+      (string< (car x) (car y))
+    (string< x y)))
+
 (defcustom ivy-sort-functions-alist
   '((read-file-name-internal . ivy-sort-file-function-default)
     (internal-complete-buffer . nil)
@@ -1492,7 +1498,7 @@ This function is suitable as a replacement for
     (counsel-git-grep-function . nil)
     (Man-goto-section . nil)
     (org-refile . nil)
-    (t . string-lessp))
+    (t . ivy-string<))
   "An alist of sorting functions for each collection function.
 Interactive functions that call completion fit in here as well.
 


### PR DESCRIPTION
The first commit fixes the issue mentioned in https://github.com/abo-abo/swiper/issues/1567#issuecomment-388626227.

The second commit fixes #1565 and #1567 (see discussion in latter).

The third commit fixes the issue mentioned in https://github.com/abo-abo/swiper/issues/1567#issuecomment-388624588.

The last two commits are attempts at logic simplification and optimisation.