### PR TITLE
Bind apropos-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ counsel replacements:
 | describe-bindings        | counsel-descbinds          |
 | describe-function        | counsel-describe-function  |
 | describe-variable        | counsel-describe-variable  |
+| apropos-command          | counsel-apropos            |
 | describe-face            | counsel-describe-face      |
 | list-faces-display       | counsel-faces              |
 | find-file                | counsel-find-file          |

--- a/counsel.el
+++ b/counsel.el
@@ -4525,6 +4525,7 @@ If there is no such buffer, start a new `shell' with NAME."
                 (describe-bindings . counsel-descbinds)
                 (describe-function . counsel-describe-function)
                 (describe-variable . counsel-describe-variable)
+                (apropos-command . counsel-apropos)
                 (describe-face . counsel-describe-face)
                 (list-faces-display . counsel-faces)
                 (find-file . counsel-find-file)


### PR DESCRIPTION
*I'm reopening #1578 as a separate PR since I deleted the original fork*

As it was pointed out in the other PR, this changes default behavior, but might be useful for some users.

---

`counsel-mode` binds `describe-function` and `describe-variable`, but somehow forgot to bind `apropos-command`?

To my understanding, <kbd>C-h f</kbd>, <kbd>C-h v</kbd>, <kbd>C-h a</kbd> always come together. So I'm adding this binding as well.