### PR TITLE
Avoid to wipe a user buffer when writing candidates.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -220,8 +220,11 @@ Update the minibuffer with the amount of lines collected every
                                (string-match-p counsel-async-ignore-re line))
                              lines)
              lines))))
-      (let ((ivy--prompt (format "%d++ %s" numlines (ivy-state-prompt ivy-last))))
-        (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))
+      (let ((ivy--prompt (format "%d++ %s" numlines (ivy-state-prompt ivy-last)))
+            (win (active-minibuffer-window)))
+        (when (window-live-p win)
+          (with-selected-window win
+            (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))))
       (setq counsel--async-time (current-time)))))
 
 (defun counsel-delete-process (&optional name)


### PR DESCRIPTION
Fix #1772.

I was able to reproduce the issue with counsel-ag, and I suspect that the bug impacts any usage of counsel--async-command as well.

My guess is that counsel--async-filter is a caller of ivy--insert-minibuffer, which must only be called when the current buffer is the minibuffer (ie, ivy--insert-minibuffer is not wrapped in a `with-current-buffer` block).

When called with a process that exists immediately, it is very unlikely that the process filter will be called at all, and even less before the user had time to change buffer himself.


@jojojames can you confirm that this version fixes the issue?

