### PR TITLE
ivy.el (ivy--occur-insert-lines): fix incorrect regexp.

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -939,6 +939,14 @@ a buffer visiting a file."
              "C-M-j")))
     (ivy-mode ivy-mode-reset-arg)))
 
+(ert-deftest ivy-starts-with-dotslash ()
+  (should (ivy--starts-with-dotslash "./test1"))
+  (should (ivy--starts-with-dotslash ".\\test2"))
+  (should (not (ivy--starts-with-dotslash "test3")))
+  (should (not (ivy--starts-with-dotslash "t/est4")))
+  (should (not (ivy--starts-with-dotslash "t\\est5")))
+  (should (not (ivy--starts-with-dotslash "tes./t6"))))
+
 (provide 'ivy-test)
 
 ;;; ivy-test.el ends here

--- a/ivy.el
+++ b/ivy.el
@@ -4120,6 +4120,9 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
 (ivy-set-occur 'ivy-switch-buffer 'ivy-switch-buffer-occur)
 (ivy-set-occur 'ivy-switch-buffer-other-window 'ivy-switch-buffer-occur)
 
+(defun ivy--starts-with-dotslash (str)
+  (string-match-p "\\`\\.[/\\]" str))
+
 (defun ivy--occur-insert-lines (cands)
   "Insert CANDS into `ivy-occur' buffer."
   (font-lock-mode -1)
@@ -4131,7 +4134,7 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
        highlight
        help-echo "mouse-1: call ivy-action")
      str)
-    (insert (if (or (string-match-p "\\`.[/\\]" str)
+    (insert (if (or (ivy--starts-with-dotslash str)
                     (eq (ivy-state-caller ivy-last) 'counsel-ag))
                 ""
               "    ")


### PR DESCRIPTION
Currently the . seems too permissive and should be escaped.


the correct one was given by @basil-conto in https://github.com/abo-abo/swiper/issues/1817#issuecomment-441229080 of course (: