### PR TITLE
Fix indentation

### DIFF
--- a/colir.el
+++ b/colir.el
@@ -37,8 +37,8 @@
   "Select a method to compose two color channels."
   :group 'ivy
   :type '(radio (function-item colir-compose-alpha)
-                (function-item colir-compose-overlay)
-                (function-item colir-compose-soft-light)))
+          (function-item colir-compose-overlay)
+          (function-item colir-compose-soft-light)))
 
 (defun colir-compose-soft-light (a b)
   "Compose A and B channels."

--- a/counsel.el
+++ b/counsel.el
@@ -47,7 +47,7 @@
 (require 'dired)
 
 (defface counsel-key-binding
-  '((t :inherit font-lock-keyword-face))
+    '((t :inherit font-lock-keyword-face))
   "Face used by `counsel-M-x' for key bindings."
   :group 'ivy-faces)
 
@@ -541,7 +541,7 @@ Variables declared using `defcustom' are highlighted according to
   "Determine what `counsel-describe-function' should preselect."
   :group 'ivy
   :type '(radio (function-item ivy-thing-at-point)
-                (function-item ivy-function-called-at-point)))
+          (function-item ivy-function-called-at-point)))
 
 ;;;###autoload
 (defun counsel-describe-function ()
@@ -715,7 +715,7 @@ can use `C-x r j i' to open that file."
             (mapcar (lambda (register-alist-entry)
                       (if (eq 'file (cadr register-alist-entry))
                           (cddr register-alist-entry)))
-                      register-alist)
+                    register-alist)
             :sort t
             :require-match t
             :history 'counsel-file-register
@@ -767,9 +767,9 @@ By default `counsel-bookmark' opens a dired buffer for directories."
  `(("d" bookmark-delete "delete")
    ("e" bookmark-rename "edit")
    ("x" ,(counsel--apply-bookmark-fn #'counsel-find-file-extern)
-    "open externally")
+        "open externally")
    ("r" ,(counsel--apply-bookmark-fn #'counsel-find-file-as-root)
-    "open as root")))
+        "open as root")))
 
 (defun counsel-M-x-transformer (cmd)
   "Return CMD annotated with its active key binding, if any."
@@ -1739,13 +1739,13 @@ The preselect behaviour can be customized via user options
 `counsel-find-file-at-point' and
 `counsel-preselect-current-file', which see."
   (or
-    (when counsel-find-file-at-point
-      (require 'ffap)
-      (let ((f (ffap-guesser)))
-        (when f (expand-file-name f))))
-    (and counsel-preselect-current-file
-         buffer-file-name
-         (file-name-nondirectory buffer-file-name))))
+   (when counsel-find-file-at-point
+     (require 'ffap)
+     (let ((f (ffap-guesser)))
+       (when f (expand-file-name f))))
+   (and counsel-preselect-current-file
+        buffer-file-name
+        (file-name-nondirectory buffer-file-name))))
 
 ;;;###autoload
 (defun counsel-find-file (&optional initial-input)
@@ -1923,7 +1923,7 @@ result as a URL."
   (ivy-read "Recentf: " (mapcar #'substring-no-properties recentf-list)
             :action (lambda (f)
                       (with-ivy-window
-                       (find-file f)))
+                        (find-file f)))
             :caller 'counsel-recentf))
 (ivy-set-actions
  'counsel-recentf
@@ -2297,10 +2297,10 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
                             (substring-no-properties extra-ag-args 0 args-end)
                           extra-ag-args)))
     (setq counsel-ag-command (format counsel-ag-command
-                                      (concat extra-ag-args
-                                              " -- "
-                                              "%s"
-                                              file))))
+                                     (concat extra-ag-args
+                                             " -- "
+                                             "%s"
+                                             file))))
   (ivy-set-prompt 'counsel-ag counsel-prompt-function)
   (let ((default-directory (or initial-directory
                                (locate-dominating-file default-directory ".git")
@@ -2988,14 +2988,14 @@ include attachments of other Org buffers."
   (interactive)
   (require 'org)
   (ivy-read "Entity: " (cl-loop for element in (append org-entities org-entities-user)
-                                unless (stringp element)
-                                collect (cons
-                                         (format "%20s | %20s | %20s | %s"
-                                                 (cl-first element)    ; name
-                                                 (cl-second element)   ; latex
-                                                 (cl-fourth element)   ; html
-                                                 (cl-seventh element)) ; utf-8
-                                         element))
+                          unless (stringp element)
+                          collect (cons
+                                   (format "%20s | %20s | %20s | %s"
+                                           (cl-first element)    ; name
+                                           (cl-second element)   ; latex
+                                           (cl-fourth element)   ; html
+                                           (cl-seventh element)) ; utf-8
+                                   element))
             :require-match t
             :action '(1
                       ("u" (lambda (candidate)
@@ -3039,16 +3039,16 @@ include attachments of other Org buffers."
  'counsel-org-capture
  `(("t" ,(lambda (x)
            (org-capture-goto-target (car (split-string x))))
-    "go to target")
+        "go to target")
    ("l" ,(lambda (_x)
            (org-capture-goto-last-stored))
-    "go to last stored")
+        "go to last stored")
    ("p" ,(lambda (x)
            (org-capture 0 (car (split-string x))))
-    "insert template at point")
+        "insert template at point")
    ("c" ,(lambda (_x)
            (customize-variable 'org-capture-templates))
-    "customize org-capture-templates")))
+        "customize org-capture-templates")))
 
 ;;** `counsel-mark-ring'
 (defun counsel-mark-ring ()
@@ -3284,8 +3284,8 @@ will be destructively removed from `kill-ring' before completion.
 All blank strings are deleted from `kill-ring' by default."
   :group 'ivy
   :type '(radio (function-item counsel-string-non-blank-p)
-                (function-item identity)
-                (function :tag "Other")))
+          (function-item identity)
+          (function :tag "Other")))
 
 (defun counsel--yank-pop-kills ()
   "Return filtered `kill-ring' for `counsel-yank-pop' completion.
@@ -3380,9 +3380,9 @@ Note: Duplicate elements of `kill-ring' are always deleted."
               :require-match t
               :preselect (let (interprogram-paste-function)
                            (current-kill (cond
-                                          (arg (prefix-numeric-value arg))
-                                          (counsel-yank-pop-preselect-last 0)
-                                          (t 1))
+                                           (arg (prefix-numeric-value arg))
+                                           (counsel-yank-pop-preselect-last 0)
+                                           (t 1))
                                          t))
               :action #'counsel-yank-pop-action
               :caller 'counsel-yank-pop)))
@@ -4280,9 +4280,9 @@ candidate."
   "Show the history of commands."
   (interactive)
   (ivy-read "%d Command: " (mapcar #'prin1-to-string command-history)
-          :require-match t
-          :action #'counsel-command-history-action-eval
-          :caller 'counsel-command-history))
+            :require-match t
+            :action #'counsel-command-history-action-eval
+            :caller 'counsel-command-history))
 
 ;;** `counsel-org-agenda-headlines'
 (defvar org-odd-levels-only)
@@ -4369,8 +4369,8 @@ candidate."
          (beg (car symbol-bounds))
          (end (cdr symbol-bounds))
          (prefix (buffer-substring-no-properties beg end)))
-  (setq ivy-completion-beg beg
-        ivy-completion-end end)
+    (setq ivy-completion-beg beg
+          ivy-completion-end end)
     (ivy-read "code: " (mapcar #'counsel-irony-annotate candidates)
               :predicate (lambda (candidate)
                            (string-prefix-p prefix (car candidate)))
@@ -4548,7 +4548,7 @@ Remaps built-in functions to counsel replacements.")
 
 ;;;###autoload
 (define-minor-mode counsel-mode
-  "Toggle Counsel mode on or off.
+    "Toggle Counsel mode on or off.
 Turn Counsel mode on if ARG is positive, off otherwise. Counsel
 mode remaps built-in emacs functions that have counsel
 replacements. "

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -26,8 +26,8 @@
 
 ;;; Code:
 (defface ivy-cursor
-  '((t (:background "black"
-        :foreground "white")))
+    '((t (:background "black"
+          :foreground "white")))
   "Cursor face for inline completion."
   :group 'ivy-faces)
 

--- a/ivy.el
+++ b/ivy.el
@@ -52,81 +52,81 @@
   :group 'faces)
 
 (defface ivy-current-match
-  '((((class color) (background light))
-     :background "#1a4b77" :foreground "white")
-    (((class color) (background dark))
-     :background "#65a7e2" :foreground "black"))
+    '((((class color) (background light))
+       :background "#1a4b77" :foreground "white")
+      (((class color) (background dark))
+       :background "#65a7e2" :foreground "black"))
   "Face used by Ivy for highlighting the current match.")
 
 (defface ivy-minibuffer-match-highlight
-  '((t :inherit highlight))
+    '((t :inherit highlight))
   "Face used by Ivy for highlighting the match under the cursor.")
 
 (defface ivy-minibuffer-match-face-1
-  '((((class color) (background light))
-     :background "#d3d3d3")
-    (((class color) (background dark))
-     :background "#555555"))
+    '((((class color) (background light))
+       :background "#d3d3d3")
+      (((class color) (background dark))
+       :background "#555555"))
   "The background face for `ivy' minibuffer matches.")
 
 (defface ivy-minibuffer-match-face-2
-  '((((class color) (background light))
-     :background "#e99ce8" :weight bold)
-    (((class color) (background dark))
-     :background "#777777" :weight bold))
+    '((((class color) (background light))
+       :background "#e99ce8" :weight bold)
+      (((class color) (background dark))
+       :background "#777777" :weight bold))
   "Face for `ivy' minibuffer matches numbered 1 modulo 3.")
 
 (defface ivy-minibuffer-match-face-3
-  '((((class color) (background light))
-     :background "#bbbbff" :weight bold)
-    (((class color) (background dark))
-     :background "#7777ff" :weight bold))
+    '((((class color) (background light))
+       :background "#bbbbff" :weight bold)
+      (((class color) (background dark))
+       :background "#7777ff" :weight bold))
   "Face for `ivy' minibuffer matches numbered 2 modulo 3.")
 
 (defface ivy-minibuffer-match-face-4
-  '((((class color) (background light))
-     :background "#ffbbff" :weight bold)
-    (((class color) (background dark))
-     :background "#8a498a" :weight bold))
+    '((((class color) (background light))
+       :background "#ffbbff" :weight bold)
+      (((class color) (background dark))
+       :background "#8a498a" :weight bold))
   "Face for `ivy' minibuffer matches numbered 3 modulo 3.")
 
 (defface ivy-confirm-face
-  '((t :foreground "ForestGreen" :inherit minibuffer-prompt))
+    '((t :foreground "ForestGreen" :inherit minibuffer-prompt))
   "Face used by Ivy for a confirmation prompt.")
 
 (defface ivy-match-required-face
-  '((t :foreground "red" :inherit minibuffer-prompt))
+    '((t :foreground "red" :inherit minibuffer-prompt))
   "Face used by Ivy for a match required prompt.")
 
 (defface ivy-subdir
-  '((t :inherit dired-directory))
+    '((t :inherit dired-directory))
   "Face used by Ivy for highlighting subdirs in the alternatives.")
 
 (defface ivy-modified-buffer
-  '((t :inherit default))
+    '((t :inherit default))
   "Face used by Ivy for highlighting modified file visiting buffers.")
 
 (defface ivy-remote
-  '((((class color) (background light))
-     :foreground "#110099")
-    (((class color) (background dark))
-     :foreground "#7B6BFF"))
+    '((((class color) (background light))
+       :foreground "#110099")
+      (((class color) (background dark))
+       :foreground "#7B6BFF"))
   "Face used by Ivy for highlighting remotes in the alternatives.")
 
 (defface ivy-virtual
-  '((t :inherit font-lock-builtin-face))
+    '((t :inherit font-lock-builtin-face))
   "Face used by Ivy for matching virtual buffer names.")
 
 (defface ivy-action
-  '((t :inherit font-lock-builtin-face))
+    '((t :inherit font-lock-builtin-face))
   "Face used by Ivy for displaying keys in `ivy-read-action'.")
 
 (defface ivy-highlight-face
-  '((t :inherit highlight))
+    '((t :inherit highlight))
   "Face used by Ivy to highlight certain candidates.")
 
 (defface ivy-prompt-match
-  '((t :inherit ivy-current-match))
+    '((t :inherit ivy-current-match))
   "Face used by Ivy for highlighting the selected prompt line.")
 
 (setcdr (assoc load-file-name custom-current-group-alist) 'ivy)
@@ -177,8 +177,8 @@ there is no text left to delete, i.e., when it is called at the
 beginning of the minibuffer.
 The default setting provides a quick exit from completion."
   :type '(choice (const :tag "Exit completion" minibuffer-keyboard-quit)
-                 (const :tag "Do nothing" ignore)
-                 (function :tag "Custom function")))
+          (const :tag "Do nothing" ignore)
+          (function :tag "Custom function")))
 
 (defcustom ivy-extra-directories '("../" "./")
   "Add this to the front of the list when completing file names.
@@ -212,7 +212,7 @@ See also URL
 
 (defvar ivy-display-functions-props
   '((ivy-display-function-overlay :cleanup ivy-overlay-cleanup))
-    "Map Ivy display functions to their property lists.
+  "Map Ivy display functions to their property lists.
 Examples of properties include associated `:cleanup' functions.")
 
 (defvar ivy-display-functions-alist
@@ -545,8 +545,8 @@ corresponds to the default behaviour of most Emacs search
 functionality, e.g. as seen in `isearch'."
   :link '(info-link "(emacs)Lax Search")
   :type '(choice (const :tag "Auto" auto)
-                 (const :tag "Always" t)
-                 (const :tag "Never" nil)))
+          (const :tag "Always" t)
+          (const :tag "Never" nil)))
 
 (defvar ivy-case-fold-search ivy-case-fold-search-default
   "Store the current overriding `case-fold-search'.")
@@ -1602,11 +1602,11 @@ like.")
   :type 'integer)
 
 (defalias 'ivy--dirname-p
-  (if (fboundp 'directory-name-p)
-      #'directory-name-p
-    (lambda (name)
-      "Return non-nil if NAME ends with a directory separator."
-      (string-match-p "/\\'" name))))
+    (if (fboundp 'directory-name-p)
+        #'directory-name-p
+      (lambda (name)
+        "Return non-nil if NAME ends with a directory separator."
+        (string-match-p "/\\'" name))))
 
 (defun ivy--sorted-files (dir)
   "Return the list of files in DIR.
@@ -2071,8 +2071,8 @@ INHERIT-INPUT-METHOD is currently ignored."
 
 (defun ivy-completing-read-with-empty-string-def
     (prompt collection
-            &optional predicate require-match initial-input
-            history def inherit-input-method)
+     &optional predicate require-match initial-input
+       history def inherit-input-method)
   "Same as `ivy-completing-read' but with different handling of DEF.
 
 Specifically, if DEF is nil, it is treated the same as if DEF was
@@ -2201,7 +2201,7 @@ See `completion-in-region' for further information."
 
 ;;;###autoload
 (define-minor-mode ivy-mode
-  "Toggle Ivy mode on or off.
+    "Toggle Ivy mode on or off.
 Turn Ivy mode on if ARG is positive, off otherwise.
 Turning on Ivy mode sets `completing-read-function' to
 `ivy-completing-read'.
@@ -2372,7 +2372,7 @@ text after delimiter if it is empty.  Modifies match data."
                 (list str))))))
 
 (defun ivy--split-spaces (str)
- "Split STR on spaces, unless they're preceded by \\.
+  "Split STR on spaces, unless they're preceded by \\.
 No unescaped spaces are left in the output.  Any substring not
 constituting a valid regexp is passed to `regexp-quote'."
   (when str
@@ -2640,11 +2640,11 @@ Possible choices are 'ivy-magic-slash-non-match-cd-selected,
 'ivy-magic-slash-non-match-create, or nil"
   :type '(choice
           (const :tag "Use currently selected directory"
-                 ivy-magic-slash-non-match-cd-selected)
+           ivy-magic-slash-non-match-cd-selected)
           (const :tag "Create and use new directory"
-                 ivy-magic-slash-non-match-create)
+           ivy-magic-slash-non-match-create)
           (const :tag "Do nothing"
-                 nil)))
+           nil)))
 
 (defun ivy--create-and-cd (dir)
   "When completing file names, create directory DIR and move there."
@@ -3683,8 +3683,8 @@ BUFFER may be a string or nil."
   "Find file from BUFFER's directory."
   (let* ((b (get-buffer buffer))
          (default-directory
-           (or (and b (buffer-local-value 'default-directory b))
-               default-directory)))
+          (or (and b (buffer-local-value 'default-directory b))
+              default-directory)))
     (call-interactively (if (functionp 'counsel-find-file)
                             #'counsel-find-file
                           #'find-file))))
@@ -3850,7 +3850,7 @@ Don't finish completion."
     (insert (ivy-state-current ivy-last))))
 
 (define-obsolete-variable-alias 'ivy--preferred-re-builders
-  'ivy-preferred-re-builders "0.10.0")
+    'ivy-preferred-re-builders "0.10.0")
 
 (defcustom ivy-preferred-re-builders
   '((ivy--regex-plus . "ivy")
@@ -3954,10 +3954,10 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
     (ivy-occur-press)))
 
 (define-derived-mode ivy-occur-mode fundamental-mode "Ivy-Occur"
-  "Major mode for output from \\[ivy-occur].
+                     "Major mode for output from \\[ivy-occur].
 
 \\{ivy-occur-mode-map}"
-  (setq-local view-read-only nil))
+                     (setq-local view-read-only nil))
 
 (defvar ivy-occur-grep-mode-map
   (let ((map (copy-keymap ivy-occur-mode-map)))
@@ -3973,12 +3973,12 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
                    (1+ (line-end-position)))))
 
 (define-derived-mode ivy-occur-grep-mode grep-mode "Ivy-Occur"
-  "Major mode for output from \\[ivy-occur].
+                     "Major mode for output from \\[ivy-occur].
 
 \\{ivy-occur-grep-mode-map}"
-  (setq-local view-read-only nil)
-  (when (fboundp 'wgrep-setup)
-    (wgrep-setup)))
+                     (setq-local view-read-only nil)
+                     (when (fboundp 'wgrep-setup)
+                       (wgrep-setup)))
 
 (defvar ivy--occurs-list nil
   "A list of custom occur generators per command.")

--- a/swiper.el
+++ b/swiper.el
@@ -41,23 +41,23 @@
   :prefix "swiper-")
 
 (defface swiper-match-face-1
-  '((t (:inherit isearch-lazy-highlight-face)))
+    '((t (:inherit isearch-lazy-highlight-face)))
   "The background face for `swiper' matches.")
 
 (defface swiper-match-face-2
-  '((t (:inherit isearch)))
+    '((t (:inherit isearch)))
   "Face for `swiper' matches modulo 1.")
 
 (defface swiper-match-face-3
-  '((t (:inherit match)))
+    '((t (:inherit match)))
   "Face for `swiper' matches modulo 2.")
 
 (defface swiper-match-face-4
-  '((t (:inherit isearch-fail)))
+    '((t (:inherit isearch-fail)))
   "Face for `swiper' matches modulo 3.")
 
 (defface swiper-line-face
-  '((t (:inherit highlight)))
+    '((t (:inherit highlight)))
   "Face for current `swiper' line.")
 
 (defcustom swiper-faces '(swiper-match-face-1


### PR DESCRIPTION
This just runs the default Elisp indentation algorithm on all the files. If indentation is correct, then editing is more convenient since packages like [`aggressive-indent-mode`](https://github.com/Malabarba/aggressive-indent-mode) can be used.