### PR TITLE
counsel.el (counsel--call): Touch-up

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1348,11 +1348,11 @@ Obey file handlers based on `default-directory'."
 
 (defun counsel--git-grep-count-func-default ()
   "Default function to calculate `counsel--git-grep-count'."
-  (if (eq system-type 'windows-nt) 0
-    (condition-case nil
-        (let ((git-dir (counsel--call "git" "rev-parse" "--git-dir")))
-          (read (counsel--call "du" "-s" git-dir)))
-      (error 0))))
+  (or (unless (eq system-type 'windows-nt)
+        (ignore-errors
+          (let ((git-dir (counsel--call "git" "rev-parse" "--git-dir")))
+            (read (counsel--call "du" "-s" git-dir)))))
+      0))
 
 (defvar counsel--git-grep-count-func #'counsel--git-grep-count-func-default
   "Defun to calculate `counsel--git-grep-count' for `counsel-git-grep'.")


### PR DESCRIPTION
* Use `process-file` instead of `call-process`.
* Add docstring.
* Avoid multi-line error message by returning only the first line of stderr.
* Deconstruct error information as `file-error` data for easier access.
* Guard stderr file access with `file-{exists,readable}-p` just in case.

Re: #1827