### PR TITLE
counsel.el: support for saving and calling the last counsel-M-x cmd

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -828,6 +828,9 @@ packages are, in order of precedence, `amx' and `smex'."
 (defvar counsel-M-x-history nil
   "History for `counsel-M-x'.")
 
+(defvar counsel-M-x-last-command nil
+  "Last command invoked via `counsel-M-x'.")
+
 ;;;###autoload
 (defun counsel-M-x (&optional initial-input)
   "Ivy version of `execute-extended-command'.
@@ -857,6 +860,7 @@ when available, in that order of precedence."
                         (setq prefix-arg current-prefix-arg)
                         (setq this-command cmd)
                         (setq real-this-command cmd)
+                        (setq counsel-M-x-last-command cmd)
                         (command-execute cmd 'record))
               :sort (not externs)
               :keymap counsel-describe-map
@@ -871,6 +875,14 @@ when available, in that order of precedence."
 (ivy-set-display-transformer
  'counsel-M-x
  'counsel-M-x-transformer)
+
+;;;###autoload
+(defun counsel-call-last-counsel-M-x-command ()
+  "Call last command invoked via `counsel-M-x'"
+  (interactive)
+  (if counsel-M-x-last-command
+      (command-execute counsel-M-x-last-command)
+    (message "No commands have been invoked via counsel-M-x yet")))
 
 ;;** `counsel-command-history'
 (defun counsel-command-history-action-eval (cmd)


### PR DESCRIPTION
This a (probably naive) implementation of saving the last command
called via `counsel-M-x` that also adds a simple function for calling
it.

Things to consider:
 - I don't understand enough of ivy/counsel internals to know if the same thing could be implemented via `counsel-M-x-history`
 - If the above cannot be done, is it possible to find a way (I
   presume via some configuration option) so that anyone who isn't
   interested in the last M-x command history doesn't have to pay the
   overhead of calling `(setq counsel-M-x-last-command cmd)` in the
   body of `counsel-M-x`? (More importantly, is that level of optimization something that we should even be concerned about?)
 - Should the function that calls the last M-x command be included
   into counsel.el, or is adding the last cmd variable enough, and 
   anyone can create their own function if they want to?

Thank you for your time