### PR TITLE
ivy.el (ivy-call): Restore previous buffer

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1219,6 +1219,7 @@ See variable `ivy-recursive-restore' for further information."
           (if (eq action 'identity)
               (funcall action x)
             (select-window (ivy--get-window ivy-last))
+            (set-buffer (ivy-state-buffer ivy-last))
             (prog1 (with-current-buffer (ivy-state-buffer ivy-last)
                      (unwind-protect (funcall action x)
                        (ivy-recursive-restore)))


### PR DESCRIPTION
In cases where `set-buffer` was called before `ivy-read`, the correct window was restored but the effects of `set-buffer` were lost. Restoring the buffer explicitly fixes the problem.

Example code to reproduce the issue:

```elisp
(with-current-buffer "*scratch*"
  (set-buffer "*Messages*")
  (ivy-read "Select one: " (list "X"))
  (pcase (buffer-name)
    ("*scratch*" (message "Buffer was not restored correctly."))
    ("*Messages*" (message "Buffer was restored correctly."))
    (_ (message "Something unexpected has happened."))))
```