### PR TITLE
ivy.el: Fix minibuffer truncation & resizing

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1842,11 +1842,8 @@ customizations apply to the current completion session."
                       (minibuffer-completion-table collection)
                       (minibuffer-completion-predicate predicate)
                       (ivy-height height)
-                      (resize-mini-windows
-                       (cond
-                         ((display-graphic-p) nil)
-                         ((null resize-mini-windows) 'grow-only)
-                         (t resize-mini-windows))))
+                      (resize-mini-windows (unless (display-graphic-p)
+                                             'grow-only)))
                  (if (and ivy-auto-select-single-candidate
                           (= (length ivy--all-candidates) 1))
                      (progn
@@ -2544,9 +2541,7 @@ tries to ensure that it does not change depending on the number of candidates."
               (lambda ()
                 (list ivy--default)))
   (setq-local inhibit-field-text-motion nil)
-  (if (display-graphic-p)
-      (setq truncate-lines ivy-truncate-lines)
-    (setq resize-mini-windows 'grow-only))
+  (setq truncate-lines ivy-truncate-lines)
   (setq-local max-mini-window-height ivy-height)
   (if (and ivy-fixed-height-minibuffer
            (not (eq (ivy-state-caller ivy-last) 'ivy-completion-in-region)))


### PR DESCRIPTION
The last attempt[1] to fix #1809 permanently changed the value of user option `resize-mini-windows` under a text terminal. Fix this by:

(`ivy--minibuffer-setup`): Move `resize-mini-windows` logic from here...
(`ivy-read`): ...to here.

[1]: ivy.el: For non-graphical Emacs set resize-mini-windows to 'grow-only
  2018-11-20 11:04:14 +0100 c1c1ec7cb9c99c50424416a143747f64e3083552

Fixes #1809