### PR TITLE
Allow counsel-yank-pop after point

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3586,20 +3586,19 @@ candidates.
 Note: Duplicate elements of `kill-ring' are always deleted."
   ;; Do not specify `*' to allow browsing `kill-ring' in read-only buffers
   (interactive "P")
-  (let ((ivy-format-function #'counsel--yank-pop-format-function)
-        (kills (counsel--yank-pop-kills)))
-    (unless kills
-      (error "Kill ring is empty or blank"))
+  (let ((kills (or (counsel--yank-pop-kills)
+                   (error "Kill ring is empty or blank")))
+        (preselect (let (interprogram-paste-function)
+                     (current-kill (cond (arg (prefix-numeric-value arg))
+                                         (counsel-yank-pop-preselect-last 0)
+                                         (t 1))
+                                   t)))
+        (ivy-format-function #'counsel--yank-pop-format-function))
     (unless (eq last-command 'yank)
       (push-mark))
     (ivy-read "kill-ring: " kills
               :require-match t
-              :preselect (let (interprogram-paste-function)
-                           (current-kill (cond
-                                           (arg (prefix-numeric-value arg))
-                                           (counsel-yank-pop-preselect-last 0)
-                                           (t 1))
-                                         t))
+              :preselect preselect
               :action #'counsel-yank-pop-action
               :caller 'counsel-yank-pop)))
 

--- a/counsel.el
+++ b/counsel.el
@@ -3532,8 +3532,7 @@ buffer position."
     (setq yank-window-start (window-start))
     ;; Avoid unexpected additions to `kill-ring'
     (let (interprogram-paste-function)
-      (yank-pop (counsel--yank-pop-position s)))
-    (setq ivy-completion-end (point))))
+      (yank-pop (counsel--yank-pop-position s)))))
 
 (defun counsel-yank-pop-action-remove (s)
   "Remove all occurrences of S from the kill ring."
@@ -3593,8 +3592,6 @@ Note: Duplicate elements of `kill-ring' are always deleted."
       (error "Kill ring is empty or blank"))
     (unless (eq last-command 'yank)
       (push-mark))
-    (setq ivy-completion-beg (mark t))
-    (setq ivy-completion-end (point))
     (ivy-read "kill-ring: " kills
               :require-match t
               :preselect (let (interprogram-paste-function)


### PR DESCRIPTION
See #1761 for precedents. I have tried to make each commit atomic, so reviewing them in turn should be easiest.

**N.B.** The last commit introduces a user-visible breaking change. Previously, `counsel-yank-pop` interpreted any prefix argument as a number, e.g. <kbd>C-u</kbd> and <kbd>M-4</kbd> both yanked the 4th previous kill. Now, plain prefix arguments like <kbd>C-u</kbd> are interpreted similarly to vanilla `yank`, in that they temporarily toggle the new `counsel-yank-pop-after-point`. The following are my justifications for this:
1. Using <kbd>C-u</kbd> for this purpose is natural because it acquires effectively the same meaning as for vanilla `yank`.
2. <kbd>C-u</kbd><kbd>4</kbd> and <kbd>M-4</kbd> are not terribly different to or more difficult than plain <kbd>C-u</kbd>, and I doubt many people were using the latter with `counsel-yank-pop`, as it's simultaneously a very specific kill ring position, but also large enough to be relatively arbitrary/obscure.
3. I find it quite unlikely that users of `counsel-yank-pop` rely on the exponential nature of repeated <kbd>C-u</kbd> invocations to quickly yank the 16th, 64th, etc. kill.