### PR TITLE
swiper.el: Replace isearch-lazy-highlight-face

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -41,7 +41,7 @@
   :prefix "swiper-")
 
 (defface swiper-match-face-1
-  '((t (:inherit isearch-lazy-highlight-face)))
+  '((t (:inherit lazy-highlight)))
   "The background face for `swiper' matches.")
 
 (defface swiper-match-face-2


### PR DESCRIPTION
`isearch-lazy-highlight-face` was declared obsolete in Emacs 22.1 in favor of `lazy-highlight`, and removed in Emacs 25.1. Therefore, `swiper-match-face-1` failed to have any effect.