### PR TITLE
counsel.el: Improve shell buffer switching

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4467,9 +4467,6 @@ NAME specifies the name of the buffer (defaults to \"*Ibuffer*\")."
   "Switch to buffer of candidate X in another window."
   (switch-to-buffer-other-window (cdr x)))
 
-(define-obsolete-function-alias 'counsel-ibuffer-visit-vanilla-ibuffer
-  'counsel-ibuffer-visit-ibuffer "0.11.0")
-
 (defun counsel-ibuffer-visit-ibuffer (_)
   "Switch to Ibuffer buffer."
   (switch-to-buffer counsel-ibuffer--buffer-name))


### PR DESCRIPTION
Cc: @mookid

### Changelog

(`counsel-list-buffers-with-mode`):
* Rename to `counsel--buffers-with-mode`.

(`counsel-switch-to-buffer-or-window`):
* Fix docstring.
* Rename to `counsel--switch-to-shell`.
* Support multiple frames and avoid `switch-to-buffer` pitfalls by using `pop-to-buffer`.

(`counsel-switch-to-shell-buffer`):
* Use their new names.

### Discussion

The problem with `counsel-list-buffers-with-mode` is that `list-*` functions such as `list-buffers` are meant as interactive commands in Emacs. The problem with `counsel-switch-to-buffer-or-window` is that it doesn't actually do that; it pops to a shell buffer, possibly in another window, creating the **shell** buffer as required. I'm only keeping the "switch" verb for consistency with `counsel-switch-to-shell-buffer`.

1. Do you agree with the function renames?
2. If so, are obsolete function aliases required?