### PR TITLE
ivy.el: Drop preselected candidate after input

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3045,7 +3045,9 @@ RE-STR is the regexp, CANDS are the current candidates."
          (func (or (and caller (cdr (assoc caller ivy-index-functions-alist)))
                    (cdr (assoc t ivy-index-functions-alist))
                    #'ivy-recompute-index-zero))
-         (case-fold-search (ivy--case-fold-p name)))
+         (case-fold-search (ivy--case-fold-p name))
+         (preselect (ivy-state-preselect ivy-last))
+         (current (ivy-state-current ivy-last)))
     (unless (eq this-command 'ivy-resume)
       (ivy-set-index
        (or
@@ -3066,16 +3068,23 @@ RE-STR is the regexp, CANDS are the current candidates."
              (not (and ivy--flx-featurep
                        (eq ivy--regex-function 'ivy--regex-fuzzy)
                        (< (length cands) 200)))
+             ;; If there was a preselected candidate, don't try to
+             ;; keep it selected even if the regexp still matches it.
+             ;; See issue #1563.  See also `ivy--preselect-index',
+             ;; which this logic roughly mirrors.
+             (not (or
+                   (and (integerp preselect)
+                        (= ivy--index preselect))
+                   (equal current preselect)
+                   (and (stringp preselect)
+                        (string-match-p preselect current))))
              ivy--old-cands
-             (cl-position (ivy-state-current ivy-last) cands
-                          :test #'equal))
+             (cl-position current cands :test #'equal))
         (funcall func re-str cands))))
     (when (or (string= name "")
               (string= name "^"))
       (ivy-set-index
-       (or (ivy--preselect-index
-            (ivy-state-preselect ivy-last)
-            cands)
+       (or (ivy--preselect-index preselect cands)
            ivy--index)))))
 
 (defun ivy-recompute-index-swiper (_re-str cands)


### PR DESCRIPTION
Suggested fix for https://github.com/abo-abo/swiper/issues/1563.