### PR TITLE
ivy.el: Exit with empty input command ivy-empty-input-done

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -875,6 +875,80 @@ will bring the behavior in line with the newer Emacsen."
            '(read-directory-name "cd: " "/tmp")
            "RET"))))
 
+(ert-deftest ivy-empty-input-set-visited-file-name-ivy-immediate-done ()
+  "Test empty input and `set-visited-file-name' command to set current buffer
+visit no file using prefix argument and command `ivy-immediate-done'."
+  (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
+    (ivy-mode 1)
+    (should
+     (equal nil
+            (ivy-with
+             '(with-temp-buffer
+                (set-visited-file-name "~/dummy-dir/dummy-file")
+                (command-execute-setting-this-command
+                 'set-visited-file-name)
+                (not-modified)
+                buffer-file-name)
+             "random-dummy-file C-u C-M-j")))
+    (ivy-mode ivy-mode-reset-arg)))
+
+(ert-deftest ivy-empty-input-read-file-name-ivy-immediate-done ()
+  "Test empty input with `read-file-name' as caller and variations in
+DEFAULT-FILENAME using prefix argument and command `ivy-immediate-done'."
+  (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
+    (ivy-mode 1)
+    (should
+     (equal ""
+            (ivy-with
+             '(read-file-name "p" nil nil 'mustmatch nil)
+             "random-dummy-file C-u C-M-j")))
+    (should
+     (equal ""
+            (ivy-with
+             '(read-file-name "p" nil "dummy-file" 'mustmatch nil)
+             "random-dummy-file C-u C-M-j")))
+    (should
+     (equal ""
+            (ivy-with
+             '(read-file-name "p" nil '("dummy-file" "file2") 'mustmatch nil)
+             "random-dummy-file C-u C-M-j")))
+    (ivy-mode ivy-mode-reset-arg)))
+
+(ert-deftest ivy-empty-input-completing-read-ivy-immediate-done ()
+  "Test empty input with `completing-read' as caller and variations in DEF
+using prefix argument and command `ivy-immediate-done'."
+  (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
+    (ivy-mode 1)
+    ;; Text default
+    (should
+     (equal ""
+            (ivy-with
+             '(completing-read "p" '("a" "b") nil 'require-match nil nil nil)
+             "random-text C-u C-M-j")))
+    (should
+     (equal "c"
+            (ivy-with
+             '(completing-read "p" '("a" "b") nil 'require-match nil nil "c")
+             "random-text C-u C-M-j")))
+    (should
+     (equal "c"
+            (ivy-with
+             '(completing-read "p" '("a") nil 'require-match nil nil '("c" "d"))
+             "random-text C-u C-M-j")))
+    ;; Non-text default
+    (should
+     (eq 'c
+         (ivy-with
+          '(completing-read "p" nil nil 'require-match nil nil '(c d))
+          "random-text C-u C-M-j")))
+    (let ((def '((a b))))
+      (should
+       (eq (car def)
+           (ivy-with
+            (eval `'(completing-read "p" nil nil 'require-match nil nil ',def))
+            "random-textx C-u C-M-j"))))
+    (ivy-mode ivy-mode-reset-arg)))
+
 (provide 'ivy-test)
 
 ;;; ivy-test.el ends here

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -875,9 +875,9 @@ will bring the behavior in line with the newer Emacsen."
            '(read-directory-name "cd: " "/tmp")
            "RET"))))
 
-(ert-deftest ivy-empty-input-set-visited-file-name-ivy-immediate-done ()
+(ert-deftest ivy-empty-input-set-visited-file-name-ivy-empty-input-done ()
   "Test empty input and `set-visited-file-name' command to set current buffer
-visit no file using prefix argument and command `ivy-immediate-done'."
+visit no file using prefix argument and command `ivy-empty-input-done'."
   (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
     (ivy-mode 1)
     (should
@@ -889,34 +889,34 @@ visit no file using prefix argument and command `ivy-immediate-done'."
                  'set-visited-file-name)
                 (not-modified)
                 buffer-file-name)
-             "random-dummy-file C-u C-M-j")))
+             "random-dummy-file C-M-S-j")))
     (ivy-mode ivy-mode-reset-arg)))
 
-(ert-deftest ivy-empty-input-read-file-name-ivy-immediate-done ()
+(ert-deftest ivy-empty-input-read-file-name-ivy-empty-input-done ()
   "Test empty input with `read-file-name' as caller and variations in
-DEFAULT-FILENAME using prefix argument and command `ivy-immediate-done'."
+DEFAULT-FILENAME using prefix argument and command `ivy-empty-input-done'."
   (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
     (ivy-mode 1)
     (should
      (equal ""
             (ivy-with
              '(read-file-name "p" nil nil 'mustmatch nil)
-             "random-dummy-file C-u C-M-j")))
+             "random-dummy-file C-M-S-j")))
     (should
      (equal ""
             (ivy-with
              '(read-file-name "p" nil "dummy-file" 'mustmatch nil)
-             "random-dummy-file C-u C-M-j")))
+             "random-dummy-file C-M-S-j")))
     (should
      (equal ""
             (ivy-with
              '(read-file-name "p" nil '("dummy-file" "file2") 'mustmatch nil)
-             "random-dummy-file C-u C-M-j")))
+             "random-dummy-file C-M-S-j")))
     (ivy-mode ivy-mode-reset-arg)))
 
-(ert-deftest ivy-empty-input-completing-read-ivy-immediate-done ()
+(ert-deftest ivy-empty-input-completing-read-ivy-empty-input-done ()
   "Test empty input with `completing-read' as caller and variations in DEF
-using prefix argument and command `ivy-immediate-done'."
+using prefix argument and command `ivy-empty-input-done'."
   (let ((ivy-mode-reset-arg (if ivy-mode 1 0)))
     (ivy-mode 1)
     ;; Text default
@@ -924,29 +924,29 @@ using prefix argument and command `ivy-immediate-done'."
      (equal ""
             (ivy-with
              '(completing-read "p" '("a" "b") nil 'require-match nil nil nil)
-             "random-text C-u C-M-j")))
+             "random-text C-M-S-j")))
     (should
      (equal "c"
             (ivy-with
              '(completing-read "p" '("a" "b") nil 'require-match nil nil "c")
-             "random-text C-u C-M-j")))
+             "random-text C-M-S-j")))
     (should
      (equal "c"
             (ivy-with
              '(completing-read "p" '("a") nil 'require-match nil nil '("c" "d"))
-             "random-text C-u C-M-j")))
+             "random-text C-M-S-j")))
     ;; Non-text default
     (should
      (eq 'c
          (ivy-with
           '(completing-read "p" nil nil 'require-match nil nil '(c d))
-          "random-text C-u C-M-j")))
+          "random-text C-M-S-j")))
     (let ((def '((a b))))
       (should
        (eq (car def)
            (ivy-with
             (eval `'(completing-read "p" nil nil 'require-match nil nil ',def))
-            "random-textx C-u C-M-j"))))
+            "random-textx C-M-S-j"))))
     (ivy-mode ivy-mode-reset-arg)))
 
 (provide 'ivy-test)

--- a/ivy.el
+++ b/ivy.el
@@ -384,6 +384,7 @@ action functions.")
     (define-key map (kbd "C-c C-a") 'ivy-toggle-ignore)
     (define-key map (kbd "C-c C-s") 'ivy-rotate-sort)
     (define-key map [remap describe-mode] 'ivy-help)
+    (define-key map (kbd "C-M-S-j") 'ivy-empty-input-done)
     map)
   "Keymap used in the minibuffer.")
 (autoload 'hydra-ivy/body "ivy-hydra" "" t)
@@ -977,26 +978,27 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
 (defvar ivy-completion-end nil
   "Completion bounds end.")
 
-(defun ivy-immediate-done (&optional arg)
-  "Exit the minibuffer with current input instead of current candidate.
-When ARG is non-nil, exit with empty input."
-  (interactive "P")
-  (if arg
-      (ivy--empty-input-done)
-    (delete-minibuffer-contents)
-    (insert (setf (ivy-state-current ivy-last)
-                  (if (and ivy--directory
-                           (not (eq (ivy-state-history ivy-last)
-                                    'grep-files-history)))
-                      (expand-file-name ivy-text ivy--directory)
-                    ivy-text)))
-    (setq ivy-completion-beg ivy-completion-end)
-    (setq ivy-exit 'done)
-    (exit-minibuffer)))
+(defun ivy-immediate-done ()
+  "Exit the minibuffer with current input instead of current candidate."
+  (interactive)
+  (delete-minibuffer-contents)
+  (insert (setf (ivy-state-current ivy-last)
+                (if (and ivy--directory
+                         (not (eq (ivy-state-history ivy-last)
+                                  'grep-files-history)))
+                    (expand-file-name ivy-text ivy--directory)
+                  ivy-text)))
+  (setq ivy-completion-beg ivy-completion-end)
+  (setq ivy-exit 'done)
+  (exit-minibuffer))
 
-(defun ivy--empty-input-done ()
+(defun ivy-empty-input-done ()
   "Exit the minibuffer with empty input.
+This command will explicitly exit with empty input regardless of what's been
+provided or entered.
+
 Empty input is either the callers default or \"\" if such default is nil."
+  (interactive)
   (delete-minibuffer-contents)
   (let ((def (ivy-state-initial-def ivy-last)))
     ;; For `completing-read' compat, empty input means that


### PR DESCRIPTION
### This is an alternative to PR #1721

### ivy.el (ivy-immediate-done): Restore, add command ivy-empty-input-done
* Add command ivy-empty-input-done to exit with empty input
* Bind ivy-empty-input-done to "C-M-S-j"
* Restore command ivy-immediate-done
* ivy-test.el: Add relevant positive tests