### PR TITLE
Robustify counsel occur

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1491,6 +1491,9 @@ If NO-ASYNC is non-nil, do it synchronously instead."
                                nil " *counsel-gg-count*")
        nil))))
 
+(defun counsel--normalize-grep-match (str)
+  (if (string-match-p "\\`\\.[/\\]" str) str (concat "./" str)))
+
 (defun counsel-git-grep-occur ()
   "Generate a custom occur buffer for `counsel-git-grep'.
 When REVERT is non-nil, regenerate the current *ivy-occur* buffer."
@@ -1523,9 +1526,7 @@ When REVERT is non-nil, regenerate the current *ivy-occur* buffer."
                     default-directory))
     (insert (format "%d candidates:\n" (length cands)))
     (ivy--occur-insert-lines
-     (mapcar
-      (lambda (cand) (concat "./" cand))
-      cands))))
+     (mapcar #'counsel--normalize-grep-match cands))))
 
 (defun counsel-git-grep-query-replace ()
   "Start `query-replace' with string to replace from last search string."
@@ -2466,7 +2467,7 @@ It applies no filtering to ivy--all-candidates."
     (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n" default-directory))
     (insert (format "%d candidates:\n" (length ivy--all-candidates)))
     (ivy--occur-insert-lines
-     (mapcar (lambda (cand) (concat "./" prepend cand)) ivy--all-candidates))))
+     (mapcar #'counsel--normalize-grep-match ivy--all-candidates))))
 
 ;;** `counsel-ag'
 (defvar counsel-ag-map
@@ -2597,7 +2598,8 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
     (insert (format "-*- mode:grep; default-directory: %S -*-\n\n\n"
                     default-directory))
     (insert (format "%d candidates:\n" (length cands)))
-    (ivy--occur-insert-lines cands)))
+    (ivy--occur-insert-lines
+     (mapcar #'counsel--normalize-grep-match cands))))
 
 (defun counsel-ag-occur ()
   "Generate a custom occur buffer for `counsel-ag'."

--- a/ivy.el
+++ b/ivy.el
@@ -4131,10 +4131,7 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
        highlight
        help-echo "mouse-1: call ivy-action")
      str)
-    (insert (if (or (string-match-p "\\`.[/\\]" str)
-                    (eq (ivy-state-caller ivy-last) 'counsel-ag))
-                ""
-              "    ")
+    (insert (if (string-match-p "\\`.[/\\]" str) "" "    ")
             str ?\n))
   (goto-char (point-min))
   (forward-line 4)


### PR DESCRIPTION
see be98b75faca8ad2298c6c25423b229f4b0807002

the implemented strategy: always prefix matches with ./ or .\, regardless of whether the tool (ie, ag or rg or git-grep or pt or......) adds it.

As mentioned, this fixes the broken navigation from the results of ag-based ivy-occur buffers.