### PR TITLE
Unwind with company-abort in counsel-company

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -374,7 +374,8 @@ Update the minibuffer with the amount of lines collected every
       (setq ivy-completion-beg (match-beginning 0))
       (setq ivy-completion-end (match-end 0)))
     (ivy-read "company cand: " company-candidates
-              :action #'ivy-completion-in-region-action)))
+              :action #'ivy-completion-in-region-action
+              :unwind #'company-abort)))
 
 ;;** `counsel-irony'
 (declare-function irony-completion-candidates-async "ext:irony-completion")


### PR DESCRIPTION
Currently, the company tooltip popup appears after aborting counsel-company with `C-g` or `ESC` (see also #1650). This is a simple patch that fixes this by adding company-abort to the unwind of counsel-company.