### PR TITLE
Add keys to counsel-grep

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2581,6 +2581,12 @@ RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
 (cl-pushnew 'counsel-rg ivy-highlight-grep-commands)
 
 ;;** `counsel-grep'
+(defvar counsel-grep-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-l") 'ivy-call-and-recenter)
+    (define-key map (kbd "M-q") 'swiper-query-replace)
+    map))
+
 (defcustom counsel-grep-base-command "grep -E -n -e %s %s"
   "Format string used by `counsel-grep' to build a shell command.
 It should contain two %-sequences (see function `format') to be
@@ -2675,6 +2681,7 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
                                          (line-beginning-position)
                                          (line-end-position)))))
 
+                             :keymap counsel-grep-map
                              :history 'counsel-git-grep-history
                              :update-fn (lambda ()
                                           (counsel-grep-action (ivy-state-current ivy-last)))


### PR DESCRIPTION
Counsel-grep is useful when browsing large files or when using old systems, but it's really irritating that you can't replace with counsel-grep like you can with swiper, forcing you to either bind a key for the replace command or start up swiper everytime you wan't to replace something. This fixes that problem and adds a few more keys for both counsel-grep and counsel-ag.