### PR TITLE
Pulse when yanking

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -38,6 +38,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'pulse)
 (require 'ffap)
 (require 'ivy-overlay)
 
@@ -3823,6 +3824,7 @@ Skip buffers that match `ivy-ignore-buffers'."
         (forward-word 1)
         (if (> (point) le)
             (goto-char pt)
+          (pulse-momentary-highlight-region pt (point))
           (setq amend (buffer-substring-no-properties pt (point))))))
     (when amend
       (insert (replace-regexp-in-string "  +" " " amend)))))


### PR DESCRIPTION
`ivy-yank-word` is a great feature. I often use it with `counsel-projectile-ag` to search for a symbol in a project. But when the focus changes to Ivy, it's hard to follow the cursor in the original window (especially for people with `cursor-in-non-selected-windows` set to nil).

I don't know if Helm did this, but I added the pulse of the region that was yanked. It helps me see immediately what I've just yanked into Ivy, without having to switch eye focus back and forth between original document and Ivy.