### PR TITLE
Fixes issue #1613

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -821,7 +821,8 @@ The currently supported packages are, in order of precedence,
            (amx-initialize))
          (when (amx-detect-new-commands)
            (amx-update))
-         amx-cache)
+         (mapcar
+          (lambda (command-item) (symbol-name (car command-item))) amx-cache))
         ((require 'smex nil t)
          (unless smex-initialized-p
            (smex-initialize))


### PR DESCRIPTION
The amx-cache needs to be formated as the old smex-ido-cache. Actually the amx-cache has the same format as smex-cache but the expected format in ivy-read is the ido format.