### PR TITLE
Extend counsel-unquote-regex-parens tests

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -72,7 +72,7 @@ N is obtained from `counsel-more-chars-alist'."
                                                     (")" . "\\)")
                                                     ("\\{" . "{")
                                                     ("\\}" . "}"))))
-                                    (error "Unexpected")))
+                                    (error "Unexpected parenthesis: %S" s)))
                               str t t)))
 
 (defun counsel-directory-name (dir)

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -314,8 +314,16 @@ will bring the behavior in line with the newer Emacsen."
                   (ivy--regex "foo bar"))
                  "(foo).*?(bar)"))
   (should (equal (counsel-unquote-regex-parens
-                  (ivy--regex "(foo bar"))
-                 "(\\(foo).*?(bar)")))
+                  (ivy--regex "(foo bar)"))
+                 "(\\(foo).*?(bar\\))"))
+  (should (equal (counsel-unquote-regex-parens
+                  (ivy--regex "{foo bar}"))
+                 "({foo).*?(bar})"))
+  (should (equal (counsel-unquote-regex-parens "\\{foo bar\\}")
+                 "{foo bar}"))
+  (should (equal (counsel-unquote-regex-parens
+                  '(("foo") ("bar" . t) ("baz" . t)))
+                 "bar.*baz")))
 
 (defmacro ivy--string-buffer (text &rest body)
   "Test helper that wraps TEXT in a temp buffer while running BODY."


### PR DESCRIPTION
* `counsel.el` (`counsel-unquote-regex-parens`): Improve error message for case that should never happen(TM).
* `ivy-test.el` (`counsel-unquote-regex-parens`): Test cons argument and all supported parentheses.

Re: #1704