### PR TITLE
ivy-overlay.el: Simplify overlay face overriding

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -60,25 +60,20 @@ Lines are truncated to the window width."
   (when (fboundp 'company-abort)
     (company-abort)))
 
-(defun ivy--overlay-font-lock-hack (str)
-  "Return a copy of STR to use in an overlay.
-This string will not inherit font-lock face."
-  (let ((s1 (copy-sequence str)))
-    (ivy-add-face-text-property 0 (length s1) 'default s1 t)
-    s1))
-
 (defun ivy-overlay-show-after (str)
   "Display STR in an overlay at point.
 
 First, fill each line of STR with spaces to the current column.
-Then attach the overlay the character before point."
+Then attach the overlay to the character before point."
   (if ivy-overlay-at
       (progn
         (move-overlay ivy-overlay-at (1- (point)) (line-end-position))
         (overlay-put ivy-overlay-at 'invisible nil))
     (setq ivy-overlay-at (make-overlay (1- (point)) (line-end-position)))
+    ;; Specify face to avoid clashing with other overlays.
+    (overlay-put ivy-overlay-at 'face 'default)
     (overlay-put ivy-overlay-at 'priority 9999))
-  (overlay-put ivy-overlay-at 'display (ivy--overlay-font-lock-hack str))
+  (overlay-put ivy-overlay-at 'display str)
   (overlay-put ivy-overlay-at 'after-string ""))
 
 (declare-function org-current-level "org")

--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -119,24 +119,24 @@ Hide the minibuffer contents and cursor."
           (setq ivy--old-cursor-type cursor-type))
         (setq cursor-type nil)
         (let ((overlay-str
-               (concat
-                (buffer-substring (max 1 (1- (point))) (point))
+               (apply
+                #'concat
+                (buffer-substring (max (point-min) (1- (point))) (point))
                 ivy-text
-                (if (eolp)
-                    " "
-                  "")
+                (and (eolp) " ")
                 (buffer-substring (point) (line-end-position))
-                (when (> (length str) 0)
-                  (concat "\n"
-                          (ivy-left-pad
-                           (ivy--remove-prefix "\n" str)
-                           (+ (if (and (eq major-mode 'org-mode)
-                                       (bound-and-true-p org-indent-mode))
-                                  (* org-indent-indentation-per-level (org-current-level))
-                                0)
-                              (save-excursion
-                                (goto-char ivy-completion-beg)
-                                (current-column)))))))))
+                (and (> (length str) 0)
+                     (list "\n"
+                           (ivy-left-pad
+                            (ivy--remove-prefix "\n" str)
+                            (+ (if (and (eq major-mode 'org-mode)
+                                        (bound-and-true-p org-indent-mode))
+                                   (* org-indent-indentation-per-level
+                                      (org-current-level))
+                                 0)
+                               (save-excursion
+                                 (goto-char ivy-completion-beg)
+                                 (current-column)))))))))
           (ivy-add-face-text-property cursor-pos (1+ cursor-pos)
                                       'ivy-cursor overlay-str t)
           (ivy-overlay-show-after overlay-str))))))


### PR DESCRIPTION
This is a refactor of the following commit 7434a792c7b4ace1f138fe4256338e20f49981fc.

(`ivy--overlay-font-lock-hack`): Remove.
(`ivy-overlay-show-after`): Specify default face of `ivy-overlay-at` to avoid clashing with other overlays.

Re: #1016, #1488, #1520, #1547, #1808