### PR TITLE
Update library headers

### DIFF
--- a/colir.el
+++ b/colir.el
@@ -20,13 +20,14 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package solves the problem of adding a face with a background
 ;; to text which may already have a background.  In all conflicting
 ;; areas, instead of choosing either the original or the new
 ;; background face, their blended sum is used.
 ;;
-;; The blend mode functions are taken from http://en.wikipedia.org/wiki/Blend_modes.
+;; The blend mode functions are taken from URL
+;; `http://en.wikipedia.org/wiki/Blend_modes'.
 
 ;;; Code:
 

--- a/counsel.el
+++ b/counsel.el
@@ -24,17 +24,17 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; Just call one of the interactive functions in this file to complete
 ;; the corresponding thing using `ivy'.
 ;;
 ;; Currently available:
-;; - Symbol completion for Elisp, Common Lisp, Python and Clojure.
+;; - Symbol completion for Elisp, Common Lisp, Python, Clojure, C, C++.
 ;; - Describe fuctions for Elisp: function, variable, library, command,
 ;;   bindings, theme.
-;; - Navigation functions: imenu, ace-line, semantic, outline
-;; - Git utilities: git-files, git-grep, git-log, git-stash.
-;; - Grep utitilies: grep, ag, pt, recoll.
+;; - Navigation functions: imenu, ace-line, semantic, outline.
+;; - Git utilities: git-files, git-grep, git-log, git-stash, git-checkout.
+;; - Grep utitilies: grep, ag, pt, recoll, ack, rg.
 ;; - System utilities: process list, rhythmbox, linux-app.
 ;; - Many more.
 

--- a/counsel.el
+++ b/counsel.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/abo-abo/swiper
 ;; Version: 0.10.0
 ;; Package-Requires: ((emacs "24.3") (swiper "0.9.0"))
-;; Keywords: completion, matching
+;; Keywords: convenience, matching, tools
 
 ;; This file is part of GNU Emacs.
 

--- a/doc/ivy-ox.el
+++ b/doc/ivy-ox.el
@@ -1,4 +1,4 @@
-;;; ivy-ox.el --- org-export settings for Ivy
+;;; ivy-ox.el --- org-export settings for Ivy -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2015-2018  Free Software Foundation, Inc.
 
@@ -18,6 +18,10 @@
 
 ;; For a full copy of the GNU General Public License
 ;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
 
 ;;* ox-texinfo
 (require 'ox-texinfo)
@@ -192,3 +196,5 @@ contextual information."
    "Top"))
 
 (provide 'ivy-ox)
+
+;;; ivy-ox.el ends here

--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -24,12 +24,13 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package provides the `hydra-ivy/body' command, which is a
 ;; quasi-prefix map, with many useful bindings.  These bindings are
 ;; shorter than usual, using mostly unprefixed keys.
 
 ;;; Code:
+
 (require 'ivy)
 (require 'hydra)
 

--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/abo-abo/swiper
 ;; Version: 0.10.0
 ;; Package-Requires: ((emacs "24.1") (ivy "0.9.0") (hydra "0.13.4"))
-;; Keywords: completion, matching, bindings
+;; Keywords: convenience
 
 ;; This file is part of GNU Emacs.
 

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -19,12 +19,13 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package allows to setup Ivy's completion at point to actually
 ;; show the candidates and the input at point, instead of in the
 ;; minibuffer.
 
 ;;; Code:
+
 (defface ivy-cursor
   '((t (:background "black"
         :foreground "white")))
@@ -129,4 +130,5 @@ Hide the minibuffer contents and cursor."
           (ivy-overlay-show-after overlay-str))))))
 
 (provide 'ivy-overlay)
+
 ;;; ivy-overlay.el ends here

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -20,15 +20,16 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This packages provides the tests for `ert'.  They can be executed
 ;; from the command line as well by calling "make test".
 
 ;;; Code:
+
 (require 'ert)
 (require 'colir)
 
-;; useful for #'ivy-read-remap. It must arrive before (require 'ivy)
+;; Useful for #'ivy-read-remap.  It must arrive before (require 'ivy).
 (define-key global-map (kbd "<S-right>") #'end-of-buffer)
 
 (require 'ivy)

--- a/ivy.el
+++ b/ivy.el
@@ -24,7 +24,7 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package provides `ivy-read' as an alternative to
 ;; `completing-read' and similar functions.
 ;;
@@ -37,6 +37,7 @@
 ;; So "for example" is transformed into "\\(for\\).*\\(example\\)".
 
 ;;; Code:
+
 (require 'cl-lib)
 (require 'ffap)
 (require 'ivy-overlay)

--- a/swiper.el
+++ b/swiper.el
@@ -24,7 +24,7 @@
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package gives an overview of the current regex search
 ;; candidates.  The search regex can be split into groups with a
 ;; space.  Each group is highlighted with a different face.
@@ -33,6 +33,7 @@
 ;; lines will be matched.
 
 ;;; Code:
+
 (require 'ivy)
 
 (defgroup swiper nil


### PR DESCRIPTION
Commits:
1. * `counsel.el`:
   * `ivy-hydra.el`: Update keywords header as per [`(elisp) Library Headers`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).

2. * `colir.el`: Quote URL as in docstrings.
   * `counsel.el`: Extend feature list.
   * `ivy-hydra.el`:
   * `ivy-overlay.el`:
   * `ivy-test.el`:
   * `ivy.el`:
   * `swiper.el`: Use consistent comments/spacing in library headers.
   * `doc/ivy-ox.el`: Enable `lexical-binding`.