### PR TITLE
counsel.el (counsel-org-agenda-headlines): require org

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3282,6 +3282,7 @@ include attachments of other Org buffers."
 (defun counsel-org-agenda-headlines ()
   "Choose from headers of `org-mode' files in the agenda."
   (interactive)
+  (require 'org)
   (let ((minibuffer-allow-text-properties t))
     (ivy-read "Org headline: "
               (counsel-org-agenda-headlines--candidates)


### PR DESCRIPTION
I am getting an error without this if org is not already loaded.