### PR TITLE
counsel.el: Call du process directly

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1323,10 +1323,15 @@ files in a project.")
     (cons proj cmd)))
 
 (defun counsel--git-grep-count-func-default ()
-  "Default defun to calculate `counsel--git-grep-count'."
-  (if (eq system-type 'windows-nt)
-      0
-    (read (shell-command-to-string "du -s \"$(git rev-parse --git-dir)\" 2>/dev/null"))))
+  "Default function to calculate `counsel--git-grep-count'."
+  (with-temp-buffer
+    (if (or (eq system-type 'windows-nt)
+            (not (eq 0 (call-process "git" nil t nil "rev-parse" "--git-dir"))))
+        0
+      (call-process "du" nil '(t nil) nil "-s"
+                    (buffer-substring-no-properties (point-min) (1- (point))))
+      (forward-line -1)
+      (read (current-buffer)))))
 
 (defvar counsel--git-grep-count-func #'counsel--git-grep-count-func-default
   "Defun to calculate `counsel--git-grep-count' for `counsel-git-grep'.")


### PR DESCRIPTION
(`counsel--git-grep-count-func-default`): Call `git` and `du` directly to avoid shell incompatibilities in redirection.

Cc: @articuluxe, @icarus-sparry, @mikecrowe, @shalin24
Re: #1470, #1558 
Fixes #1502

P.S. Sorry for not commenting on this at the time, but why do `counsel--git-grep-count`, `counsel--git-grep-count-func`, and `counsel--git-grep-count-func-default` have double hyphens in their names, if they're intended as a means for (advanced) user customisation?

Re: https://github.com/abo-abo/swiper/pull/1470#issuecomment-367851346
Wouldn't it be cleaner to allow values of `ivy-more-chars-alist` to be functions, so that `ivy-more-chars` is no longer guarded ad-hoc by `(> counsel--git-grep-count counsel--git-grep-count-threshold)` in `counsel-git-grep-function`?