### PR TITLE
counsel.el (counsel-unquote-regex-parens): Bugfixes

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -52,15 +52,20 @@
 (defun counsel-unquote-regex-parens (str)
   "Unquote regexp parentheses in STR."
   (if (consp str)
-      (mapconcat #'car (cl-remove-if-not #'cdr str) ".*")
-    (replace-regexp-in-string "\\\\[(){}]\\|[()]"
+      (mapconcat
+       (lambda (pair)
+         (counsel-unquote-regex-parens (car pair)))
+       (cl-remove-if-not #'cdr str)
+       ".*")
+    (replace-regexp-in-string "\\\\[(){}|]\\|[()]"
                               (lambda (s)
                                 (or (cdr (assoc s '(("\\(" . "(")
                                                     ("\\)" . ")")
                                                     ("(" . "\\(")
                                                     (")" . "\\)")
                                                     ("\\{" . "{")
-                                                    ("\\}" . "}"))))
+                                                    ("\\}" . "}")
+                                                    ("\\|" . "|"))))
                                     (error "Unexpected parenthesis: %S" s)))
                               str t t)))
 


### PR DESCRIPTION
Fixes a bug in Counsel that caused https://github.com/raxod502/prescient.el/issues/19.