### PR TITLE
Avoid TRAMP related errors from blocking ivy-...-buffer commands

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3524,7 +3524,9 @@ possible match.  See `all-completions' for further information."
      (lambda (x)
        (let* ((buf (get-buffer x))
               (dir (buffer-local-value 'default-directory buf))
-              (face (if (and dir (file-remote-p (abbreviate-file-name dir)))
+              (face (if (and dir
+                             (ignore-errors
+                               (file-remote-p (abbreviate-file-name dir))))
                         'ivy-remote
                       (cdr (assq (buffer-local-value 'major-mode buf)
                                  ivy-switch-buffer-faces-alist)))))
@@ -3831,7 +3833,7 @@ Skip buffers that match `ivy-ignore-buffers'."
         (cond
           ((buffer-modified-p b)
            (ivy-append-face str 'ivy-modified-buffer))
-          ((and (not (file-remote-p (buffer-file-name b)))
+          ((and (not (ignore-errors (file-remote-p (buffer-file-name b))))
                 (not (verify-visited-file-modtime b)))
            (ivy-append-face str 'ivy-modified-outside-buffer))
           (t str))


### PR DESCRIPTION
Otherwise, on my system (Ubuntu LTS 18.04, Emacs 27.0.50), using e.g. `ivy-switch-buffer` fails if a ZIP file listing has been inserted into a dired buffer (I believe that `kill-buffer` is also affected once `ivy-mode` is enabled).

How to reproduce the problem (i.e. without this patch):

1. Create a /tmp/minimal-init.el file (this assumes that you `package-install` ivy in your normal Emacs setup first):
   ```lisp
   (require 'package)
   (setq package-directory-list (list (locate-user-emacs-file "elpa/")))
   (package-initialize)
   (require 'ivy)
   ```

2. Start Emacs with minimal customization:
   ```shell
   emacs --quick --load /tmp/minimal-init.el
   ```

3. `M-x dired` and navigate to a directory containing a ZIP file.  Select the ZIP file & `dired-maybe-insert-subdir` (i.e. shortcut key `i`) it into the dired buffer.  It should look like this:
   ```
   /tmp/issue:
   total used in directory 32 available 3818908
   drwxr-x---  2 user user  4096 Nov  6 11:14 .
   drwxrwxrwt 21 root root 24576 Nov  6 11:14 ..
   -rw-r-----  1 user user   152 Nov  6 11:14 b.zip

   /tmp/issue/b.zip/:
   total used in directory 0 available 3818908
   dr-x------  0 user user 0 1970-01-01  .
   dr-x------  0 user user 0 1970-01-01  ..
   -r--------  0 user user 0 11-06 11:14 a
   ```

4. Navigate to the file (i.e. go to the line with `a` and `dired-find-file`, i.e. press Enter).

5. `M-x ivy-switch-buffer` and nothing happens except an error message
   ```
   tramp-file-name-handler: Process *tramp/archive file%3A%2F%2F%2Ftmp%2Fissue%2Fb.zip* not running
   ```
