### PR TITLE
Re-handle anonymous sorting functions

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4485,6 +4485,8 @@ NAME specifies the name of the buffer (defaults to \"*Ibuffer*\")."
         (push (buffer-name buf) bufs)))
     (nreverse bufs)))
 
+(declare-function shell-mode "shell")
+
 ;;;###autoload
 (defun counsel-switch-to-shell-buffer ()
   "Switch to a shell buffer, or create one."

--- a/ivy.el
+++ b/ivy.el
@@ -1530,7 +1530,9 @@ See also `ivy-sort-max-size'."
   "Retrieve sort function for COLLECTION from `ivy-sort-functions-alist'."
   (let ((entry (cdr (or (assq collection ivy-sort-functions-alist)
                         (assq t ivy-sort-functions-alist)))))
-    (or (car-safe entry) entry)))
+    (and (or (functionp entry)
+             (functionp (setq entry (car-safe entry))))
+         entry)))
 
 (defun ivy-rotate-sort ()
   "Rotate through sorting functions available for current collection.


### PR DESCRIPTION
The `car-safe` in 2984025f9a7c2500956e1209682590cd31a223bb handles lists of function symbols, but breaks with anonymous functions, which are also lists.

* `ivy.el` (`ivy--sort-function`): Handle anonymous fns.
* `ivy-test.el` (`ivy--sort-function`): New test.

Fixes #1574.