### PR TITLE
Another try to fix #1772: avoid to erase non-minibuffers content

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -219,11 +219,8 @@ Update the minibuffer with the amount of lines collected every
                                (string-match-p counsel-async-ignore-re line))
                              lines)
              lines))))
-      (let ((ivy--prompt (format "%d++ %s" numlines (ivy-state-prompt ivy-last)))
-            (win (active-minibuffer-window)))
-        (when (window-live-p win)
-          (with-selected-window win
-            (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))))
+      (let ((ivy--prompt (format "%d++ %s" numlines (ivy-state-prompt ivy-last))))
+        (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))
       (setq counsel--async-time (current-time)))))
 
 (defun counsel-delete-process (&optional name)

--- a/ivy.el
+++ b/ivy.el
@@ -2855,20 +2855,23 @@ Should be run via minibuffer `post-command-hook'."
   (let ((resize-mini-windows nil)
         (update-fn (ivy-state-update-fn ivy-last))
         (old-mark (marker-position (mark-marker)))
+        (win (active-minibuffer-window))
         deactivate-mark)
-    (ivy--cleanup)
-    (when update-fn
-      (funcall update-fn))
-    (ivy--insert-prompt)
-    ;; Do nothing if while-no-input was aborted.
-    (when (stringp text)
-      (if ivy-display-function
-          (funcall ivy-display-function text)
-        (ivy-display-function-fallback text)))
-    (ivy--resize-minibuffer-to-fit)
-    ;; prevent region growing due to text remove/add
-    (when (region-active-p)
-      (set-mark old-mark))))
+    (when win
+      (with-selected-window win
+        (ivy--cleanup)
+        (when update-fn
+          (funcall update-fn))
+        (ivy--insert-prompt)
+        ;; Do nothing if while-no-input was aborted.
+        (when (stringp text)
+          (if ivy-display-function
+              (funcall ivy-display-function text)
+            (ivy-display-function-fallback text)))
+        (ivy--resize-minibuffer-to-fit)
+        ;; prevent region growing due to text remove/add
+        (when (region-active-p)
+          (set-mark old-mark))))))
 
 (defun ivy--resize-minibuffer-to-fit ()
   "Resize the minibuffer window size to fit the text in the minibuffer."


### PR DESCRIPTION
see #1837 and #1772 

I can still reproduce the original bug:

sometimes when starting for instance counsel-rg and maintaining M-j pressed, the buffer where counsel-rg has been called is erased.

Hence propagate the fix so that the body of ivy--insert-minibuffer is protected against window changes.


Question @abo-abo should we keep functions such as ivy--cleanup that 1. assume that the current buffer is the minibuffer  2. are used only once?

