### PR TITLE
fix a couple of issue with company-read-env

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1892,32 +1892,6 @@ Skip some dotfiles unless `ivy-text' requires them."
 (defvar counsel-find-file-speedup-remote t
   "Speed up opening remote files by disabling `find-file-hook' for them.")
 
-(defun counsel-read-env ()
-  "Read a file path environment variable and insert it into the
-minibuffer."
-  (interactive)
-  (if (and ivy--directory
-           (equal ivy-text ""))
-      (let* ((cands (cl-loop for pair in process-environment
-                       for (var val) = (split-string pair "=" t)
-                       if (and val (not (equal "" val)))
-                       if (file-exists-p
-                           (if (file-name-absolute-p val)
-                               val
-                             (setq val
-                                   (expand-file-name val ivy--directory))))
-                       collect (cons var val)))
-             (enable-recursive-minibuffers t)
-             (x (ivy-read "Env: " cands))
-             (path (cdr (assoc x cands))))
-        (insert (if (file-accessible-directory-p path)
-                    (file-name-as-directory path)
-                  path))
-        (ivy--cd-maybe))
-    (insert last-input-event)))
-
-(define-key ivy-minibuffer-map "$" 'counsel-read-env)
-
 (defun counsel-find-file-action (x)
   "Find file X."
   (with-ivy-window

--- a/counsel.el
+++ b/counsel.el
@@ -1748,7 +1748,6 @@ currently checked out."
     (define-key map (kbd "C-DEL") 'counsel-up-directory)
     (define-key map (kbd "C-<backspace>") 'counsel-up-directory)
     (define-key map (kbd "C-M-y") 'counsel-yank-directory)
-    (define-key map "$" 'counsel-read-env)
     map))
 
 (defun counsel-yank-directory ()
@@ -1897,7 +1896,8 @@ Skip some dotfiles unless `ivy-text' requires them."
   "Read a file path environment variable and insert it into the
 minibuffer."
   (interactive)
-  (if (equal ivy-text "")
+  (if (and ivy--directory
+           (equal ivy-text ""))
       (let* ((cands (cl-loop for pair in process-environment
                        for (var val) = (split-string pair "=" t)
                        if (and val (not (equal "" val)))
@@ -1915,6 +1915,8 @@ minibuffer."
                   path))
         (ivy--cd-maybe))
     (insert last-input-event)))
+
+(define-key ivy-minibuffer-map "$" 'counsel-read-env)
 
 (defun counsel-find-file-action (x)
   "Find file X."

--- a/counsel.el
+++ b/counsel.el
@@ -1910,7 +1910,9 @@ minibuffer."
              (enable-recursive-minibuffers t)
              (x (ivy-read "Env: " cands))
              (path (cdr (assoc x cands))))
-        (insert path)
+        (insert (if (file-accessible-directory-p path)
+                    (file-name-as-directory path)
+                  path))
         (ivy--cd-maybe))
     (insert last-input-event)))
 


### PR DESCRIPTION
This PR does two things:

1. Makes `company-read-env` handle directory names correctly
2. Enables environment variable completion in `read-file-name-function`

Based on feedback from #1932 