### PR TITLE
Strip properties from returned alist candidate

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -113,6 +113,10 @@ will bring the behavior in line with the newer Emacsen."
            (ivy-with '(ivy-read "test" '("aaab" "aaac"))
                      "a C-n <tab> C-m")
            "aaac"))
+  (should (equal-including-properties
+           (ivy-with '(ivy-read "test" '(("foo" . "bar")))
+                     "C-m")
+           "foo"))
   (should (equal
            (ivy-with '(ivy-read "test" '(("foo" . "bar")))
                      "asdf C-m")

--- a/ivy.el
+++ b/ivy.el
@@ -1833,9 +1833,8 @@ customizations apply to the current completion session."
           (unless (eq ivy-exit 'done)
             (ivy-recursive-restore)))
       (ivy-call)
-      (when (> (length (ivy-state-current ivy-last)) 0)
-        (remove-list-of-text-properties
-         0 1 '(idx) (ivy-state-current ivy-last))))))
+      (let ((cur (ivy-state-current ivy-last)))
+        (remove-list-of-text-properties 0 (length cur) '(idx) cur)))))
 
 (defun ivy--display-function-prop (prop)
   "Return PROP associated with current `ivy-display-function'."


### PR DESCRIPTION
Strip `idx` property from entire candidate returned.

* `ivy.el` (`ivy-read`): Strip `idx` property from entire candidate returned following 4ca87866037353cb0a0ddcab13d64ab48a9ccb71.
* `ivy-test.el` (`ivy-read`): Test `idx` property removal.

Re: #1706
Fixes #1724