### PR TITLE
ivy.el (ivy-immediate-done): Exit with unchanged initial input

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -871,6 +871,22 @@ will bring the behavior in line with the newer Emacsen."
            '(read-directory-name "cd: " "/tmp")
            "RET"))))
 
+(ert-deftest ivy-read-file-name-in-buffer-visiting-file ()
+  "Test `ivy-immediate-done' command in `read-file-name' without any editing in
+a buffer visiting a file."
+  (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
+    (ivy-mode 1)
+    (should
+     (equal "~/dummy-dir/dummy-file" ;visiting file name, abbreviated form
+            (ivy-with
+             '(let ((insert-default-directory t))
+                (with-temp-buffer
+                  (set-visited-file-name "~/dummy-dir/dummy-file")
+                  (read-file-name "Load file: " nil nil 'lambda))) ;load-file
+             ;; No editing, just command ivy-immediate-done
+             "C-M-j")))
+    (ivy-mode ivy-mode-reset-arg)))
+
 (provide 'ivy-test)
 
 ;;; ivy-test.el ends here

--- a/ivy.el
+++ b/ivy.el
@@ -981,7 +981,9 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                 (if (and ivy--directory
                          (not (eq (ivy-state-history ivy-last)
                                   'grep-files-history)))
-                    (expand-file-name ivy-text ivy--directory)
+                    (if (string= ivy-text "")
+                        ivy--directory ; in abbreviated form if input not edited
+                      (expand-file-name ivy-text ivy--directory))
                   ivy-text)))
   (setq ivy-completion-beg ivy-completion-end)
   (setq ivy-exit 'done)

--- a/ivy.el
+++ b/ivy.el
@@ -981,8 +981,18 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                 (if (and ivy--directory
                          (not (eq (ivy-state-history ivy-last)
                                   'grep-files-history)))
-                    (if (string= ivy-text "")
-                        ivy--directory ; in abbreviated form if input not edited
+                    (if (and (string= ivy-text "")
+                             (eq (ivy-state-collection ivy-last)
+                                 #'read-file-name-internal))
+                        ;; For `read-file-name' compat, unchanged initial input
+                        ;; means that `ivy-read' shall return INITIAL-INPUT.
+                        ;; `read-file-name-default' `string-equal' return value
+                        ;; with provided INITIAL-INPUT to detect that the user
+                        ;; choose the default, `default-filename'.
+                        ;; We must return `ivy--directory' in unchanged form
+                        ;; in cased `ivy--directory' started out as
+                        ;; INITIAL-INPUT in abbreviated form.
+                        ivy--directory  ;unchanged (unexpanded)
                       (expand-file-name ivy-text ivy--directory))
                   ivy-text)))
   (setq ivy-completion-beg ivy-completion-end)


### PR DESCRIPTION
This change makes ivy-immediate-done (without any editing) to exit
completing-read with return value in same (abbreviated) form and value
as the initial input.

This fix functions read-file-name and read-directory-name to return the
default-filename with ivy-immediate-done, instead of current
input (expanded).

Fixes #1170