### PR TITLE
counsel.el: Refactor counsel-ag derived commands.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2577,9 +2577,7 @@ CALLER is forwarded to `ivy-read'."
 
 (cl-defmacro def-counsel-ag-command (name &key tool-name base-command-variable-name)
   (declare (indent 1))
-  (or (boundp base-command-variable-name) (error "Variable %S not defined" base-command-variable-name))
   `(progn
-     (autoload ',name "counsel" "" t)
      (defun ,name (&optional initial-input initial-directory extra-args prompt)
        ,(format
          "Grep for a string in the current directory using %s.

--- a/counsel.el
+++ b/counsel.el
@@ -2536,8 +2536,7 @@ NEEDLE is the search string."
                                   (shell-quote-argument regex)))
          nil)))))
 
-;;;###autoload
-(defun counsel-ag (&optional initial-input initial-directory extra-ag-args ag-prompt caller)
+(defun counsel--grep-like (&optional initial-input initial-directory extra-ag-args ag-prompt caller)
   "Grep for a string in the current directory using ag.
 INITIAL-INPUT can be given as the initial minibuffer input.
 INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
@@ -2592,11 +2591,15 @@ PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
          var)
        (interactive)
        (let ((counsel-ag-base-command ,var))
-         (counsel-ag initial-input initial-directory extra-args prompt ',symbol)))
+         (counsel--grep-like initial-input initial-directory extra-args prompt ',symbol)))
      (unless (plist-get ivy--occurs-list ',symbol)
        ;; do not override user configuration
        (ivy-set-occur ',symbol 'counsel-ag-occur))
      (cl-pushnew ',symbol ivy-highlight-grep-commands)))
+
+(def-counsel-grep-like-command counsel-ag
+  :program ag
+  :var counsel-ag-base-command)
 
 (cl-pushnew 'counsel-ag ivy-highlight-grep-commands)
 

--- a/counsel.el
+++ b/counsel.el
@@ -2575,25 +2575,28 @@ CALLER is forwarded to `ivy-read'."
                         (swiper--cleanup))
               :caller caller)))
 
-(cl-defmacro def-counsel-ag-command (name &key tool-name base-command-variable-name)
+(cl-defmacro def-counsel-grep-like-command (symbol &key program var)
+  "Define the grep-like command SYMBOL.
+VAR is a string variable used as a command template.
+PROGRAM is the name of the command (a string or a symbol)."
   (declare (indent 1))
   `(progn
-     (defun ,name (&optional initial-input initial-directory extra-args prompt)
+     (defun ,symbol (&optional initial-input initial-directory extra-args prompt)
        ,(format
          "Grep for a string in the current directory using %s.
 INITIAL-INPUT can be given as the initial minibuffer input.
 INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
 EXTRA-ARGS string, if non-nil, is appended to `%s'.
 PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
-         tool-name
-         base-command-variable-name)
+         program
+         var)
        (interactive)
-       (let ((counsel-ag-base-command ,base-command-variable-name))
-         (counsel-ag initial-input initial-directory extra-args prompt ',name)))
-     (unless (plist-get ivy--occurs-list ',name)
+       (let ((counsel-ag-base-command ,var))
+         (counsel-ag initial-input initial-directory extra-args prompt ',symbol)))
+     (unless (plist-get ivy--occurs-list ',symbol)
        ;; do not override user configuration
-       (ivy-set-occur ',name 'counsel-ag-occur))
-     (cl-pushnew ',name ivy-highlight-grep-commands)))
+       (ivy-set-occur ',symbol 'counsel-ag-occur))
+     (cl-pushnew ',symbol ivy-highlight-grep-commands)))
 
 (cl-pushnew 'counsel-ag ivy-highlight-grep-commands)
 
@@ -2631,9 +2634,9 @@ PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   :type 'string
   :group 'ivy)
 
-(def-counsel-ag-command counsel-pt
-  :tool-name pt
-  :base-command-variable-name counsel-pt-base-command)
+(def-counsel-grep-like-command counsel-pt
+  :program pt
+  :var counsel-pt-base-command)
 
 ;;** `counsel-ack'
 (defcustom counsel-ack-base-command
@@ -2645,9 +2648,9 @@ PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   :type 'string
   :group 'ivy)
 
-(def-counsel-ag-command counsel-ack
-  :tool-name ack
-  :base-command-variable-name counsel-ack-base-command)
+(def-counsel-grep-like-command counsel-ack
+  :program ack
+  :var counsel-ack-base-command)
 
 ;;** `counsel-rg'
 (defcustom counsel-rg-base-command "rg -S --no-heading --line-number --color never %s ."
@@ -2660,9 +2663,9 @@ Note: don't use single quotes for the regex."
 (counsel-set-async-exit-code 'counsel-rg 1 "No matches found")
 (ivy-set-display-transformer 'counsel-rg 'counsel-git-grep-transformer)
 
-(def-counsel-ag-command counsel-rg
-  :tool-name rg
-  :base-command-variable-name counsel-rg-base-command)
+(def-counsel-grep-like-command counsel-rg
+  :program rg
+  :var counsel-rg-base-command)
 
 ;;** `counsel-grep'
 (defvar counsel-grep-map

--- a/counsel.el
+++ b/counsel.el
@@ -2724,7 +2724,7 @@ substituted by the search regexp and file, respectively.  Neither
               (swiper--ensure-visible)
             (isearch-range-invisible (line-beginning-position)
                                      (line-end-position))
-              (swiper--add-overlays (ivy--regex ivy-text))))))))
+            (swiper--add-overlays (ivy--regex ivy-text))))))))
 
 (defun counsel-grep-occur ()
   "Generate a custom occur buffer for `counsel-grep'."


### PR DESCRIPTION
This is just a subset of the patch in #1783 containing nothing of the original work on the color-moccur display.