### PR TITLE
* counsel.el (counsel--M-x-externs): Take function names from cache

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -821,7 +821,7 @@ The currently supported packages are, in order of precedence,
            (amx-initialize))
          (when (amx-detect-new-commands)
            (amx-update))
-         amx-cache)
+         (mapcar #'car amx-cache))
         ((require 'smex nil t)
          (unless smex-initialized-p
            (smex-initialize))


### PR DESCRIPTION
AMX cache contains more than command names. This fix makes sure `counsel--M-x-externs` only return command names.

/cc @basil-conto 