### PR TITLE
Generalize counsel-outline to handle major modes and display styles

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3092,45 +3092,8 @@ version.  Argument values are based on the
 
 (defun counsel-org-goto--get-headlines ()
   "Get all headlines from the current org buffer."
-  (save-excursion
-    (let (entries
-          start-pos
-          stack
-          (stack-level 0)
-          (heading-args (counsel--org-get-heading-args)))
-      (goto-char (point-min))
-      (setq start-pos (or (and (org-at-heading-p)
-                               (point))
-                          (outline-next-heading)))
-      (while start-pos
-        (let ((name (or (apply #'org-get-heading heading-args) ""))
-              level)
-          (search-forward " ")
-          (setq level
-                (- (length (buffer-substring-no-properties start-pos (point)))
-                   1))
-          (cond ((eq counsel-org-headline-display-style 'path)
-                 ;; Update stack. The empty entry guards against incorrect
-                 ;; headline hierarchies e.g. a level 3 headline immediately
-                 ;; following a level 1 entry.
-                 (while (<= level stack-level)
-                   (pop stack)
-                   (cl-decf stack-level))
-                 (while (> level stack-level)
-                   (push "" stack)
-                   (cl-incf stack-level))
-                 (setf (car stack) (counsel-org-goto--add-face name level))
-                 (setq name (mapconcat
-                             #'identity
-                             (reverse stack)
-                             counsel-org-headline-path-separator)))
-                (t
-                 (when (eq counsel-org-headline-display-style 'headline)
-                   (setq name (concat (make-string level ?*) " " name)))
-                 (setq name (counsel-org-goto--add-face name level))))
-          (push (cons name (point-marker)) entries))
-        (setq start-pos (outline-next-heading)))
-      (nreverse entries))))
+  (let ((counsel-outline-title 'counsel-outline-title-org))
+    (counsel-outline-candidates)))
 
 (defun counsel-org-goto--add-face (name level)
   "Add face to headline NAME on LEVEL.
@@ -4019,30 +3982,144 @@ TREEP is used to expand internal nodes."
     (counsel-imenu)))
 
 ;;** `counsel-outline'
+(defvar counsel-outline-title 'counsel-outline-title-default
+  "Function used by `counsel-outline' to get the title of the current outline heading.
+
+It is called with point at the end of `outline-regexp' and with the match data reflecting `outline-regexp'.  It must take no argument and return the title string.")
+;;;###autoload(put 'counsel-outline-title-function 'risky-local-variable t)
+
+(defun counsel-outline-title-default ()
+  "Default function used by `counsel-outline' to get the title of
+the current outline heading. See `counsel-outline-title'."
+  (buffer-substring (point) (line-end-position)))
+
+(defun counsel-outline-title-org ()
+  "Function used by `counsel-outline' to get the title of the
+current outline heading in org-mode buffers. See
+`counsel-outline-title'."
+  (apply 'org-get-heading (counsel--org-get-heading-args)))
+
+(defun counsel-outline-title-markdown ()
+  "Function used by `counsel-outline' to get the title of the
+current outline heading in markdown-mode buffers. See
+`counsel-outline-title'."
+  ;; `outline-regexp' is set by `markdown-mode' to match both setext
+  ;; (underline) and atx (hash) headings (see
+  ;; `markdown-regex-header').
+  (or (match-string 1) ; setext heading title
+      (match-string 5))) ; atx heading title
+        
+(defun counsel-outline-title-LaTeX ()
+  "Function used by `counsel-outline' to get the title of the
+current outline heading in LaTeX-mode buffers. See
+`counsel-outline-title'."
+  ;; `outline-regexp' is set by `LaTeX-mode' (see
+  ;; `LaTeX-outline-regexp') to match section macros, in which case we
+  ;; get the section name, as well as `\appendix', `\documentclass',
+  ;; `\begin{document}' and `\end{document}', in which case we simply
+  ;; return that.
+  (if (and (assoc (match-string 1) LaTeX-section-list) ;; section macro
+           (progn ; point is at end of macro name, skip stars and optional args
+             (skip-chars-forward "*")
+             (while (looking-at "\\[")
+               (forward-list))
+             (looking-at "{"))) ; first mandatory arg should be section title
+      (buffer-substring (1+ (point)) (1- (forward-list)))
+    (buffer-substring (line-beginning-position) (point))))
+
+(defun counsel-outline-level-emacs-lisp ()
+  "Replacement for `lisp-outline-level', adequate for `counsel-outline'."
+  (if (looking-at ";;\\([;*]+\\)")
+      (length (match-string 1))
+    (funcall outline-level)))
+
+(defvar counsel-outline--preselect nil
+  "Index of the presected candidate in `counsel-outline'.")
+
 (defun counsel-outline-candidates ()
   "Return outline candidates."
-  (let (cands)
-    (save-excursion
+  (save-excursion
+    (let (cands
+          name
+          level
+          marker
+          stack
+          (stack-level 0)
+          (orig-point (point)))
+      (setq counsel-outline--preselect 0)
       (goto-char (point-min))
       (while (re-search-forward (concat "^\\(?:" outline-regexp "\\)") nil t)
-        (skip-chars-forward " ")
-        (push (cons (buffer-substring-no-properties
-                     (point) (line-end-position))
-                    (line-beginning-position))
-              cands))
+        (save-excursion
+          (setq name (or (save-match-data
+                           (funcall counsel-outline-title))
+                         ""))
+          (goto-char (match-beginning 0))
+          (setq marker (point-marker))
+          (setq level (funcall outline-level))
+          (cond ((eq counsel-org-headline-display-style 'path)
+                     ;; Update stack. The empty entry guards against incorrect
+                     ;; headline hierarchies e.g. a level 3 headline immediately
+                     ;; following a level 1 entry.
+                     (while (<= level stack-level)
+                       (pop stack)
+                       (cl-decf stack-level))
+                     (while (> level stack-level)
+                       (push "" stack)
+                       (cl-incf stack-level))
+                     (setf (car stack) (counsel-org-goto--add-face name level))
+                     (setq name (mapconcat
+                                 #'identity
+                                 (reverse stack)
+                                 counsel-org-headline-path-separator)))
+                    (t
+                     (when (eq counsel-org-headline-display-style 'headline)
+                       (setq name (concat (make-string level ?*) " " name)))
+                     (setq name (counsel-org-goto--add-face name level))))
+          (push (cons name marker) cands))
+        (unless (or (string= name "")
+                    (< orig-point marker))
+          (cl-incf counsel-outline--preselect)))
       (nreverse cands))))
-
+  
 (defun counsel-outline-action (x)
   "Go to outline X."
-  (with-ivy-window
-    (goto-char (cdr x))))
+    (goto-char (cdr x)))
 
 ;;;###autoload
 (defun counsel-outline ()
-  "Jump to outline with completion."
+  "Jump to outline with completion.
+
+This command relies on `outline-regexp', `outline-level', and
+`counsel-outline-title' to match an outline heading and get its
+level and title, respectively.  For major modes where this is not
+adequate or optimal, these variables can be rebound locally in
+the major mode hook.  Replacements are provided for some such
+modes. To set them up, add this to your init file:
+
+(add-hook
+ 'emacs-lisp-mode-hook 
+ (defun counsel-outline-emacs-lisp-setup ()
+   (setq-local outline-regexp \";;[;*]+[\s\t]+\")
+   (setq-local outline-level 'counsel-outline-level-emacs-lisp)))
+
+(add-hook
+ 'org-mode-hook
+ (defun counsel-outline-org-setup ()
+   (setq-local counsel-outline-title 'counsel-outline-title-org)))
+
+(add-hook
+ 'markdown-mode-hook
+ (defun counsel-outline-markdown-setup ()
+   (setq-local counsel-outline-title 'counsel-outline-title-markdown)))
+
+(add-hook
+ 'LaTeX-mode-hook
+ (defun counsel-outline-LaTeX-setup ()
+   (setq-local counsel-outline-title 'counsel-outline-title-LaTeX)))"
   (interactive)
   (ivy-read "outline: " (counsel-outline-candidates)
-            :action #'counsel-outline-action))
+            :action #'counsel-outline-action
+            :preselect (max (1- counsel-outline--preselect) 0)))
 
 ;;** `counsel-ibuffer'
 (defvar counsel-ibuffer--buffer-name nil

--- a/counsel.el
+++ b/counsel.el
@@ -4024,7 +4024,7 @@ TREEP is used to expand internal nodes."
   (let (cands)
     (save-excursion
       (goto-char (point-min))
-      (while (re-search-forward outline-regexp nil t)
+      (while (re-search-forward (concat "^\\(?:" outline-regexp "\\)") nil t)
         (skip-chars-forward " ")
         (push (cons (buffer-substring-no-properties
                      (point) (line-end-position))


### PR DESCRIPTION
Hello,

The first of the two commits is a simple fix making sure that `counsel-outline-candidates` only searches for `outline-regexp' at the beginning of a line (because from the docstring of `outline-regexp`, it does not necessarily start with `^`).

The second commit is the one that generalizes `counsel-outline`, in two ways. First, to handle display/face styles as in `counsel-org-goto`. This is simply done by moving code from `counsel-org-goto--get-headlines` to `counsel-outline-candidates` and make the former call the latter. Note that the display/face style in `counsel-outline` is also controlled by the variables `counsel-org-goto-display/face-style`, perhaps that's not elegant and new variables should be introduced, I'm not sure.

Second, to handle major modes in which the outline title does not simply go from the end of `outline-regexp` to the end of the line. For instance, in markdown-mode, the title is iside the regexp, such as markdown or latex. This is done by introducing a variable `counsel-outline-title` storing the function to use, which can be locally bound in major mode hooks. There are instructions in the docstring of `counsel-outline` about how to set this up. I've also put there instructions for emacs-lisp-mode, because the default values of `outline-regexp` and `outline-level` set by this mode are not adequate for `counsel-outline` (by the way, the dir-local value in the swiper repository ìs better but still matches all lines starting with `(` or the autoload cookie, which we don't want I think).

I think this approach is quite flexible but I'm not sure it's the best one because `counsel-outline` will not work out of the box for these modes. Alternative I thought of:
- Putting the `add-hook` statements directly in `counsel.el`, but I'm not sure it's good practice.
- Storing mode settings for `counsel-outline` (regexp, level function, title function) in an alist varaible, with a working default value, but I'm not sure it's good practice either for the regexp and level because it would overlook file/dir-local bindings of these variables and introduce an inconsistency between `counsel-outline` and the vanilla outline commands (eg `outline-next-heading`).

Note that after this generalization, `counsel-org-goto` is actually equivalent to `counsel-outline` after `counsel-outline-title` in `org-mode-hook` (actually there's one difference remaining in the action function, but that could accomodated). But `counsel-org-goto` works without setting anything, by let-binding `counsel-outline-title`. I didn't remove any existing function.

Finally, I implemeted a `:preselect` for `counsel-outline`, it seems useful to me to have the current heading preselected, but this is an independent thing.

If you're interesed in this PR, let me know of course if I should make changes.

Thanks for your attention.

