### PR TITLE
Add support for counsel-locate over tramp

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2238,7 +2238,8 @@ INITIAL-INPUT can be given as the initial minibuffer input."
             :action (lambda (file)
                       (when file
                         (with-ivy-window
-                          (find-file file))))
+                          (find-file
+                           (concat (file-remote-p default-directory) file)))))
             :unwind #'counsel-delete-process
             :caller 'counsel-locate))
 


### PR DESCRIPTION
This allows `counsel-locate` to properly open files when in a tramp buffer, previously, it would open the remote file path on the local machine.

Is there a custom way of getting the default directory in ivy? `ivy--directory` appears to be nil in this function.