### PR TITLE
Standardise defalias indentation

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -27,6 +27,7 @@ Here are the important settings for code style:
 (setq lisp-indent-function #'common-lisp-indent-function)
 (put 'if 'common-lisp-indent-function 2)
 (put 'defface 'common-lisp-indent-function 1)
+(put 'defalias 'common-lisp-indent-function 1)
 (put 'define-minor-mode 'common-lisp-indent-function 1)
 (put 'define-derived-mode 'common-lisp-indent-function 3)
 (put 'cl-flet 'common-lisp-indent-function

--- a/counsel.el
+++ b/counsel.el
@@ -470,11 +470,11 @@ Update the minibuffer with the amount of lines collected every
 (declare-function xref-push-marker-stack "xref")
 
 (defalias 'counsel--push-xref-marker
-    (if (require 'xref nil t)
-        #'xref-push-marker-stack
-      (require 'etags)
-      (lambda (&optional m)
-        (ring-insert (with-no-warnings find-tag-marker-ring) (or m (point-marker)))))
+  (if (require 'xref nil t)
+      #'xref-push-marker-stack
+    (require 'etags)
+    (lambda (&optional m)
+      (ring-insert (with-no-warnings find-tag-marker-ring) (or m (point-marker)))))
   "Compatibility shim for `xref-push-marker-stack'.")
 
 (defun counsel--find-symbol (x)

--- a/ivy.el
+++ b/ivy.el
@@ -1616,11 +1616,11 @@ like.")
   :type 'integer)
 
 (defalias 'ivy--dirname-p
-    (if (fboundp 'directory-name-p)
-        #'directory-name-p
-      (lambda (name)
-        "Return non-nil if NAME ends with a directory separator."
-        (string-match-p "/\\'" name))))
+  (if (fboundp 'directory-name-p)
+      #'directory-name-p
+    (lambda (name)
+      "Return non-nil if NAME ends with a directory separator."
+      (string-match-p "/\\'" name))))
 
 (defun ivy--sorted-files (dir)
   "Return the list of files in DIR.


### PR DESCRIPTION
* `CONTRIBUTING.org`: Suggest `common-lisp-indent-function` setting similar to that of `lisp-indent-function`.
* `counsel.el` (`counsel--push-xref-marker`):
* `ivy.el` (`ivy--dirname-p`): Reindent accordingly.

Re: #1601, #1602, #1612