### PR TITLE
Add installation instructions for Debian and derivatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ buffer names.
 
 Install the `ivy` package from MELPA / GNU ELPA.
 
+Users of Debian ≥10 (and derivatives such as Ubuntu ≥18.04) can
+install Ivy, Counsel, and Swiper with `sudo apt install elpa-counsel`.
+To add Hydra support `sudo apt install elpa-ivy-hydra`.
+
 ## Documentation
 
 ### Manual


### PR DESCRIPTION
Not much to say...just a few lines with two points.  If you care about the packaging structure:
src:emacs-ivy generates these three binary packages:
elpa-ivy, elpa-swiper, elpa-counsel, elpa-ivy-hydra

When a user installs any elpa-package the els are bytecompiled for every version of GNU Emacs a user has installed.  So, if a user was to install the Debian 10 packages on Debian 9 (officially unsupported, but it works fine) the user gets Ivy/Swiper/Counsel for both Emacs 24.x and 25.x.  I'm not sure if Debian 10 will support both Emacs 25.x and 26.x.