### PR TITLE
Fix swiper jumping incorrectly to the first match

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3097,6 +3097,7 @@ RE-STR is the regexp, CANDS are the current candidates."
              (not empty)
              0)
         (and (not empty)
+             (not (eq caller 'swiper))
              (not (and ivy--flx-featurep
                        (eq ivy--regex-function 'ivy--regex-fuzzy)
                        ;; Limit to 200 candidates


### PR DESCRIPTION
To reproduce the problem:

1. have a file with content
```
aaa
bbb
ccc
aaa
```
2. go to third line `ccc`
3. `M-x swiper`
4. type in `a` one at a time and observe selection to jump to the first line after typing the second `a`.

The expected behavior would be to stay at the fourth line, instead of jumping to the first.

When I work with some large files, swiper sometimes jump to thousands of lines above (which have identical content), when I only want to search in the vicinity.

My quick fix is to modify `ivy--recompute-index` to ensure calling the designated function in `ivy-index-functions-alist` at least for the swiper caller.  There might be some better handling of the control flow than mine here.