### PR TITLE
Avoid to hardcode the opinionated display-buffer-pop-up-window.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4350,7 +4350,7 @@ EVENT gives the mouse position."
                   (buffer-live-p buffer))
          (save-selected-window
            (setf (ivy-state-window ivy-occur-last)
-                 (display-buffer buffer 'display-buffer-pop-up-window))))))
+                 (display-buffer buffer))))))
 
     ((counsel-describe-function counsel-describe-variable)
      (setf (ivy-state-window ivy-occur-last)


### PR DESCRIPTION
fix #1838

It is certainly more user-friendly to let the local configuration (= the value of display-buffer-alist) handle the placement of the new window (see the issue).