### PR TITLE
Fontify completion annotations

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -1174,7 +1174,7 @@ later use yourself. However, it's recommended that you use the
                    (push (symbol-name x) cands))))
               cands)
             :keymap counsel-describe-map
-            :preselect (counsel-symbol-at-point)
+            :preselect (ivy-thing-at-point)
             :history 'counsel-describe-symbol-history
             :require-match t
             :sort t
@@ -1189,7 +1189,7 @@ Here are the interesting features of the above function, in the order that they 
 - The =prompt= argument is a simple string ending in ": ".
 - The =collection= argument evaluates to a (large) list of strings.
 - The =keymap= argument is for a custom keymap to supplement =ivy-minibuffer-map=.
-- The =preselect= is provided by =counsel-symbol-at-point=, which
+- The =preselect= is provided by =ivy-thing-at-point=, which
   returns a symbol near the point. Ivy then selects the first
   candidate from the collection that matches this symbol. To select
   this pre-selected candidate, a ~RET~ will suffice. No further user

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -1560,7 +1560,7 @@ later use yourself. However, it's recommended that you use the
 		   (push (symbol-name x) cands))))
 	      cands)
 	    :keymap counsel-describe-map
-	    :preselect (counsel-symbol-at-point)
+	    :preselect (ivy-thing-at-point)
 	    :history 'counsel-describe-symbol-history
 	    :require-match t
 	    :sort t
@@ -1580,7 +1580,7 @@ The @code{collection} argument evaluates to a (large) list of strings.
 @item
 The @code{keymap} argument is for a custom keymap to supplement @code{ivy-minibuffer-map}.
 @item
-The @code{preselect} is provided by @code{counsel-symbol-at-point}, which
+The @code{preselect} is provided by @code{ivy-thing-at-point}, which
 returns a symbol near the point. Ivy then selects the first
 candidate from the collection that matches this symbol. To select
 this pre-selected candidate, a @kbd{RET} will suffice. No further user

--- a/ivy.el
+++ b/ivy.el
@@ -3387,9 +3387,11 @@ Note: The usual last two arguments are flipped for convenience.")
   (let* ((str (ivy-cleanup-string str))
          (str (if (eq ivy-display-style 'fancy)
                   (funcall ivy--highlight-function (copy-sequence str))
-                (copy-sequence str))))
+                (copy-sequence str)))
+         (olen (length str))
+         (annot (plist-get completion-extra-properties :annotation-function)))
     (add-text-properties
-     0 (length str)
+     0 olen
      '(mouse-face
        ivy-minibuffer-match-highlight
        help-echo
@@ -3399,10 +3401,11 @@ Note: The usual last two arguments are flipped for convenience.")
           "mouse-1: %s   mouse-3: %s")
         ivy-mouse-1-tooltip ivy-mouse-3-tooltip))
      str)
-    (let ((annotation-function (plist-get completion-extra-properties :annotation-function)))
-      (if annotation-function
-          (concat str (funcall annotation-function str))
-        str))))
+    (when annot
+      (setq str (concat str (funcall annot str)))
+      (ivy-add-face-text-property
+       olen (length str) 'completions-annotations str))
+    str))
 
 (ivy-set-display-transformer
  'counsel-find-file 'ivy-read-file-transformer)

--- a/ivy.el
+++ b/ivy.el
@@ -3384,10 +3384,10 @@ Note: The usual last two arguments are flipped for convenience.")
 
 (defun ivy--format-minibuffer-line (str)
   "Format line STR for use in minibuffer."
-  (let* ((str (ivy-cleanup-string str))
+  (let* ((str (ivy-cleanup-string (copy-sequence str)))
          (str (if (eq ivy-display-style 'fancy)
-                  (funcall ivy--highlight-function (copy-sequence str))
-                (copy-sequence str)))
+                  (funcall ivy--highlight-function str)
+                str))
          (olen (length str))
          (annot (plist-get completion-extra-properties :annotation-function)))
     (add-text-properties


### PR DESCRIPTION
Please review each commit in turn.

### Questions

1. Is the second commit correct? I found it weird/confusing that `copy-sequence` was being called *after* `ivy-cleanup-string`.
2. When I run `make` under `doc/`, I get the following errors:

       $ make
       emacs -batch -l ivy-ox.el -l scripts.el --eval "(org-to-texi \"ivy.org\")"
       Unable to read file "/home/blc/git/org-html-themes/setup/theme-readtheorg.setup"
       Unable to read file "/home/blc/git/org-html-themes/setup/theme-readtheorg.setup"
       executing Elisp code block...
       "ivy-ox"
       Unable to read file "/home/blc/git/org-html-themes/setup/theme-readtheorg.setup"

   Can I safely ignore them?