### PR TITLE
counsel.el (counsel-locate): Add "open as root" action

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2153,6 +2153,7 @@ string - the full shell command to run."
 (ivy-set-actions
  'counsel-locate
  '(("x" counsel-locate-action-extern "xdg-open")
+   ("r" counsel-find-file-as-root "open as root")
    ("d" counsel-locate-action-dired "dired")))
 
 (counsel-set-async-exit-code 'counsel-locate 1 "Nothing found")


### PR DESCRIPTION
I often use `counsel-locate` to search for files in `/etc` so it is convenient to have an action to open them as root directly from the prompt.