### PR TITLE
Use compatibility shim for add-face-text-property

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1324,14 +1324,12 @@ Typical value: '(recenter)."
 (defun counsel-git-grep-transformer (str)
   "Higlight file and line number in STR."
   (when (string-match "\\`\\([^:]+\\):\\([^:]+\\):" str)
-    (add-face-text-property (match-beginning 1)
-                            (match-end 1)
-                            'compilation-info
-                            nil str)
-    (add-face-text-property (match-beginning 2)
-                            (match-end 2)
-                            'compilation-line-number
-                            nil str))
+    (ivy-add-face-text-property (match-beginning 1) (match-end 1)
+                                'compilation-info
+                                str)
+    (ivy-add-face-text-property (match-beginning 2) (match-end 2)
+                                'compilation-line-number
+                                str))
   str)
 
 (defvar counsel-git-grep-projects-alist nil

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -137,8 +137,8 @@ discoverability.
 Install Ivy automatically through Emacs's package manager, or manually
 from Ivy's development repository.
 
-Emacs 24.3.1 is the oldest version to run Ivy. Emacs 24.5.1 is the
-oldest version that runs Ivy with fancy faces display.
+Emacs 24.3 is the oldest version to run Ivy. Emacs 24.4 is the oldest
+version that runs Ivy with fancy faces display.
 
 ** Installing from Emacs Package Manager
 :PROPERTIES:
@@ -770,8 +770,7 @@ installed.
 - User Option =ivy-display-style= ::
      Specifies highlighting candidates in the minibuffer.
 
-     The default setting is ='fancy= and valid only in Emacs versions
-     24.5 or newer.
+     The default setting is ='fancy= in Emacs versions 24.4 or newer.
 
      Set =ivy-display-style= to =nil= for a plain minibuffer.
 

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -78,6 +78,7 @@ Then attach the overlay the character before point."
 (defvar ivy-last)
 (defvar ivy-text)
 (defvar ivy-completion-beg)
+(declare-function ivy-add-face-text-property "ivy")
 (declare-function ivy--get-window "ivy")
 (declare-function ivy-state-current "ivy")
 (declare-function ivy-state-window "ivy")
@@ -99,8 +100,8 @@ Hide the minibuffer contents and cursor."
         (save-excursion
           (forward-line 1)
           (insert str)))
-    (add-face-text-property (minibuffer-prompt-end) (point-max)
-                            '(:foreground "white"))
+    (ivy-add-face-text-property (minibuffer-prompt-end) (point-max)
+                                '(:foreground "white"))
     (let ((cursor-pos (1+ (- (point) (minibuffer-prompt-end))))
           (ivy-window (ivy--get-window ivy-last)))
       (setq cursor-type nil)
@@ -125,8 +126,8 @@ Hide the minibuffer contents and cursor."
                     (save-excursion
                       (goto-char ivy-completion-beg)
                       (current-column)))))))
-          (add-face-text-property cursor-pos (1+ cursor-pos)
-                                  'ivy-cursor t overlay-str)
+          (ivy-add-face-text-property cursor-pos (1+ cursor-pos)
+                                      'ivy-cursor overlay-str t)
           (ivy-overlay-show-after overlay-str))))))
 
 (provide 'ivy-overlay)


### PR DESCRIPTION
* `ivy.el` (`ivy--add-face`): Minor simplification.
  (`ivy-add-face-text-property`): Expand arglist to that of `add-face-text-property`, but with the order of the last two args flipped.  Move compatibility check from runtime to evaluation time. Use `font-lock-prepend-text-property` instead of `font-lock-append-text-property` when applicable.
(`ivy-append-face`): Replace `font-lock-append-text-property` with `ivy-add-face-text-property`.
(`ivy-display-style`):
* `doc/ivy.org` (Installation, Defcustoms): Mention Emacs 24.4 instead of 24.5.
* `counsel.el` (`counsel-git-grep-transformer`):
* `ivy-overlay.el` (`ivy-display-function-overlay`): Replace `add-face-text-property` with `ivy-add-face-text-property`.

Re: #1634

Before merging this PR I would like to make sure that the docstring and implementation of `ivy--add-face` are clear and correct w.r.t. the discussion in #1634.