### PR TITLE
Improve sorting with collection functions

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1949,7 +1949,7 @@ This is useful for recursive `ivy-read'."
         (if (and (functionp collection)
                  (setq sort-fn (ivy--sort-function collection)))
             (when (not (eq collection 'read-file-name-internal))
-              (setq coll (sort coll sort-fn)))
+              (setq coll (sort (copy-sequence coll) sort-fn)))
           (when (and (not (eq history 'org-refile-history))
                      (<= (length coll) ivy-sort-max-size)
                      (setq sort-fn (ivy--sort-function caller)))

--- a/ivy.el
+++ b/ivy.el
@@ -1952,6 +1952,7 @@ This is useful for recursive `ivy-read'."
       (when sort
         (if (functionp collection)
             (when (and (not (eq collection 'read-file-name-internal))
+                       (<= (length coll) ivy-sort-max-size)
                        (setq sort-fn (ivy--sort-function collection caller)))
               (setq coll (sort (copy-sequence coll) sort-fn)))
           (when (and (not (eq history 'org-refile-history))


### PR DESCRIPTION
Commit 1734ea9b9ae9123cd8be054f46ea181e2d7cb947 changed `(cl-sort coll sort-fn)` to `(sort (copy-sequence coll) sort-fn)` at one place in `ivy-reset-state`, line 1956. This PR simply does the same change in the same function, line 1952.

I'm not exactly sure why this matters, but it solves an issue I got in counsel-projectile, ericdanan/counsel-projectile/issues/87.