### PR TITLE
Ivy completing read compatibility for non-string defaults

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -738,6 +738,13 @@ will bring the behavior in line with the newer Emacsen."
    (equal "c"
           (ivy-with '(ivy-completing-read "Pick: " '("a" "b" "c") nil t nil nil nil)
                     "c RET")))
+  ;; DEF list, empty input (no text collection), non-text default, same object
+  (let ((def '([a b])))
+    (should
+     (eq (car def)
+         (ivy-with
+          (eval `'(ivy-completing-read "Pick: " nil nil 'require-match nil nil ',def))
+          "RET"))))
   ;; DEF nil, and called via `ivy-completing-read-with-empty-string-def'
   (should
    (equal ""

--- a/ivy.el
+++ b/ivy.el
@@ -1997,9 +1997,9 @@ This is useful for recursive `ivy-read'."
       (unless (ivy-state-dynamic-collection ivy-last)
         (setq coll (delete "" coll)))
       (when def
-        (cond ((listp def)
+        (cond ((and (listp def) (stringp (car def)))
                (setq coll (cl-union def coll :test #'equal)))
-              ((not (member def coll))
+              ((and (stringp def) (not (member def coll)))
                (push def coll))))
       (when (and sort
                  (or (functionp collection)


### PR DESCRIPTION
For non-string defaults, fix compat with `completing-read' to return the first element of default, if it is a list; "", if default is nil; or default
Also, fixes where previously a non-string default (symbol) cleared the collection

Fixes  #1526 