### PR TITLE
counsel.el (counsel-M-x): Filter obsolete commands

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -807,7 +807,10 @@ when available, in that order of precedence."
   (setq real-this-command real-last-command)
   (let ((externs (counsel--M-x-externs)))
     (ivy-read (counsel--M-x-prompt) (or externs obarray)
-              :predicate (and (not externs) #'commandp)
+              :predicate (and (not externs)
+                              (lambda (sym)
+                                (and (commandp sym)
+                                     (not (get sym 'byte-obsolete-info)))))
               :require-match t
               :history 'counsel-M-x-history
               :action (lambda (cmd)


### PR DESCRIPTION
This makes `counsel-M-x` consistent with Emacs 25.1 `read-extended-command`.

Fixes #1843 
Cc: @jabranham