### PR TITLE
Wordatpt dwim

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4426,6 +4426,20 @@ EVENT gives the mouse position."
                                 (expand-file-name "doc/ivy-help.org"))))
   "The file for `ivy-help'.")
 
+(defun ivy-text-at-point ()
+  "Return either text from region if active, or `current-word'.
+
+This function tries to make a meaningful initial-input for
+`ivy-read' from text around the point. It is destined to be used
+as a cdr in `ivy-initial-inputs-alist'."
+  (cond ((and transient-mark-mode mark-active)
+         (let* ((beg (region-beginning))
+                (end (region-end))
+                (eol (save-excursion (goto-char beg) (line-end-position))))
+           (buffer-substring-no-properties beg (min end eol))))
+        (t
+         (current-word))))
+
 (defun ivy-help ()
   "Help for `ivy'."
   (interactive)

--- a/ivy.el
+++ b/ivy.el
@@ -1663,7 +1663,7 @@ like.")
     (ivy--regex-plus . ivy--highlight-default))
   "An alist of highlighting functions for each regex buidler function.")
 
-(defvar ivy-initial-inputs-alist
+(defcustom ivy-initial-inputs-alist
   '((org-refile . "^")
     (org-agenda-refile . "^")
     (org-capture-refile . "^")
@@ -1676,7 +1676,9 @@ like.")
   "An alist associating commands with their initial input.
 
 Each cdr is either a string or a function called in the context
-of a call to `ivy-read'.")
+of a call to `ivy-read'."
+  :type '(alist :key-type (symbol)
+                :value-type (choice (string) (function))))
 
 (defcustom ivy-sort-max-size 30000
   "Sorting won't be done for collections larger than this."


### PR DESCRIPTION
This is a follow-up to #1868.

I propose this new default function for grep-like commands.
It provides a 'do what I mean' behaviour to get a meaningful initial input to search.

In particular, using the active region plays well with packages like expand-region.

To be discussed?