### PR TITLE
Highlight outside modified file buffers

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -108,6 +108,10 @@
   '((t :inherit default))
   "Face used by Ivy for highlighting modified file visiting buffers.")
 
+(defface ivy-outside-modified-buffer
+  '((t :inherit default))
+  "Face used by Ivy for highlighting outside modified file visiting buffers.")
+
 (defface ivy-remote
   '((((class color) (background light))
      :foreground "#110099")
@@ -3799,10 +3803,14 @@ Skip buffers that match `ivy-ignore-buffers'."
 (defun ivy-switch-buffer-transformer (str)
   "Transform candidate STR when switching buffers."
   (let ((b (get-buffer str)))
-    (if (and b
-             (buffer-file-name b)
-             (buffer-modified-p b))
-        (ivy-append-face str 'ivy-modified-buffer)
+    (if (and b (buffer-file-name b))
+        (cond
+         ((buffer-modified-p b)
+          (ivy-append-face str 'ivy-modified-buffer))
+         ((and (not (file-remote-p (buffer-file-name b)))
+               (not (verify-visited-file-modtime b)))
+          (ivy-append-face str 'ivy-outside-modified-buffer))
+         (t str))
       str)))
 
 (defun ivy-switch-buffer-occur ()


### PR DESCRIPTION
with 'ivy-outside-modified-buffer face.

Fixes #1740

![image](https://user-images.githubusercontent.com/238681/45032058-b0ec0280-b08b-11e8-9858-9765b2d562ba.png)

EDIT: I don't have copyright assignment, but I think the change is small.