### PR TITLE
[WIP please do not merge yet] counsel.el (counsel-git-grep-matcher): reduce allocation rate.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1274,21 +1274,21 @@ Typical value: '(recenter)."
       (prog1
           (setq ivy--old-cands
                 (cl-remove-if-not
-                 (lambda (x)
-                   (ignore-errors
-                     (when (string-match "^[^:]+:[^:]+:" x)
-                       (setq x (substring x (match-end 0)))
-                       (if (stringp regexp)
-                           (string-match regexp x)
-                         (let ((res t))
-                           (dolist (re regexp)
-                             (setq res
-                                   (and res
-                                        (ignore-errors
-                                          (if (cdr re)
-                                              (string-match (car re) x)
-                                            (not (string-match (car re) x)))))))
-                           res)))))
+                 (let ((grep-loc-re "^[^:]+:[^:]+:"))
+                   (if (stringp regexp)
+                       (lambda (x)
+                         (and (string-match grep-loc-re x)
+                              (string-match-p regexp x (match-end 0))))
+                     (lambda (x)
+                       (ignore-errors
+                         (when (string-match grep-loc-re x)
+                           (let ((start (match-end 0)))
+                             (cl-every
+                              (lambda (re)
+                                (if (cdr re)
+                                    (string-match (car re) x start)
+                                  (not (string-match (car re) x start))))
+                              regexp)))))))
                  candidates))
         (setq ivy--old-re regexp))))
 


### PR DESCRIPTION
When running counsel-git-grep, a lot of candidates is typical.

Part of the slowness of this entrypoint is that
counsel-git-grep-matcher is run on big lists.

This commit ensures that the body of the lambda is as simple as possible.

+ In the common case where REGEXP is a string, try to lift loop
invariants outside of the lambda and not to allocate.

+ In the other case, use cl-every instead of hand re-implementation of it.



ref: #1812


mandatory micro benchmark (on my dotfiles repo, counsel-git-grep with no user input):

this version ( 944a30f ):
```
- command-execute                                          98,255,976  99%
 - call-interactively                                      98,255,976  99%
  - funcall-interactively                                  98,239,806  99%
   - execute-extended-command                              77,665,415  79%
    - command-execute                                      77,574,983  78%
     - call-interactively                                  77,574,983  78%
      - funcall-interactively                              77,574,967  78%
       - counsel-git-grep                                  77,574,967  78%
        - ivy-read                                         77,564,219  78%
         - ivy--reset-state                                77,232,754  78%
          - all-completions                                77,072,648  78%
           - counsel-git-grep-function                     77,072,648  78%
            - shell-command-to-string                      43,571,136  44%
               shell-command                               22,891,176  23%
               #<compiled 0x1000af407>                          1,104   0%
            + split-string                                 33,500,488  34%
            + ivy--regex                                        1,024   0%
          + ivy-thing-at-point                                158,536   0%
            ivy-add-prompt-count                                1,058   0%
          + ivy--quote-format-string                              512   0%
         - read-from-minibuffer                               297,895   0%
          + ivy--queue-exhibit                                139,728   0%
          - #<compiled 0x25eec19>                             131,035   0%
           - ivy--minibuffer-setup                            131,035   0%
            - ivy--exhibit                                    129,979   0%
             + ivy--format                                     83,272   0%
             + ivy--insert-minibuffer                          46,069   0%
             - ivy--filter                                        638   0%
              - counsel-git-grep-matcher                          638   0%
               + cl-remove-if-not                                 638   0%


- command-execute                                                  36  94%
 - call-interactively                                              36  94%
  - funcall-interactively                                          36  94%
   - execute-extended-command                                      36  94%
    - command-execute                                              35  92%
     - call-interactively                                          35  92%
      - funcall-interactively                                      35  92%
       - counsel-git-grep                                          35  92%
        - ivy-read                                                 35  92%
         - ivy--reset-state                                        22  57%
          - all-completions                                        22  57%
           - counsel-git-grep-function                             22  57%
              split-string                                         13  34%
            - shell-command-to-string                               8  21%
               shell-command                                        7  18%
         - read-from-minibuffer                                    13  34%
          - #<compiled 0x25eec19>                                  13  34%
           - ivy--minibuffer-setup                                 13  34%
            - ivy--exhibit                                         13  34%
             - ivy--filter                                         13  34%
              - counsel-git-grep-matcher                           10  26%
               - cl-remove-if-not                                  10  26%
```

master:
```


- command-execute                                         160,843,568  99%
 - call-interactively                                     160,843,568  99%
  - funcall-interactively                                 160,790,137  99%
   - execute-extended-command                             155,860,684  96%
    - command-execute                                     155,749,132  96%
     - call-interactively                                 155,749,132  96%
      - funcall-interactively                             155,749,116  96%
       - counsel-git-grep                                 155,749,116  96%
        - ivy-read                                        155,718,516  96%
         - ivy--reset-state                                79,407,171  49%
          - all-completions                                79,247,923  49%
           - counsel-git-grep-function                     79,247,923  49%
            - shell-command-to-string                      43,579,815  27%
             - shell-command                               22,899,690  14%
                push-mark                                       1,064   0%
               #<compiled 0x1000af407>                          1,269   0%
            + split-string                                 35,667,084  22%
            + ivy--regex                                        1,024   0%
          + ivy-thing-at-point                                157,712   0%
            ivy-add-prompt-count                                1,024   0%
          + ivy--quote-format-string                              512   0%
         - read-from-minibuffer                            76,300,919  47%
          - #<compiled 0x33ddcc9>                          76,242,909  47%
           - ivy--minibuffer-setup                         76,241,853  47%
            - ivy--exhibit                                 76,241,853  47%
             - ivy--filter                                 76,193,300  47%
              - counsel-git-grep-matcher                   76,193,300  47%
               - cl-remove-if-not                          76,193,300  47%

- command-execute                                                  36  81%
 - call-interactively                                              36  81%
  - funcall-interactively                                          36  81%
   - execute-extended-command                                      36  81%
    - command-execute                                              36  81%
     - call-interactively                                          36  81%
      - funcall-interactively                                      36  81%
       - counsel-git-grep                                          36  81%
        - ivy-read                                                 36  81%
         - ivy--reset-state                                        18  40%
          - all-completions                                        18  40%
           - counsel-git-grep-function                             18  40%
              split-string                                          9  20%
            + shell-command-to-string                               8  18%
         - read-from-minibuffer                                    18  40%
          - #<compiled 0x33ddcc9>                                  16  36%
           - ivy--minibuffer-setup                                 16  36%
            - ivy--exhibit                                         16  36%
             - ivy--filter                                         16  36%
              + counsel-git-grep-matcher                           13  29%

```