### PR TITLE
A color-moccur like display of counsel-ag/rg results.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2580,12 +2580,9 @@ CALLER is forwarded to `ivy-read'."
               :caller caller)))
 
 (defun counsel-ag--split-match (candidate)
-  "Example usage:
-
-(counsel-ag--split-match \"ivy.el:4134:(defun counsel-ag--split-match (candidate)\") is (\"ivy.el\" \"4134\" \"(defun counsel-ag--split-match (candidate)\")"
   (let ((split (split-string candidate ":")))
     (when split
-      (list (car split) (cadr split) (mapconcat 'identity (nthcdr 2 split) ":")))))
+      (list (car split) (cadr split) (mapconcat #'identity (nthcdr 2 split) ":")))))
 
 (defun counsel-ag--display-match (loc-info text)
   (let ((current-line-display))

--- a/counsel.el
+++ b/counsel.el
@@ -2569,8 +2569,7 @@ CALLER is forwarded to `ivy-read'."
   (let ((default-directory (or initial-directory
                                (locate-dominating-file default-directory ".git")
                                default-directory)))
-    (ivy-read (or ag-prompt
-                  (concat (car (split-string counsel-ag-command)) ": "))
+    (ivy-read (or ag-prompt (concat (car (split-string counsel-ag-command)) ": "))
               #'counsel-ag-function
               :initial-input initial-input
               :dynamic-collection t

--- a/counsel.el
+++ b/counsel.el
@@ -2629,7 +2629,6 @@ CALLER is forwarded to `ivy-read'."
 
 (cl-defmacro def-counsel-ag-command (name &key tool-name base-command-variable-name)
   (declare (indent 1))
-  (or (boundp base-command-variable-name) (error "Variable %S not defined" base-command-variable-name))
   `(progn
      (autoload ',name "counsel" "" t)
      (defun ,name (&optional initial-input initial-directory extra-args prompt)

--- a/counsel.el
+++ b/counsel.el
@@ -1251,9 +1251,7 @@ Typical value: '(recenter)."
        (setq line-number (match-string-no-properties 2 x)))
       ((string-match "\\` \\([0-9]+\\)\\(.*\\)\\'" x)
        (setq line-number (match-string-no-properties 1 x))
-       (with-current-buffer ivy--occur-press-orig-buffer
-         (re-search-backward "^file: \\(.*\\)$")
-         (setq file-name (match-string-no-properties 1)))))
+       (setq file-name (get-text-property 0 'file x))))
     (find-file (expand-file-name
                 file-name
                 (ivy-state-directory ivy-last)))
@@ -2618,8 +2616,10 @@ CALLER is forwarded to `ivy-read'."
         (unless (string= current-file (car-safe current-line))
           (setq current-file (car-safe current-line))
           (insert "file: " current-file "\n"))
-        (insert (counsel-ag--display-match (cadr current-line)
-                                           (caddr current-line))
+        (insert (propertize
+                 (counsel-ag--display-match (cadr current-line)
+                                            (caddr current-line))
+                 'file current-file)
                 "\n")
         (incf count)))
     (goto-char (point-min))

--- a/counsel.el
+++ b/counsel.el
@@ -1244,20 +1244,27 @@ Typical value: '(recenter)."
 
 (defun counsel-git-grep-action (x)
   "Go to occurrence X in current Git repository."
-  (when (string-match "\\`\\(.*?\\):\\([0-9]+\\):\\(.*\\)\\'" x)
-    (let ((file-name (match-string-no-properties 1 x))
-          (line-number (match-string-no-properties 2 x)))
-      (find-file (expand-file-name
-                  file-name
-                  (ivy-state-directory ivy-last)))
-      (goto-char (point-min))
-      (forward-line (1- (string-to-number line-number)))
-      (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
-      (swiper--ensure-visible)
-      (run-hooks 'counsel-grep-post-action-hook)
-      (unless (eq ivy-exit 'done)
-        (swiper--cleanup)
-        (swiper--add-overlays (ivy--regex ivy-text))))))
+  (let (file-name line-number)
+    (cond
+      ((string-match "\\`\\(.*?\\):\\([0-9]+\\):\\(.*\\)\\'" x)
+       (setq file-name (match-string-no-properties 1 x))
+       (setq line-number (match-string-no-properties 2 x)))
+      ((string-match "\\` \\([0-9]+\\)\\(.*\\)\\'" x)
+       (setq line-number (match-string-no-properties 1 x))
+       (with-current-buffer ivy--occur-press-orig-buffer
+         (re-search-backward "^file: \\(.*\\)$")
+         (setq file-name (match-string-no-properties 1)))))
+    (find-file (expand-file-name
+                file-name
+                (ivy-state-directory ivy-last)))
+    (goto-char (point-min))
+    (forward-line (1- (string-to-number line-number)))
+    (re-search-forward (ivy--regex ivy-text t) (line-end-position) t)
+    (swiper--ensure-visible)
+    (run-hooks 'counsel-grep-post-action-hook)
+    (unless (eq ivy-exit 'done)
+      (swiper--cleanup)
+      (swiper--add-overlays (ivy--regex ivy-text)))))
 
 (defun counsel-git-grep-matcher (regexp candidates)
   "Return REGEXP matching CANDIDATES for `counsel-git-grep'."
@@ -2537,12 +2544,13 @@ NEEDLE is the search string."
          nil)))))
 
 ;;;###autoload
-(defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt)
+(defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt caller)
   "Grep for a string in the current directory using ag.
 INITIAL-INPUT can be given as the initial minibuffer input.
 INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
 EXTRA-AG-ARGS string, if non-nil, is appended to `counsel-ag-base-command'.
-AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
+AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument.
+CALLER is forwarded to `ivy-read'."
   (interactive)
   (setq counsel-ag-command counsel-ag-base-command)
   (counsel-require-program (car (split-string counsel-ag-command)))
@@ -2572,7 +2580,29 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
               :unwind (lambda ()
                         (counsel-delete-process)
                         (swiper--cleanup))
-              :caller 'counsel-ag)))
+              :caller caller)))
+
+(cl-defmacro def-counsel-ag-command (name &key tool-name base-command-variable-name)
+  (declare (indent 1))
+  (or (boundp base-command-variable-name) (error "Variable %S not defined" base-command-variable-name))
+  `(progn
+     (autoload ',name "counsel" "" t)
+     (defun ,name (&optional initial-input initial-directory extra-args prompt)
+       ,(format
+         "Grep for a string in the current directory using %s.
+INITIAL-INPUT can be given as the initial minibuffer input.
+INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
+EXTRA-ARGS string, if non-nil, is appended to `%s'.
+PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
+         tool-name
+         base-command-variable-name)
+       (interactive)
+       (let ((counsel-ag-base-command ,base-command-variable-name))
+         (counsel-ag initial-input initial-directory extra-args prompt ',name)))
+     (unless (plist-get ivy--occurs-list ',name)
+       ;; do not override user configuration
+       (ivy-set-occur ',name 'counsel-ag-occur))
+     (cl-pushnew ',name ivy-highlight-grep-commands)))
 
 (cl-pushnew 'counsel-ag ivy-highlight-grep-commands)
 
@@ -2610,16 +2640,9 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   :type 'string
   :group 'ivy)
 
-;;;###autoload
-(defun counsel-pt (&optional initial-input)
-  "Grep for a string in the current directory using pt.
-INITIAL-INPUT can be given as the initial minibuffer input.
-This uses `counsel-ag' with `counsel-pt-base-command' instead of
-`counsel-ag-base-command'."
-  (interactive)
-  (let ((counsel-ag-base-command counsel-pt-base-command))
-    (counsel-ag initial-input)))
-(cl-pushnew 'counsel-pt ivy-highlight-grep-commands)
+(def-counsel-ag-command counsel-pt
+  :tool-name pt
+  :base-command-variable-name counsel-pt-base-command)
 
 ;;** `counsel-ack'
 (defcustom counsel-ack-base-command
@@ -2631,16 +2654,9 @@ This uses `counsel-ag' with `counsel-pt-base-command' instead of
   :type 'string
   :group 'ivy)
 
-;;;###autoload
-(defun counsel-ack (&optional initial-input)
-  "Grep for a string in the current directory using ack.
-INITIAL-INPUT can be given as the initial minibuffer input.
-This uses `counsel-ag' with `counsel-ack-base-command' replacing
-`counsel-ag-base-command'."
-  (interactive)
-  (let ((counsel-ag-base-command counsel-ack-base-command))
-    (counsel-ag initial-input)))
-
+(def-counsel-ag-command counsel-ack
+  :tool-name ack
+  :base-command-variable-name counsel-ack-base-command)
 
 ;;** `counsel-rg'
 (defcustom counsel-rg-base-command "rg -S --no-heading --line-number --color never %s ."
@@ -2651,20 +2667,11 @@ Note: don't use single quotes for the regex."
   :group 'ivy)
 
 (counsel-set-async-exit-code 'counsel-rg 1 "No matches found")
-(ivy-set-occur 'counsel-rg 'counsel-ag-occur)
 (ivy-set-display-transformer 'counsel-rg 'counsel-git-grep-transformer)
 
-;;;###autoload
-(defun counsel-rg (&optional initial-input initial-directory extra-rg-args rg-prompt)
-  "Grep for a string in the current directory using rg.
-INITIAL-INPUT can be given as the initial minibuffer input.
-INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
-EXTRA-RG-ARGS string, if non-nil, is appended to `counsel-rg-base-command'.
-RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
-  (interactive)
-  (let ((counsel-ag-base-command counsel-rg-base-command))
-    (counsel-ag initial-input initial-directory extra-rg-args rg-prompt)))
-(cl-pushnew 'counsel-rg ivy-highlight-grep-commands)
+(def-counsel-ag-command counsel-rg
+  :tool-name rg
+  :base-command-variable-name counsel-rg-base-command)
 
 ;;** `counsel-grep'
 (defvar counsel-grep-map
@@ -2726,7 +2733,7 @@ substituted by the search regexp and file, respectively.  Neither
               (swiper--ensure-visible)
             (isearch-range-invisible (line-beginning-position)
                                      (line-end-position))
-            (swiper--add-overlays (ivy--regex ivy-text))))))))
+              (swiper--add-overlays (ivy--regex ivy-text))))))))
 
 (defun counsel-grep-occur ()
   "Generate a custom occur buffer for `counsel-grep'."

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -938,6 +938,11 @@ a buffer visiting a file."
              ;; No editing, just command ivy-immediate-done
              "C-M-j")))
     (ivy-mode ivy-mode-reset-arg)))
+(ert-deftest counsel-ag--split-match ()
+  (should (equal (counsel-ag--split-match "ivy.el:4134:(defun counsel-ag--split-match (candidate)")
+                 '("ivy.el"
+                   "4134"
+                   "(defun counsel-ag--split-match (candidate)"))))
 
 (provide 'ivy-test)
 

--- a/ivy.el
+++ b/ivy.el
@@ -4172,51 +4172,6 @@ There is no limit on the number of *ivy-occur* buffers."
       (ivy-exit-with-action
        (lambda (_) (pop-to-buffer buffer))))))
 
-(defun counsel-ag--split-match (candidate)
-  "Example usage:
-
-(counsel-ag--split-match \"ivy.el:4134:(defun counsel-ag--split-match (candidate)\") is (\"ivy.el\" \"4134\" \"(defun counsel-ag--split-match (candidate)\")"
-  (let ((split (split-string candidate ":")))
-    (when split
-      (list (car split) (cadr split) (mapconcat 'identity (nthcdr 2 split) ":")))))
-
-(defun counsel-ag--display-match (loc-info text)
-  (let ((current-line-display))
-    (add-text-properties
-     0 (length loc-info)
-     `(face success)
-     loc-info)
-    (setq current-line-display
-          (format "     %s: %s" loc-info text))
-    (add-text-properties
-     0 (length current-line-display)
-     `(mouse-face
-       highlight
-       help-echo "mouse-1: call ivy-action")
-     current-line-display)
-    current-line-display))
-
-(defun counsel-ag-occur-color-moccur ()
-  "A function suitable for `ivy-set-occur' for grep-like outputs."
-  (ivy-occur-mode)
-  (read-only-mode)
-  (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
-                  default-directory))
-  (let ((count 0)
-        current-file)
-    (dolist (candidate ivy--old-cands)
-      (let ((current-line (counsel-ag--split-match candidate)))
-        (unless (string= current-file (car-safe current-line))
-          (setq current-file (car-safe current-line))
-          (insert "file: " current-file "\n"))
-        (insert (counsel-ag--display-match (cadr current-line)
-                                           (caddr current-line))
-                "\n")
-        (incf count)))
-    (goto-char (point-min))
-    (forward-line 3)
-    (insert (format "%d candidates:\n" count))))
-
 (defun ivy-occur-revert-buffer ()
   "Refresh the buffer making it up-to date with the collection.
 

--- a/ivy.el
+++ b/ivy.el
@@ -4263,11 +4263,6 @@ EVENT gives the mouse position."
         buffer
       (current-buffer))))
 
-(defvar ivy--occur-press-orig-buffer nil
-  "The buffer in which `ivy-occur-press' has been triggerer.
-
-Its value is only set during the call to `ivy-occur-press'.")
-
 (defun ivy-occur-press ()
   "Execute action for the current candidate."
   (interactive)
@@ -4275,8 +4270,7 @@ Its value is only set during the call to `ivy-occur-press'.")
   (when (save-excursion
           (beginning-of-line)
           (looking-at "\\(?:./\\|    \\)\\(.*\\)$"))
-    (let* ((ivy--occur-press-orig-buffer (current-buffer))
-           (ivy-last ivy-occur-last)
+    (let* ((ivy-last ivy-occur-last)
            (ivy-text (ivy-state-text ivy-last))
            (str (buffer-substring
                  (match-beginning 1)

--- a/ivy.el
+++ b/ivy.el
@@ -4172,6 +4172,51 @@ There is no limit on the number of *ivy-occur* buffers."
       (ivy-exit-with-action
        (lambda (_) (pop-to-buffer buffer))))))
 
+(defun counsel-ag--split-match (candidate)
+  "Example usage:
+
+(counsel-ag--split-match \"ivy.el:4134:(defun counsel-ag--split-match (candidate)\") is (\"ivy.el\" \"4134\" \"(defun counsel-ag--split-match (candidate)\")"
+  (let ((split (split-string candidate ":")))
+    (when split
+      (list (car split) (cadr split) (mapconcat 'identity (nthcdr 2 split) ":")))))
+
+(defun counsel-ag--display-match (loc-info text)
+  (let ((current-line-display))
+    (add-text-properties
+     0 (length loc-info)
+     `(face success)
+     loc-info)
+    (setq current-line-display
+          (format "     %s: %s" loc-info text))
+    (add-text-properties
+     0 (length current-line-display)
+     `(mouse-face
+       highlight
+       help-echo "mouse-1: call ivy-action")
+     current-line-display)
+    current-line-display))
+
+(defun counsel-ag-occur-color-moccur ()
+  "A function suitable for `ivy-set-occur' for grep-like outputs."
+  (ivy-occur-mode)
+  (read-only-mode)
+  (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
+                  default-directory))
+  (let ((count 0)
+        current-file)
+    (dolist (candidate ivy--old-cands)
+      (let ((current-line (counsel-ag--split-match candidate)))
+        (unless (string= current-file (car-safe current-line))
+          (setq current-file (car-safe current-line))
+          (insert "file: " current-file "\n"))
+        (insert (counsel-ag--display-match (cadr current-line)
+                                           (caddr current-line))
+                "\n")
+        (incf count)))
+    (goto-char (point-min))
+    (forward-line 3)
+    (insert (format "%d candidates:\n" count))))
+
 (defun ivy-occur-revert-buffer ()
   "Refresh the buffer making it up-to date with the collection.
 
@@ -4263,6 +4308,11 @@ EVENT gives the mouse position."
         buffer
       (current-buffer))))
 
+(defvar ivy--occur-press-orig-buffer nil
+  "The buffer in which `ivy-occur-press' has been triggerer.
+
+Its value is only set during the call to `ivy-occur-press'.")
+
 (defun ivy-occur-press ()
   "Execute action for the current candidate."
   (interactive)
@@ -4270,7 +4320,8 @@ EVENT gives the mouse position."
   (when (save-excursion
           (beginning-of-line)
           (looking-at "\\(?:./\\|    \\)\\(.*\\)$"))
-    (let* ((ivy-last ivy-occur-last)
+    (let* ((ivy--occur-press-orig-buffer (current-buffer))
+           (ivy-last ivy-occur-last)
            (ivy-text (ivy-state-text ivy-last))
            (str (buffer-substring
                  (match-beginning 1)


### PR DESCRIPTION
Fix #1655.

I did not figure out how to avoid introducing a new global (ivy--occur-press-orig-buffer).

Also, maybe more faces are needed? 
CC @ztlevi 


