### PR TITLE
counsel.el (counsel-linux-apps-directories): Add XDG defaults.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4655,12 +4655,32 @@ selected color."
             :caller 'counsel-rhythmbox))
 
 ;;** `counsel-linux-app'
+(require 'xdg nil t)
+
+(defalias 'counsel--xdg-data-home
+  (if (fboundp 'xdg-data-home)
+      #'xdg-data-home
+    (lambda ()
+      (let ((directory (getenv "XDG_DATA_HOME")))
+        (if (or (null directory) (string= directory ""))
+            "~/.local/share"
+          directory))))
+  "Compatibility shim for `xdg-data-home'.")
+
+(defalias 'counsel--xdg-data-dirs
+  (if (fboundp 'xdg-data-dirs)
+      #'xdg-data-dirs
+    (lambda ()
+      (let ((path (getenv "XDG_DATA_DIRS")))
+        (if (or (null path) (string= path ""))
+            '("/usr/local/share" "/usr/share")
+          (parse-colon-path path)))))
+  "Compatibility shim for `xdg-data-dirs'.")
+
 (defcustom counsel-linux-apps-directories
-  '("~/.local/share/applications/"
-    "~/.guix-profile/share/applications/"
-    "/usr/local/share/applications/"
-    "/var/lib/flatpak/exports/share/applications/"
-    "/usr/share/applications/")
+  (mapcar (lambda (dir) (expand-file-name "applications" dir))
+          (cons (counsel--xdg-data-home)
+                (counsel--xdg-data-dirs)))
   "Directories in which to search for applications (.desktop files)."
   :group 'ivy
   :type '(repeat directory))


### PR DESCRIPTION
This PR has several goals;

* Make `counsel-linux-app` "Just Work" by default in more settings
* Make resolving `*.desktop` files work similar to how other tools do it.
* Make maintenance of a sane default easier going forward (e.g. no adding paths to `counsel-linux-apps-directories` like what happened for flatpack.)

# CHANGES 

* counsel.el (counsel-linux-apps-directories): Use XDG_DATA_DIRS
  environment variable to determine directories to search.