### PR TITLE
counsel.el: Respect split string setting when doing grep-like occur.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1494,7 +1494,7 @@ When REVERT is non-nil, regenerate the current *ivy-occur* buffer."
          cands)
     (setq cands (split-string
                  (shell-command-to-string cmd)
-                 "\n"
+                 counsel-async-split-string-re
                  t))
     ;; Need precise number of header lines for `wgrep' to work.
     (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
@@ -2550,7 +2550,9 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
                        (shell-quote-argument
                         (counsel-unquote-regex-parens
                          (ivy--regex (cdr command-args)))))))
-         (cands (split-string (shell-command-to-string cmd) "\n" t)))
+         (cands (split-string (shell-command-to-string cmd)
+                              counsel-async-split-string-re
+                              t)))
     ;; Need precise number of header lines for `wgrep' to work.
     (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
                     default-directory))


### PR DESCRIPTION
(counsel-grep-like-occur, counsel-git-grep-occur): Respect user
setting of `counsel-async-split-string-re' when doing grep-like occur,
so as to better support `wgrep'.

Fixes #1384
---
Hi,

As mentioned in #1384, after setting `(setq counsel-async-split-string-re "\r?\n")` it does work for `counsel-ag` itself,
but there are still `^M` when doing occur. So this PR tries to fix it.

Don't know if it's appropriate to use `counsel-async-split-string-re` for `counsel-git-grep-occur`,
as git grep isn't an async command IIUC.
