### PR TITLE
Do not let ivy virtual buffer faces creep into the recentf file

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3550,7 +3550,7 @@ CANDS is a list of strings."
         (unless (or (equal name "")
                     (get-file-buffer file-name)
                     (assoc name virtual-buffers))
-          (push (cons name file-name) virtual-buffers))))
+          (push (cons (copy-sequence name) file-name) virtual-buffers))))
     (when virtual-buffers
       (dolist (comp virtual-buffers)
         (put-text-property 0 (length (car comp))


### PR DESCRIPTION
We have to use `copy-sequence` before setting faces, otherwise the
user's ~/.emacs.d/recentf file will contain the reference to faces.
Since strings with or without text-properties are semantically
equivalent in elisp, this doesn't cause any issues, but is certainly
ugly and confusing to users who are not familiar with elisp/ivy
internals.