### PR TITLE
Define own variants of compilation-* faces

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1288,10 +1288,10 @@ Typical value: '(recenter)."
   "Higlight file and line number in STR."
   (when (string-match "\\`\\([^:]+\\):\\([^:]+\\):" str)
     (ivy-add-face-text-property (match-beginning 1) (match-end 1)
-                                'compilation-info
+                                'ivy-grep-info
                                 str)
     (ivy-add-face-text-property (match-beginning 2) (match-end 2)
-                                'compilation-line-number
+                                'ivy-grep-line-number
                                 str))
   str)
 
@@ -3728,7 +3728,7 @@ PREFIX is used to create the key."
                  (let ((key (concat
                              (when prefix
                                (concat
-                                (propertize prefix 'face 'compilation-info)
+                                (propertize prefix 'face 'ivy-grep-info)
                                 ": "))
                              (car elm))))
                    (list (cons key

--- a/ivy.el
+++ b/ivy.el
@@ -139,6 +139,14 @@
   '((t :inherit font-lock-doc-face))
   "Face for multiline source separator.")
 
+(defface ivy-grep-info
+  '((t :inherit compilation-info))
+  "Face for highlighting grep information such as file names.")
+
+(defface ivy-grep-line-number
+  '((t :inherit compilation-line-number))
+  "Face for displaying line numbers in grep messages.")
+
 ;; Set default customization `:group' to `ivy' for the rest of the file.
 (setcdr (assoc load-file-name custom-current-group-alist) 'ivy)
 
@@ -4129,11 +4137,7 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
   (forward-line 4)
   (while (re-search-forward "^[^:]+:[[:digit:]]+:" nil t)
     (ivy-add-face-text-property
-     (match-beginning 0)
-     (match-end 0)
-     'compilation-info
-     nil
-     t)))
+     (match-beginning 0) (match-end 0) 'ivy-grep-info nil t)))
 
 (defun ivy-occur ()
   "Stop completion and put the current candidates into a new buffer.

--- a/swiper.el
+++ b/swiper.el
@@ -439,7 +439,7 @@ When capture groups are present in the input, print them instead of lines."
                         (buffer-file-name buffer))
                      (buffer-name buffer)))
                  'face
-                 'compilation-info))
+                 'ivy-grep-info))
          (re (progn (string-match "\"\\(.*\\)\"" (buffer-name))
                     (match-string 1 (buffer-name))))
          (re (mapconcat #'identity (ivy--split re) ".*?"))
@@ -449,7 +449,7 @@ When capture groups are present in the input, print them instead of lines."
              (let* ((n (get-text-property 0 'swiper-line-number s))
                     (i (string-match-p "[ \t\n\r]+\\'" n)))
                (when i (setq n (substring n 0 i)))
-               (put-text-property 0 (length n) 'face 'compilation-line-number n)
+               (put-text-property 0 (length n) 'face 'ivy-grep-line-number n)
                (format "%s:%s:%s" fname n (substring s 1))))
            (if (not revert)
                ivy--old-cands


### PR DESCRIPTION
* `ivy.el` (`ivy-grep-info`, `ivy-grep-line-number`): New faces inheriting `compilation-info` and `compilation-line-number`, respectively.
(`ivy--occur-insert-lines`):
* `swiper.el` (`swiper-occur`):
* `counsel.el` (`counsel-git-grep-transformer`)
(`counsel-imenu-get-candidates-from`): Use them.

Re: #1839
Cc: @diamond-lizard