### PR TITLE
ivy.el: Keep only one action for one key

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1793,10 +1793,11 @@ candidates is updated after each input by calling COLLECTION.
 CALLER is a symbol to uniquely identify the caller to `ivy-read'.
 It is used, along with COLLECTION, to determine which
 customizations apply to the current completion session."
-  (let ((extra-actions (delete-dups
+  (let ((extra-actions (cl-delete-duplicates
                         (append (plist-get ivy--actions-list t)
                                 (plist-get ivy--actions-list this-command)
-                                (plist-get ivy--actions-list caller)))))
+                                (plist-get ivy--actions-list caller))
+                        :key #'car :test #'equal)))
     (when extra-actions
       (setq action
             (cond ((functionp action)


### PR DESCRIPTION
Sometimes the global actions are not suitable for a specific command, and I think currently there is no way to override them. I guess it might be better to remove duplicate actions by the key, so that only the command-specific entries are kept.

Thanks!