### PR TITLE
Add .dir-locals-2.el to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /doc/dir
 *.info
 *-autoloads.el
+.dir-locals-2.el


### PR DESCRIPTION
This allows people to customize directory-local variables for Swiper without leaving unstaged changes or untracked files in the Git repository. (Support for `.dir-locals-2.el` is new in Emacs 26.)