### PR TITLE
Remove swiperall magic number

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -45,20 +45,9 @@
 (require 'dired)
 
 ;;* Utility
-(defvar counsel-more-chars-alist
-  '((counsel-grep . 2)
-    (t . 3))
-  "Map commands to their minimum required input length.
-That is the number of characters prompted for before fetching
-candidates.  The special key t is used as a fallback.")
+(define-obsolete-variable-alias 'counsel-more-chars-alist 'ivy-more-chars-alist "0.10.0")
 
-(defun counsel-more-chars ()
-  "Return two fake candidates prompting for at least N input.
-N is obtained from `counsel-more-chars-alist'."
-  (let ((diff (- (ivy-alist-setting counsel-more-chars-alist)
-                 (length ivy-text))))
-    (when (> diff 0)
-      (list "" (format "%d chars more" diff)))))
+(define-obsolete-function-alias 'counsel-more-chars 'ivy-more-chars "0.10.0")
 
 (defun counsel-unquote-regex-parens (str)
   "Unquote regexp parentheses in STR."
@@ -1247,7 +1236,7 @@ Typical value: '(recenter)."
   "Grep in the current git repository for STRING."
   (or
    (and (> counsel--git-grep-count counsel--git-grep-count-threshold)
-        (counsel-more-chars))
+        (ivy-more-chars))
    (let* ((default-directory (ivy-state-directory ivy-last))
           (cmd (format counsel-git-grep-cmd
                        (setq ivy--old-re (ivy--regex str t)))))
@@ -1390,7 +1379,7 @@ INITIAL-INPUT can be given as the initial minibuffer input."
 (defun counsel-git-grep-proj-function (str)
   "Grep for STR in the current git repository."
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (let ((regex (setq ivy--old-re
                       (ivy--regex str t))))
      (counsel--async-command (format counsel-git-grep-cmd regex))
@@ -1561,7 +1550,7 @@ done") "\n" t)))
 (defun counsel-git-log-function (str)
   "Search for STR in git log."
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (progn
      ;; `counsel--yank-pop-format-function' uses this
      (setq ivy--old-re (funcall ivy--regex-function str))
@@ -2210,7 +2199,7 @@ string - the full shell command to run."
 (defun counsel-locate-function (input)
   "Call the \"locate\" shell command with INPUT."
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (progn
      (counsel--async-command
       (funcall counsel-locate-cmd input))
@@ -2487,7 +2476,7 @@ NEEDLE is the search string."
           (search-term (cdr command-args)))
       (if (< (length search-term) 3)
           (let ((ivy-text search-term))
-            (counsel-more-chars))
+            (ivy-more-chars))
         (let ((default-directory (ivy-state-directory ivy-last))
               (regex (counsel-unquote-regex-parens
                       (setq ivy--old-re
@@ -2651,7 +2640,7 @@ substituted by the search regexp and file, respectively.  Neither
 (defun counsel-grep-function (string)
   "Grep in the current directory for STRING."
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (let ((regex (counsel-unquote-regex-parens
                  (setq ivy--old-re
                        (ivy--regex string)))))
@@ -2775,7 +2764,7 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
 (defun counsel-recoll-function (str)
   "Run recoll for STR."
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (progn
      (counsel--async-command
       (format "recoll -t -b %s"

--- a/counsel.el
+++ b/counsel.el
@@ -2474,17 +2474,17 @@ NEEDLE is the search string."
   (let ((command-args (counsel--split-command-args string)))
     (let ((switches (car command-args))
           (search-term (cdr command-args)))
-      (if (< (length search-term) 3)
-          (let ((ivy-text search-term))
-            (ivy-more-chars))
-        (let ((default-directory (ivy-state-directory ivy-last))
-              (regex (counsel-unquote-regex-parens
-                      (setq ivy--old-re
-                            (ivy--regex search-term)))))
-          (counsel--async-command (counsel--format-ag-command
-                                   switches
-                                   (shell-quote-argument regex)))
-          nil)))))
+      (or
+       (let ((ivy-text search-term))
+         (ivy-more-chars))
+       (let ((default-directory (ivy-state-directory ivy-last))
+             (regex (counsel-unquote-regex-parens
+                     (setq ivy--old-re
+                           (ivy--regex search-term)))))
+         (counsel--async-command (counsel--format-ag-command
+                                  switches
+                                  (shell-quote-argument regex)))
+         nil)))))
 
 ;;;###autoload
 (defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt)

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -1239,7 +1239,7 @@ narrowing) or select a candidate from the visible collection.
 #+begin_src elisp
 (defun counsel-locate-function (str)
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (progn
      (counsel--async-command
       (format "locate %s '%s'"
@@ -1272,7 +1272,7 @@ that they appear:
   of strings. Note that it's not compatible with =all-completions=,
   but since we're not using that here, might as well use one argument
   instead of three.
-- =counsel-more-chars= is a simple function that returns e.g.
+- =ivy-more-chars= is a simple function that returns e.g.
   ='("2 chars more")= asking the user for more input.
 - =counsel--async-command= is a very easy API simplification that
   takes a single string argument suitable for

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -1635,7 +1635,7 @@ narrowing) or select a candidate from the visible collection.
 @lisp
 (defun counsel-locate-function (str)
   (or
-   (counsel-more-chars)
+   (ivy-more-chars)
    (progn
      (counsel--async-command
       (format "locate %s '%s'"
@@ -1671,7 +1671,7 @@ of strings. Note that it's not compatible with @code{all-completions},
 but since we're not using that here, might as well use one argument
 instead of three.
 @item
-@code{counsel-more-chars} is a simple function that returns e.g.
+@code{ivy-more-chars} is a simple function that returns e.g.
 @code{'("2 chars more")} asking the user for more input.
 @item
 @code{counsel--async-command} is a very easy API simplification that

--- a/ivy.el
+++ b/ivy.el
@@ -229,6 +229,21 @@ Examples of properties include associated `:cleanup' functions.")
 (defvar ivy-completing-read-dynamic-collection nil
   "Run `ivy-completing-read' with `:dynamic-collection t`.")
 
+(defvar ivy-more-chars-alist
+  '((counsel-grep . 2)
+    (t . 3))
+  "Map commands to their minimum required input length.
+That is the number of characters prompted for before fetching
+candidates.  The special key t is used as a fallback.")
+
+(defun ivy-more-chars ()
+  "Return two fake candidates prompting for at least N input.
+N is obtained from `ivy-more-chars-alist'."
+  (let ((diff (- (ivy-alist-setting ivy-more-chars-alist)
+                 (length ivy-text))))
+    (when (> diff 0)
+      (list "" (format "%d chars more" diff)))))
+
 (defcustom ivy-completing-read-handlers-alist
   '((tmm-menubar . completing-read-default)
     (tmm-shortcut . completing-read-default)

--- a/swiper.el
+++ b/swiper.el
@@ -913,40 +913,40 @@ otherwise continue prompting for buffers."
 ;;* `swiper-all'
 (defun swiper-all-function (str)
   "Search in all open buffers for STR."
-  (if (and (< (length str) 3))
-      (list "" (format "%d chars more" (- 3 (length ivy-text))))
-    (let* ((buffers (cl-remove-if-not #'swiper-all-buffer-p (buffer-list)))
-           (re-full (funcall ivy--regex-function str))
-           re re-tail
-           cands match
-           (case-fold-search (ivy--case-fold-p str)))
-      (if (stringp re-full)
-          (setq re re-full)
-        (setq re (caar re-full))
-        (setq re-tail (cdr re-full)))
-      (dolist (buffer buffers)
-        (with-current-buffer buffer
-          (save-excursion
-            (goto-char (point-min))
-            (while (re-search-forward re nil t)
-              (setq match (if (memq major-mode '(org-mode dired-mode))
-                              (buffer-substring-no-properties
-                               (line-beginning-position)
-                               (line-end-position))
-                            (buffer-substring
-                             (line-beginning-position)
-                             (line-end-position))))
-              (put-text-property
-               0 1 'buffer
-               (buffer-name)
-               match)
-              (put-text-property 0 1 'point (point) match)
-              (when (or (null re-tail) (ivy-re-match re-tail match))
-                (push match cands))))))
-      (setq ivy--old-re re-full)
-      (if (null cands)
-          (list "")
-        (setq ivy--old-cands (nreverse cands))))))
+  (or
+   (ivy-more-chars)
+   (let* ((buffers (cl-remove-if-not #'swiper-all-buffer-p (buffer-list)))
+          (re-full (funcall ivy--regex-function str))
+          re re-tail
+          cands match
+          (case-fold-search (ivy--case-fold-p str)))
+     (if (stringp re-full)
+         (setq re re-full)
+       (setq re (caar re-full))
+       (setq re-tail (cdr re-full)))
+     (dolist (buffer buffers)
+       (with-current-buffer buffer
+         (save-excursion
+           (goto-char (point-min))
+           (while (re-search-forward re nil t)
+             (setq match (if (memq major-mode '(org-mode dired-mode))
+                             (buffer-substring-no-properties
+                              (line-beginning-position)
+                              (line-end-position))
+                           (buffer-substring
+                            (line-beginning-position)
+                            (line-end-position))))
+             (put-text-property
+              0 1 'buffer
+              (buffer-name)
+              match)
+             (put-text-property 0 1 'point (point) match)
+             (when (or (null re-tail) (ivy-re-match re-tail match))
+               (push match cands))))))
+     (setq ivy--old-re re-full)
+     (if (null cands)
+         (list "")
+       (setq ivy--old-cands (nreverse cands))))))
 
 (defvar swiper-window-width 80)
 


### PR DESCRIPTION
Move counsel-more-chars-alist and counsel-more-chars to ivy.el.

I moved it there because it was reimplemented for swiper-all.

Unify the way counsel-more-chars is called, and remove a few remaining hardcoded values by the occasion.




this is one half of #1030