### PR TITLE
counsel.el : Add counsel-separator face

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -730,6 +730,12 @@ a symbol and how to search for them."
   "Face used by `counsel-M-x' for key bindings."
   :group 'ivy-faces)
 
+;;** `counsel-yank-pop'
+(defface counsel-separator
+  '((t :inherit font-lock-doc-face))
+  "Face for multiline source separator."
+  :group 'ivy-faces)
+
 (defun counsel-M-x-transformer (cmd)
   "Return CMD annotated with its active key binding, if any."
   (let ((key (where-is-internal (intern cmd) nil t)))
@@ -3492,7 +3498,7 @@ Additional actions:\\<ivy-minibuffer-map>
    (lambda (str)
      (counsel--yank-pop-truncate str))
    cand-pairs
-   counsel-yank-pop-separator))
+   (propertize counsel-yank-pop-separator 'face 'counsel-separator)))
 
 (defun counsel--yank-pop-position (s)
   "Return position of S in `kill-ring' relative to last yank."

--- a/counsel.el
+++ b/counsel.el
@@ -730,12 +730,6 @@ a symbol and how to search for them."
   "Face used by `counsel-M-x' for key bindings."
   :group 'ivy-faces)
 
-;;** `counsel-yank-pop'
-(defface counsel-separator
-  '((t :inherit font-lock-doc-face))
-  "Face for multiline source separator."
-  :group 'ivy-faces)
-
 (defun counsel-M-x-transformer (cmd)
   "Return CMD annotated with its active key binding, if any."
   (let ((key (where-is-internal (intern cmd) nil t)))
@@ -3498,7 +3492,7 @@ Additional actions:\\<ivy-minibuffer-map>
    (lambda (str)
      (counsel--yank-pop-truncate str))
    cand-pairs
-   (propertize counsel-yank-pop-separator 'face 'counsel-separator)))
+   (propertize counsel-yank-pop-separator 'face 'ivy-separator)))
 
 (defun counsel--yank-pop-position (s)
   "Return position of S in `kill-ring' relative to last yank."

--- a/ivy.el
+++ b/ivy.el
@@ -135,6 +135,10 @@
   '((t :inherit ivy-current-match))
   "Face used by Ivy for highlighting the selected prompt line.")
 
+(defface ivy-separator
+  '((t :inherit font-lock-doc-face))
+  "Face for multiline source separator.")
+
 ;; Set default customization `:group' to `ivy' for the rest of the file.
 (setcdr (assoc load-file-name custom-current-group-alist) 'ivy)
 


### PR DESCRIPTION
First of all, thanks for this great package.
I added counsel-separator face to make it easy to distinguish texts on counsel-yank-pop list.
when I eval `(setq counsel-yank-pop-separator "\n----------\n")`, separators on counsel-yank-pop list will be looked as below.

![s1](https://user-images.githubusercontent.com/8042298/48908027-851f3280-eeac-11e8-9d9f-a32e00934542.png)

![s2](https://user-images.githubusercontent.com/8042298/48908031-86505f80-eeac-11e8-9a72-98515f96cfa5.png)

Thanks.