### PR TITLE
swiper.el (swiper-font-lock-exclude): Add deadgrep-mode

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -301,7 +301,8 @@
     circe-server-mode
     circe-query-mode
     sauron-mode
-    w3m-mode)
+    w3m-mode
+    deadgrep-mode)
   "List of major-modes that are incompatible with `font-lock-ensure'.")
 
 (defun swiper-font-lock-ensure-p ()


### PR DESCRIPTION
Refer to https://github.com/Wilfred/deadgrep/issues/44

I just added `deadgrep-mode` at the last of `swiper-font-lock-exclude` as it seems not ordered.
Maybe, better to sort  `swiper-font-lock-exclude` in dictionary order?