### PR TITLE
Update copyright notices

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -4,6 +4,7 @@
 ((nil
   (bug-reference-bug-regexp . "#\\(?2:[[:digit:]]+\\)")
   (bug-reference-url-format . "https://github.com/abo-abo/swiper/issues/%s")
+  (copyright-names-regexp . "Free Software Foundation, Inc\\.")
   (sentence-end-double-space . t))
  (emacs-lisp-mode
   (indent-tabs-mode . nil)

--- a/colir.el
+++ b/colir.el
@@ -1,6 +1,6 @@
 ;;; colir.el --- Color blending library -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 

--- a/counsel.el
+++ b/counsel.el
@@ -1,6 +1,6 @@
 ;;; counsel.el --- Various completion functions using Ivy -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/swiper

--- a/doc/ivy-ox.el
+++ b/doc/ivy-ox.el
@@ -1,6 +1,6 @@
 ;;; ivy-ox.el --- org-export settings for Ivy
 
-;; Copyright (C) 2015  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel
 

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -64,7 +64,7 @@ final candidate is either through simple keyboard character inputs or
 through powerful regular expressions.
 #+TEXINFO: @end ifnottex
 
-Copyright (C) 2015 Free Software Foundation, Inc.
+Copyright (C) 2015-2018 Free Software Foundation, Inc.
 
 #+BEGIN_QUOTE
 Permission is granted to copy, distribute and/or modify this document

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -20,7 +20,7 @@ final candidate is either through simple keyboard character inputs or
 through powerful regular expressions.
 @end ifnottex
 
-Copyright (C) 2015 Free Software Foundation, Inc.
+Copyright (C) 2015-2018 Free Software Foundation, Inc.
 
 @quotation
 Permission is granted to copy, distribute and/or modify this document
@@ -71,24 +71,19 @@ modify this GNU manual.''
 @detailmenu
 --- The Detailed Node Listing ---
 
-
 Installation
 
 * Installing from Emacs Package Manager::
 * Installing from the Git repository::
 
-
-
 Getting started
 
 * Basic customization::
-
 
 Key bindings
 
 * Global key bindings::
 * Minibuffer key bindings::
-
 
 Minibuffer key bindings
 
@@ -106,16 +101,12 @@ Completion Styles
 * ivy--regex-ignore-order::
 * ivy--regex-fuzzy::
 
-
-
 Customization
 
 * Faces::
 * Defcustoms::
 * Actions::
 * Packages::
-
-
 
 Actions
 
@@ -125,15 +116,10 @@ Actions
 * Example - add two actions to each command::
 * Example - define a new command with several actions::
 
-
-
-
 Example - add two actions to each command
 
 * How to undo adding the two actions::
 * How to add actions to a specific command::
-
-
 
 Example - define a new command with several actions
 
@@ -156,6 +142,7 @@ API
 * Example - @code{counsel-describe-function}::
 * Example - @code{counsel-locate}::
 * Example - @code{ivy-read-with-extra-properties}::
+
 @end detailmenu
 @end menu
 
@@ -604,8 +591,9 @@ complete the renaming.
 @indentedblock
 Inserts the sub-word at point into the minibuffer.
 
-This is similar to @kbd{C-s C-w} with @code{isearch}. Ivy reserves @kbd{C-w}
-for @code{kill-region}.
+This is similar to @kbd{C-s C-w} with @code{isearch}.  Ivy reserves @kbd{C-w}
+for @code{kill-region}.  See also @code{ivy-yank-symbol} and
+@code{ivy-yank-char}.
 @end indentedblock
 @subsubheading @kbd{S-SPC} (@code{ivy-restrict-to-matches})
 @vindex ivy-restrict-to-matches
@@ -1058,7 +1046,10 @@ Set @code{ivy-display-style} to @code{nil} for a plain minibuffer.
 @end defopt
 
 @defopt ivy-on-del-error-function
-Specify what when @kbd{DEL} (@code{ivy-backward-delete-char}) throws.
+Specifies what to do when @kbd{DEL} (@code{ivy-backward-delete-char}) fails.
+
+This is usually the case when there is no text left to delete,
+i.e., when @kbd{DEL} is typed at the beginning of the minibuffer.
 
 The default behavior is to quit the completion after @kbd{DEL} -- a
 handy key to invoke after mistakenly triggering a completion.

--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -1,6 +1,6 @@
 ;;; ivy-hydra.el --- Additional key bindings for Ivy  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/swiper

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -1,6 +1,6 @@
 ;;; ivy-overlay.el --- Overlay display functions for Ivy  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2016-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; Keywords: convenience

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1,6 +1,6 @@
 ;;; ivy-test.el --- tests for ivy -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel
 

--- a/ivy.el
+++ b/ivy.el
@@ -1,6 +1,6 @@
 ;;; ivy.el --- Incremental Vertical completYon -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/swiper

--- a/swiper.el
+++ b/swiper.el
@@ -1,6 +1,6 @@
 ;;; swiper.el --- Isearch with an overview. Oh, man! -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/swiper


### PR DESCRIPTION
* `.dir-locals.el`: Configure `copyright-names-regexp` for use with `copyright-update`.
* `colir.el`:
* `counsel.el`:
* `ivy-hydra.el`:
* `ivy-overlay.el`:
* `ivy-test.el`:
* `ivy.el`:
* `swiper.el`:
* `doc/ivy-ox.el`:
* `doc/ivy.org`: Update copyright notice for 2018.
* `doc/ivy.texi`: Re-export.

Note that `cd doc; make ivy.texi` warns of `Unable to read file "/home/blc/git/org-html-themes/setup/theme-readtheorg.setup"`, so you may have to regenerate whatever that's trying to do yourself.