### PR TITLE
Propertize matches in ivy-occur buffers.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4082,16 +4082,24 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
 
 (defun ivy--occur-insert-lines (cands)
   "Insert CANDS into `ivy-occur' buffer."
+  (font-lock-mode -1)
   (dolist (str cands)
     (add-text-properties
      0 (length str)
      `(mouse-face
        highlight
        help-echo "mouse-1: call ivy-action")
-     str)
+     (ivy--highlight-fuzzy str))
     (insert str "\n"))
   (goto-char (point-min))
-  (forward-line 4))
+  (forward-line 4)
+  (while (re-search-forward "^[^:]+:[[:digit:]]+:" nil t)
+    (ivy-add-face-text-property
+     (match-beginning 0)
+     (match-end 0)
+     'compilation-info
+     nil
+     t)))
 
 (defun ivy-occur ()
   "Stop completion and put the current candidates into a new buffer.


### PR DESCRIPTION
fix #1765.

an implementation like #1777 but completely takes over font-lock-mode.