### PR TITLE
Ignore non-readable desktop files

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4644,7 +4644,7 @@ This function always returns its elements in a stable order."
         (let ((dir (file-name-as-directory dir)))
           (dolist (file (directory-files-recursively dir ".*\\.desktop$"))
             (let ((id (subst-char-in-string ?/ ?- (file-relative-name file dir))))
-              (unless (gethash id hash)
+              (when (and (not (gethash id hash)) (file-readable-p file))
                 (push (cons id file) result)
                 (puthash id file hash)))))))
     result))


### PR DESCRIPTION
* counsel.el (counsel-linux-apps-list-desktop-files): Make sure a
  desktop file is readable before adding it to the list. Otherwise,
  doing so would break high-level commands. A file can exist and be
  non-readable, e.g., symlinks to non-existing files.