### PR TITLE
Fix project dependencies

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -41,7 +41,6 @@
 ;;; Code:
 
 (require 'swiper)
-(require 'esh-util)
 (require 'compile)
 (require 'dired)
 
@@ -124,8 +123,11 @@
   (ivy-add-prompt-count
    (format "%s: " (ivy-state-prompt ivy-last))))
 
+(declare-function eshell-split-path "esh-util")
+
 (defun counsel-prompt-function-dir ()
   "Return prompt appended with the parent directory."
+  (require 'esh-util)
   (ivy-add-prompt-count
    (let ((directory (ivy-state-directory ivy-last)))
      (format "%s [%s]: "

--- a/doc/ivy-ox.el
+++ b/doc/ivy-ox.el
@@ -25,7 +25,7 @@
 
 ;;* ox-texinfo
 (require 'ox-texinfo)
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 (org-export-define-backend 'texinfo
   '((bold . org-texinfo-bold)
     (center-block . org-texinfo-center-block)

--- a/swiper.el
+++ b/swiper.el
@@ -400,7 +400,6 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
   (swiper--ivy (swiper--candidates) initial-input))
 
-(declare-function string-trim-right "subr-x")
 (defvar swiper--current-window-start nil)
 
 (defun swiper--extract-matches (regex cands)
@@ -421,7 +420,6 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
   "Generate a custom occur buffer for `swiper'.
 When REVERT is non-nil, regenerate the current *ivy-occur* buffer.
 When capture groups are present in the input, print them instead of lines."
-  (require 'subr-x)
   (let* ((buffer (ivy-state-buffer ivy-last))
          (fname (propertize
                  (with-ivy-window
@@ -437,14 +435,12 @@ When capture groups are present in the input, print them instead of lines."
          (cands
           (mapcar
            (lambda (s)
-             (format "%s:%s:%s"
-                     fname
-                     (propertize
-                      (string-trim-right
-                       (get-text-property 0 'swiper-line-number s))
-                      'face 'compilation-line-number)
-                     (substring s 1)))
-           (if (null revert)
+             (let* ((n (get-text-property 0 'swiper-line-number s))
+                    (i (string-match-p "[ \t\n\r]+\\'" n)))
+               (when i (setq n (substring n 0 i)))
+               (put-text-property 0 (length n) 'face 'compilation-line-number n)
+               (format "%s:%s:%s" fname n (substring s 1))))
+           (if (not revert)
                ivy--old-cands
              (setq ivy--old-re nil)
              (let ((ivy--regex-function 'swiper--re-builder))


### PR DESCRIPTION
Summary:
* Remove `etags` and `esh-util` as top-level dependencies of Counsel.
* Fix Emacs 24.4 usage of `subr-x` re: #1629.

Please see each commit for details.