### PR TITLE
Add counsel-bookmarked-directory

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2063,6 +2063,57 @@ By default `counsel-bookmark' opens a dired buffer for directories."
    ("r" ,(counsel--apply-bookmark-fn #'counsel-find-file-as-root)
         "open as root")))
 
+;;** `counsel-bookmarked-directory'
+(defun counsel-bookmarked-directory--candidates ()
+  "Get a list of bookmarked directories sorted by file path."
+  (bookmark-maybe-load-default-file)
+  (sort (cl-remove-if-not
+         #'ivy--dirname-p
+         (delq nil (mapcar #'bookmark-get-filename bookmark-alist)))
+        #'string<))
+
+;;;###autoload
+(defun counsel-bookmarked-directory-add (dir)
+  "Create a directory bookmark to DIR interactively.
+
+This function prompts for the bookmark name, which defaults to the
+abbreviate path of the directory.
+
+When called-interactively, DIR defaults to the current value of
+`default-directory'."
+  (interactive (list default-directory))
+  (setq dir (abbreviate-file-name (expand-file-name dir)))
+  (let ((name (read-string (format "Name of the new directory bookmark [%s]: " dir)
+                           nil nil dir))
+        (record `((filename . ,(file-name-as-directory dir))
+                  (front-context-string)
+                  (rear-context-string))))
+    (bookmark-maybe-load-default-file)
+    (bookmark-store name record nil)))
+
+;;;###autoload
+(defun counsel-bookmarked-directory ()
+  "Ivy interface for bookmarked directories.
+
+With a prefix argument, this command creates a new bookmark which points to the
+current value of `default-directory'."
+  (interactive)
+  (if current-prefix-arg
+      (call-interactively #'counsel-bookmarked-directory-add)
+    (ivy-read "Bookmarked directory: "
+              (counsel-bookmarked-directory--candidates)
+              :caller 'counsel-bookmarked-directory
+              :action #'dired)))
+
+(ivy-set-actions 'counsel-bookmarked-directory
+                 '(("j" dired-other-window "other window")
+                   ("x" counsel-find-file-extern "open externally")
+                   ("r" counsel-find-file-as-root "open as root")
+                   ("f" (lambda (dir)
+                          (let ((default-directory dir))
+                            (call-interactively #'find-file)))
+                    "find-file")))
+
 ;;** `counsel-file-register'
 ;;;###autoload
 (defun counsel-file-register ()


### PR DESCRIPTION
This command was originally named [ivy-bookmarked-directory](https://github.com/akirak/ivy-bookmarked-directory), but I got [a suggestion](https://github.com/melpa/melpa/pull/5573) to add it as an alternative command, so I added this to counsel package. If you don't mind, I would like you to add this command.