### PR TITLE
Extend Ivy yank commands

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -449,8 +449,8 @@ actions.
 - ~M-j~ (=ivy-yank-word=) ::
      Inserts the sub-word at point into the minibuffer.
 
-     This is similar to ~C-s C-w~ with =isearch=. Ivy reserves ~C-w~
-     for =kill-region=.
+     This is similar to ~C-s C-w~ with =isearch=.  Ivy reserves ~C-w~
+     for =kill-region=.  See also =ivy-yank-char=.
 
 - ~S-SPC~ (=ivy-restrict-to-matches=) ::
      Deletes the current input, and resets the candidates list to the

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -450,7 +450,8 @@ actions.
      Inserts the sub-word at point into the minibuffer.
 
      This is similar to ~C-s C-w~ with =isearch=.  Ivy reserves ~C-w~
-     for =kill-region=.  See also =ivy-yank-char=.
+     for =kill-region=.  See also =ivy-yank-symbol= and
+     =ivy-yank-char=.
 
 - ~S-SPC~ (=ivy-restrict-to-matches=) ::
      Deletes the current input, and resets the candidates list to the

--- a/ivy.el
+++ b/ivy.el
@@ -3833,6 +3833,14 @@ point before and after applying FN to ARGS."
   (interactive)
   (ivy--yank-by #'forward-word))
 
+(defun ivy-yank-symbol ()
+  "Pull next symbol from buffer into search string."
+  (interactive)
+  ;; Emacs < 24.4 compatibility
+  (unless (fboundp 'forward-symbol)
+    (require 'thingatpt))
+  (ivy--yank-by #'forward-symbol 1))
+
 (defun ivy-yank-char ()
   "Pull next character from buffer into search string."
   (interactive)

--- a/ivy.el
+++ b/ivy.el
@@ -3819,34 +3819,41 @@ The region to extract is determined by the respective values of
 point before and after applying FN to ARGS."
   (let (text)
     (with-ivy-window
-      (let ((pt (point))
-            (le (line-end-position)))
+      (let ((pos (point))
+            (bol (line-beginning-position))
+            (eol (line-end-position)))
         (unwind-protect
             (progn (apply fn args)
                    (setq text (buffer-substring-no-properties
-                               pt (goto-char (min (point) le)))))
+                               pos (goto-char (max bol (min (point) eol))))))
           (unless text
-            (goto-char pt)))))
+            (goto-char pos)))))
     (when text
       (insert (replace-regexp-in-string "  +" " " text t t)))))
 
-(defun ivy-yank-word ()
-  "Pull next word from buffer into search string."
-  (interactive)
-  (ivy--yank-by #'forward-word))
+(defun ivy-yank-word (&optional arg)
+  "Pull next word from buffer into search string.
+If optional ARG is non-nil, pull in the next ARG
+words (previous if ARG is negative)."
+  (interactive "p")
+  (ivy--yank-by #'forward-word arg))
 
-(defun ivy-yank-symbol ()
-  "Pull next symbol from buffer into search string."
-  (interactive)
+(defun ivy-yank-symbol (&optional arg)
+  "Pull next symbol from buffer into search string.
+If optional ARG is non-nil, pull in the next ARG
+symbols (previous if ARG is negative)."
+  (interactive "p")
   ;; Emacs < 24.4 compatibility
   (unless (fboundp 'forward-symbol)
     (require 'thingatpt))
-  (ivy--yank-by #'forward-symbol 1))
+  (ivy--yank-by #'forward-symbol (or arg 1)))
 
-(defun ivy-yank-char ()
-  "Pull next character from buffer into search string."
-  (interactive)
-  (ivy--yank-by #'forward-char))
+(defun ivy-yank-char (&optional arg)
+  "Pull next character from buffer into search string.
+If optional ARG is non-nil, pull in the next ARG
+characters (previous if ARG is negative)."
+  (interactive "p")
+  (ivy--yank-by #'forward-char arg))
 
 (defun ivy-kill-ring-save ()
   "Store the current candidates into the kill ring.

--- a/ivy.el
+++ b/ivy.el
@@ -3823,8 +3823,8 @@ point before and after applying FN to ARGS."
             (le (line-end-position)))
         (unwind-protect
             (progn (apply fn args)
-                   (when (<= (point) le)
-                     (setq text (buffer-substring-no-properties pt (point)))))
+                   (setq text (buffer-substring-no-properties
+                               pt (goto-char (min (point) le)))))
           (unless text
             (goto-char pt)))))
     (when text

--- a/ivy.el
+++ b/ivy.el
@@ -3817,16 +3817,18 @@ Skip buffers that match `ivy-ignore-buffers'."
   "Pull buffer text from current line into search string.
 The region to extract is determined by the respective values of
 point before and after applying FN to ARGS."
-  (let (amend)
+  (let (text)
     (with-ivy-window
       (let ((pt (point))
             (le (line-end-position)))
-        (apply fn args)
-        (if (> (point) le)
-            (goto-char pt)
-          (setq amend (buffer-substring-no-properties pt (point))))))
-    (when amend
-      (insert (replace-regexp-in-string "  +" " " amend)))))
+        (unwind-protect
+            (progn (apply fn args)
+                   (when (<= (point) le)
+                     (setq text (buffer-substring-no-properties pt (point)))))
+          (unless text
+            (goto-char pt)))))
+    (when text
+      (insert (replace-regexp-in-string "  +" " " text t t)))))
 
 (defun ivy-yank-word ()
   "Pull next word from buffer into search string."

--- a/ivy.el
+++ b/ivy.el
@@ -3813,19 +3813,30 @@ Skip buffers that match `ivy-ignore-buffers'."
 
 (define-obsolete-function-alias 'ivy-recentf 'counsel-recentf "0.8.0")
 
-(defun ivy-yank-word ()
-  "Pull next word from buffer into search string."
-  (interactive)
+(defun ivy--yank-by (fn &rest args)
+  "Pull buffer text from current line into search string.
+The region to extract is determined by the respective values of
+point before and after applying FN to ARGS."
   (let (amend)
     (with-ivy-window
       (let ((pt (point))
             (le (line-end-position)))
-        (forward-word 1)
+        (apply fn args)
         (if (> (point) le)
             (goto-char pt)
           (setq amend (buffer-substring-no-properties pt (point))))))
     (when amend
       (insert (replace-regexp-in-string "  +" " " amend)))))
+
+(defun ivy-yank-word ()
+  "Pull next word from buffer into search string."
+  (interactive)
+  (ivy--yank-by #'forward-word))
+
+(defun ivy-yank-char ()
+  "Pull next character from buffer into search string."
+  (interactive)
+  (ivy--yank-by #'forward-char))
 
 (defun ivy-kill-ring-save ()
   "Store the current candidates into the kill ring.

--- a/swiper.el
+++ b/swiper.el
@@ -630,6 +630,7 @@ Matched candidates should have `swiper-invocation-face'."
                       (string-to-number (match-string 0 str))
                     0)))
         (unless (memq this-command '(ivy-yank-word
+                                     ivy-yank-symbol
                                      ivy-yank-char
                                      scroll-other-window))
           (when (cl-plusp num)

--- a/swiper.el
+++ b/swiper.el
@@ -630,6 +630,7 @@ Matched candidates should have `swiper-invocation-face'."
                       (string-to-number (match-string 0 str))
                     0)))
         (unless (memq this-command '(ivy-yank-word
+                                     ivy-yank-char
                                      scroll-other-window))
           (when (cl-plusp num)
             (unless (if swiper--current-line


### PR DESCRIPTION
Commit summary:

1. Address #1588. The question of whether a default key binding should be provided for `ivy-yank-char` still remains.
2. Add a similar command for symbols (same question about key binding).
3. Minor refactoring.
4. Unconditionally allow all yank commands to continue yanking until EOL.
5. Add optional prefix arguments to all yank commands.

Please see each commit message in turn for further details.