### PR TITLE
Add find args customization for counsel-{file,dired}-jump

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2424,6 +2424,11 @@ FZF-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
                         (message (cdr x)))
               :caller 'counsel-rpm)))
 
+(defcustom counsel-file-jump-args "* -type f -not -path '*\/.git*'"
+  "Arguments for the `find-command' when using `counsel-file-jump'."
+  :type 'string
+  :group 'ivy)
+
 ;;** `counsel-file-jump'
 ;;;###autoload
 (defun counsel-file-jump (&optional initial-input initial-directory)
@@ -2440,7 +2445,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
     (ivy-read "Find file: "
               (split-string
                (shell-command-to-string
-                (concat find-program " * -type f -not -path '*\/.git*'"))
+                (concat find-program " " counsel-file-jump-args))
                "\n" t)
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input
@@ -2452,6 +2457,11 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
               :history 'file-name-history
               :keymap counsel-find-file-map
               :caller 'counsel-file-jump)))
+
+(defcustom counsel-dired-jump-args "* -type f -not -path '*\/.git*'"
+  "Arguments for the `find-command' when using `counsel-dired-jump'."
+  :type 'string
+  :group 'ivy)
 
 ;;** `counsel-dired-jump'
 ;;;###autoload
@@ -2469,7 +2479,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
     (ivy-read "Directory: "
               (split-string
                (shell-command-to-string
-                (concat find-program " * -type d -not -path '*\/.git*'"))
+                (concat find-program " " counsel-dired-jump-args))
                "\n" t)
               :initial-input initial-input
               :action (lambda (d) (dired-jump nil (expand-file-name d)))


### PR DESCRIPTION
This is useful, because I use counsel in a big symlink farm, so the
default behaviour of "-type f" has to be repaced for me with "-type
f,l".  Other customization is e.g. inclusion of hidden files, as the
default is using * glob, that doesn't match hidden directories.