### PR TITLE
Add a simple initial counsel-switch-buffer

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4995,6 +4995,28 @@ When ARG is non-nil, ignore NoDisplay property in *.desktop files."
               :action #'counsel-wmctrl-action
               :caller 'counsel-wmctrl)))
 
+(defun counsel--switch-buffer-update-fn ()
+  (let ((current (ivy-state-current ivy-last)))
+    ;; This check is necessary, otherwise typing into the completion
+    ;; would create empty buffers.
+    (if (get-buffer current)
+        (ivy-call)
+      (with-ivy-window
+        (switch-to-buffer (ivy-state-buffer ivy-last))))))
+
+;;;###autoload
+(defun counsel-switch-buffer ()
+  "Switch to another buffer.
+Display a preview of the selected ivy completion candidate buffer
+in the current window."
+  (interactive)
+  (ivy-read "Switch to buffer: " 'internal-complete-buffer
+            :preselect (buffer-name (other-buffer (current-buffer)))
+            :action #'ivy--switch-buffer-action
+            :matcher #'ivy--switch-buffer-matcher
+            :caller 'counsel-switch-buffer
+            :update-fn 'counsel--switch-buffer-update-fn))
+
 ;;* `counsel-mode'
 (defvar counsel-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
This first implementation already provides the interactive element of
functionality: in the current window the user can preview her buffer
selection.