### PR TITLE
counsel.el (counsel-library-candidates): check dirs in `load-path` exists

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -891,33 +891,36 @@ when available, in that order of precedence."
         dir-parent
         res)
     (dolist (dir load-path)
-      (dolist (file (file-name-all-completions "" (or dir default-directory)))
-        (when (string-match suffix file)
-          (unless (string-match "pkg.elc?$" file)
-            (setq short-name (substring file 0 (match-beginning 0)))
-            (if (setq old-val (gethash short-name cands))
-                (progn
-                  ;; assume going up directory once will resolve name clash
-                  (setq dir-parent (counsel-directory-name (cdr old-val)))
-                  (puthash short-name
-                           (cons
-                            (counsel-string-compose dir-parent (car old-val))
-                            (cdr old-val))
-                           cands)
-                  (setq dir-parent (counsel-directory-name dir))
-                  (puthash (concat dir-parent short-name)
-                           (cons
-                            (propertize
-                             (counsel-string-compose
-                              dir-parent short-name)
-                             'full-name (expand-file-name file dir))
-                            dir)
-                           cands))
-              (puthash short-name
-                       (cons (propertize
-                              short-name
-                              'full-name (expand-file-name file dir))
-                             dir) cands))))))
+      (setq dir (or dir default-directory)) ;; interpret nil in load-path as default-directory
+      (when (file-directory-p dir)
+        (dolist (file (file-name-all-completions "" dir))
+          (when (string-match suffix file)
+            (unless (string-match "pkg.elc?$" file)
+              (setq short-name (substring file 0 (match-beginning 0)))
+              (if (setq old-val (gethash short-name cands))
+                  (progn
+                    ;; assume going up directory once will resolve name clash
+                    (setq dir-parent (counsel-directory-name (cdr old-val)))
+                    (puthash short-name
+                             (cons
+                              (counsel-string-compose dir-parent (car old-val))
+                              (cdr old-val))
+                             cands)
+                    (setq dir-parent (counsel-directory-name dir))
+                    (puthash (concat dir-parent short-name)
+                             (cons
+                              (propertize
+                               (counsel-string-compose
+                                dir-parent short-name)
+                               'full-name (expand-file-name file dir))
+                              dir)
+                             cands))
+                (puthash short-name
+                         (cons (propertize
+                                short-name
+                                'full-name (expand-file-name file dir))
+                               dir)
+                         cands)))))))
     (maphash (lambda (_k v) (push (car v) res)) cands)
     (nreverse res)))
 


### PR DESCRIPTION
This PR fixes the following issue for me:

`M-x counsel-find-library` causes the following error on macOS:
```
Debugger entered--Lisp error: (file-missing "Opening directory" "No such file or directory" "/Library/Application Support/Emacs/26.1/site-lisp")
  file-name-all-completions("" "/Library/Application Support/Emacs/26.1/site-lisp")
  (let ((--dolist-tail-- (file-name-all-completions "" (or dir default-directory)))) (while --dolist-tail-- (let ((file (car --dolist-tail--))) (if (string-match suffix file) (progn (if (string-match "pkg.elc?$" file) nil (setq short-name (substring file 0 (match-beginning 0))) (if (setq old-val (gethash short-name cands)) (progn (setq dir-parent (counsel-directory-name (cdr old-val))) (puthash short-name (cons (counsel-string-compose dir-parent (car old-val)) (cdr old-val)) cands) (setq dir-parent (counsel-directory-name dir)) (puthash (concat dir-parent short-name) (cons (propertize (counsel-string-compose dir-parent short-name) 'full-name (expand-file-name file dir)) dir) cands)) (puthash short-name (cons (propertize short-name 'full-name (expand-file-name file dir)) dir) cands))))) (setq --dolist-tail-- (cdr --dolist-tail--)))))
  (let ((dir (car --dolist-tail--))) (let ((--dolist-tail-- (file-name-all-completions "" (or dir default-directory)))) (while --dolist-tail-- (let ((file (car --dolist-tail--))) (if (string-match suffix file) (progn (if (string-match "pkg.elc?$" file) nil (setq short-name (substring file 0 (match-beginning 0))) (if (setq old-val (gethash short-name cands)) (progn (setq dir-parent (counsel-directory-name (cdr old-val))) (puthash short-name (cons (counsel-string-compose dir-parent (car old-val)) (cdr old-val)) cands) (setq dir-parent (counsel-directory-name dir)) (puthash (concat dir-parent short-name) (cons (propertize (counsel-string-compose dir-parent short-name) 'full-name (expand-file-name file dir)) dir) cands)) (puthash short-name (cons (propertize short-name 'full-name (expand-file-name file dir)) dir) cands))))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (setq --dolist-tail-- (cdr --dolist-tail--)))
  (while --dolist-tail-- (let ((dir (car --dolist-tail--))) (let ((--dolist-tail-- (file-name-all-completions "" (or dir default-directory)))) (while --dolist-tail-- (let ((file (car --dolist-tail--))) (if (string-match suffix file) (progn (if (string-match "pkg.elc?$" file) nil (setq short-name (substring file 0 (match-beginning 0))) (if (setq old-val (gethash short-name cands)) (progn (setq dir-parent (counsel-directory-name (cdr old-val))) (puthash short-name (cons (counsel-string-compose dir-parent (car old-val)) (cdr old-val)) cands) (setq dir-parent (counsel-directory-name dir)) (puthash (concat dir-parent short-name) (cons (propertize (counsel-string-compose dir-parent short-name) 'full-name (expand-file-name file dir)) dir) cands)) (puthash short-name (cons (propertize short-name 'full-name (expand-file-name file dir)) dir) cands))))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (setq --dolist-tail-- (cdr --dolist-tail--))))
  (let ((--dolist-tail-- load-path)) (while --dolist-tail-- (let ((dir (car --dolist-tail--))) (let ((--dolist-tail-- (file-name-all-completions "" (or dir default-directory)))) (while --dolist-tail-- (let ((file (car --dolist-tail--))) (if (string-match suffix file) (progn (if (string-match "pkg.elc?$" file) nil (setq short-name (substring file 0 (match-beginning 0))) (if (setq old-val (gethash short-name cands)) (progn (setq dir-parent (counsel-directory-name (cdr old-val))) (puthash short-name (cons (counsel-string-compose dir-parent (car old-val)) (cdr old-val)) cands) (setq dir-parent (counsel-directory-name dir)) (puthash (concat dir-parent short-name) (cons (propertize (counsel-string-compose dir-parent short-name) 'full-name (expand-file-name file dir)) dir) cands)) (puthash short-name (cons (propertize short-name 'full-name (expand-file-name file dir)) dir) cands))))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (setq --dolist-tail-- (cdr --dolist-tail--)))))
  (let ((suffix (concat (regexp-opt '(".el" ".el.gz") t) "\\'")) (cands (make-hash-table :test (function equal))) short-name old-val dir-parent res) (let ((--dolist-tail-- load-path)) (while --dolist-tail-- (let ((dir (car --dolist-tail--))) (let ((--dolist-tail-- (file-name-all-completions "" (or dir default-directory)))) (while --dolist-tail-- (let ((file (car --dolist-tail--))) (if (string-match suffix file) (progn (if (string-match "pkg.elc?$" file) nil (setq short-name (substring file 0 (match-beginning 0))) (if (setq old-val (gethash short-name cands)) (progn (setq dir-parent (counsel-directory-name (cdr old-val))) (puthash short-name (cons (counsel-string-compose dir-parent (car old-val)) (cdr old-val)) cands) (setq dir-parent (counsel-directory-name dir)) (puthash (concat dir-parent short-name) (cons (propertize (counsel-string-compose dir-parent short-name) 'full-name (expand-file-name file dir)) dir) cands)) (puthash short-name (cons (propertize short-name 'full-name (expand-file-name file dir)) dir) cands))))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (maphash (function (lambda (_k v) (setq res (cons (car v) res)))) cands) (nreverse res))
  counsel-library-candidates()
  counsel-find-library()
  funcall-interactively(counsel-find-library)
  call-interactively(counsel-find-library)
```

For some reason, `/Library/Application Support/Emacs/26.1/site-lisp` is in my load-path, but the dir doesn't exist.

Looking at `find-library`'s code, I see that it also runs `file-directory-p` (in `locate-file-completion-table`). Note: `find-library` works fine, it doesn't cause the same error as counsel-find-library