### PR TITLE
ivy.el (ivy--reset-state): Use copy-sequence when sorting collection

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1954,7 +1954,7 @@ This is useful for recursive `ivy-read'."
             (when (and (not (eq collection 'read-file-name-internal))
                        (<= (length coll) ivy-sort-max-size)
                        (setq sort-fn (ivy--sort-function collection)))
-              (setq coll (sort coll sort-fn)))
+              (setq coll (sort (copy-sequence coll) sort-fn)))
           (when (and (not (eq history 'org-refile-history))
                      (<= (length coll) ivy-sort-max-size)
                      (setq sort-fn (ivy--sort-function caller)))


### PR DESCRIPTION
This avoids modifications of external data that could be caused by
sorting with a collection function.  Calling `copy-sequence` inside
`ivy--reset-state` rather than requiring the collection function to do
so has the advantage that it only happens if the collection is smaller
than `ivy-sort-max-size`, which limits the performance impact.

This is a follow up to #1592.