### PR TITLE
Make counsel-ag respect ivy-re-builder-alist

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2544,13 +2544,9 @@ regex string."
 
 (defvar counsel-ag-command nil)
 
-(defvar counsel-ag-look-around t
-  "Control for enabling lookarounds in `counsel-grep-regex'.
-If nil, disable look-arounds, else enable. If set to a string,
-enable look-arounds and add this value to `counsel-ag-command' as
-an additional argument.")
+(defvar counsel--ag-look-around t)
 
-(defvar counsel-regex-look-around nil)
+(defvar counsel--regex-look-around nil)
 
 (counsel-set-async-exit-code 'counsel-ag 1 "No matches found")
 (ivy-set-occur 'counsel-ag 'counsel-ag-occur)
@@ -2584,7 +2580,7 @@ NEEDLE is the search string."
   (counsel--elisp-to-pcre
    (setq ivy--old-re
          (funcall ivy--regex-function str))
-   counsel-regex-look-around))
+   counsel--regex-look-around))
 
 (defun counsel-ag-function (string)
   "Grep in the current directory for STRING."
@@ -2596,9 +2592,9 @@ NEEDLE is the search string."
          (ivy-more-chars))
        (let ((default-directory (ivy-state-directory ivy-last))
              (regex (counsel--grep-regex search-term)))
-         (if (and (stringp counsel-regex-look-around)
+         (if (and (stringp counsel--regex-look-around)
                   (string-match-p "\\`(\\?[=!]" regex))
-             (setq switches (concat switches counsel-regex-look-around)))
+             (setq switches (concat switches counsel--regex-look-around)))
          (counsel--async-command (counsel--format-ag-command
                                   switches
                                   (shell-quote-argument regex)))
@@ -2613,7 +2609,7 @@ EXTRA-AG-ARGS string, if non-nil, is appended to `counsel-ag-base-command'.
 AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   (interactive)
   (setq counsel-ag-command counsel-ag-base-command)
-  (setq counsel-regex-look-around counsel-ag-look-around)
+  (setq counsel--regex-look-around counsel--ag-look-around)
   (counsel-require-program counsel-ag-command)
   (when current-prefix-arg
     (setq initial-directory
@@ -2687,7 +2683,7 @@ This uses `counsel-ag' with `counsel-pt-base-command' instead of
 `counsel-ag-base-command'."
   (interactive)
   (let ((counsel-ag-base-command counsel-pt-base-command)
-        (counsel-ag-look-around nil))
+        (counsel--ag-look-around nil))
     (counsel-ag initial-input)))
 (cl-pushnew 'counsel-pt ivy-highlight-grep-commands)
 
@@ -2707,7 +2703,8 @@ INITIAL-INPUT can be given as the initial minibuffer input.
 This uses `counsel-ag' with `counsel-ack-base-command' replacing
 `counsel-ag-base-command'."
   (interactive)
-  (let ((counsel-ag-base-command counsel-ack-base-command))
+  (let ((counsel-ag-base-command counsel-ack-base-command)
+        (counsel--ag-look-around t))
     (counsel-ag initial-input)))
 
 
@@ -2718,11 +2715,9 @@ This uses `counsel-ag' with `counsel-ack-base-command' replacing
 Note: don't use single quotes for the regex."
   :type 'string)
 
-(defcustom counsel-rg-version nil
+(defvar counsel--rg-version nil
   "Ripgrep version used by `counsel-rg'.
-
-Version 0.10.0 and later supports PCRE2."
-  :type 'string)
+Version 0.10.0 and later supports PCRE2.")
 
 (counsel-set-async-exit-code 'counsel-rg 1 "No matches found")
 (ivy-set-occur 'counsel-rg 'counsel-ag-occur)
@@ -2736,17 +2731,17 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search.
 EXTRA-RG-ARGS string, if non-nil, is appended to `counsel-rg-base-command'.
 RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   (interactive)
-  (unless counsel-rg-version
-    (setq counsel-rg-version
-          (let ((version (shell-command-to-string "rg --version")))
+  (unless counsel--rg-version
+    (setq counsel--rg-version
+          (let* ((rg (executable-find "rg"))
+                 (version (shell-command-to-string (concat rg " --version"))))
             (if (string-match "\\`ripgrep \\([.0-9]+\\) " version)
                 (match-string 1 version)
               "0"))))
   (let ((counsel-ag-base-command counsel-rg-base-command)
-        (counsel-ag-look-around
-         (and counsel-rg-version
-              (version<= "0.10.0" counsel-rg-version)
-              " --pcre2")))
+        (counsel--ag-look-around
+         (when (version<= "0.10.0" counsel--rg-version)
+           " --pcre2")))
     (counsel-ag initial-input initial-directory extra-rg-args rg-prompt)))
 (cl-pushnew 'counsel-rg ivy-highlight-grep-commands)
 

--- a/counsel.el
+++ b/counsel.el
@@ -2731,7 +2731,7 @@ RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
         (counsel--grep-tool-look-around
          (let ((rg (car (split-string counsel-rg-base-command)))
                (switch "--pcre2"))
-           (and (eq 0 (call-process rg nil nil nil switch "--help"))
+           (and (eq 0 (call-process rg nil nil nil switch "--version"))
                 switch))))
     (counsel-ag initial-input initial-directory extra-rg-args rg-prompt)))
 (cl-pushnew 'counsel-rg ivy-highlight-grep-commands)

--- a/counsel.el
+++ b/counsel.el
@@ -2544,7 +2544,7 @@ regex string."
 
 (defvar counsel-ag-command nil)
 
-(defvar counsel--ag-look-around t)
+(defvar counsel--grep-tool-look-around t)
 
 (defvar counsel--regex-look-around nil)
 
@@ -2609,7 +2609,7 @@ EXTRA-AG-ARGS string, if non-nil, is appended to `counsel-ag-base-command'.
 AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   (interactive)
   (setq counsel-ag-command counsel-ag-base-command)
-  (setq counsel--regex-look-around counsel--ag-look-around)
+  (setq counsel--regex-look-around counsel--grep-tool-look-around)
   (counsel-require-program counsel-ag-command)
   (when current-prefix-arg
     (setq initial-directory
@@ -2683,7 +2683,7 @@ This uses `counsel-ag' with `counsel-pt-base-command' instead of
 `counsel-ag-base-command'."
   (interactive)
   (let ((counsel-ag-base-command counsel-pt-base-command)
-        (counsel--ag-look-around nil))
+        (counsel--grep-tool-look-around nil))
     (counsel-ag initial-input)))
 (cl-pushnew 'counsel-pt ivy-highlight-grep-commands)
 
@@ -2704,7 +2704,7 @@ This uses `counsel-ag' with `counsel-ack-base-command' replacing
 `counsel-ag-base-command'."
   (interactive)
   (let ((counsel-ag-base-command counsel-ack-base-command)
-        (counsel--ag-look-around t))
+        (counsel--grep-tool-look-around t))
     (counsel-ag initial-input)))
 
 
@@ -2739,7 +2739,7 @@ RG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
                 (match-string 1 version)
               "0"))))
   (let ((counsel-ag-base-command counsel-rg-base-command)
-        (counsel--ag-look-around
+        (counsel--grep-tool-look-around
          (when (version<= "0.10.0" counsel--rg-version)
            " --pcre2")))
     (counsel-ag initial-input initial-directory extra-rg-args rg-prompt)))


### PR DESCRIPTION
closes #1342. `counsel-ag` nor its derivatives support out of order matching, even though the underlying programs do. This means builders like `ivy--regex-ignore-order` or `ivy--regex-plus` are essentially ignored. I took the liberty of enabling out of order matching for the searchers that support it. This is one of the killer features of `helm-ag` IMHO. This will respect `ivy-re-builder-alist`. 

The only corner case for this is `rg` which did not add support for look-around's till `0.10.0` which was released Sep 2018. I implemented a solution to automatically handle the version checking, but if that seems too heavy handed I can remove it. Instead we could just define a custom variable like `counsel-rg-look-around-enabled-p`. However that would mean it would not work out of the box anymore.

Last thing I changed that may be up for debate is I removed the `:caller` options from `counsel-ag`. See #1934 for more details. I think this is the right call, because now you can set a different re-builder for each type of searcher, which was impossible before. If you still want to match all `counsel-ag` related functions, you can set the key to the collection (`counsel-ag-function`).