### PR TITLE
counsel.el: fix xdg-open under Ubuntu for counsel-locate-action-extern

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2171,7 +2171,11 @@ string - the full shell command to run."
                                          (cl-case system-type
                                            (darwin "open")
                                            (cygwin "cygstart")
-                                           (t "xdg-open"))
+                                           (t (if (string-match-p
+						   (regexp-quote "Ubuntu")
+						   (shell-command-to-string "lsb_release -d"))
+						  "setsid -w xdg-open"
+						"xdg-open")))
                                          (shell-quote-argument x)))))
 
 (defalias 'counsel-find-file-extern #'counsel-locate-action-extern)


### PR DESCRIPTION
`start-process-shell-command` doesn't seem to wait for `counsel-locate-action-extern` to finish under Ubuntu. [Gist to reproduce the issue](https://gist.github.com/yiufung/38be4c3a6832334f36f2441550cf0b12). 

Related discussions ([#1](https://askubuntu.com/questions/646631/emacs-doesnot-work-with-xdg-open), [#2](https://emacs.stackexchange.com/questions/19344/why-does-xdg-open-not-work-in-eshell), [#3](http://emacs.1067599.n8.nabble.com/emacs-and-xdg-open-td106892.html)) suggest to:

1. Set `process-connection-type` as nil temporarily
2. Called with `setsid -w` to wait for the process to finish. 

To avoid interfering with other platforms and applications, I adopted the latter approach which uses `lsb_release` to check distribution type with fall back as `xdg-open`. Currently only check for Ubuntu, and to be extended in the future. 

Related issues: #863 and #1401. 