### PR TITLE
counsel.el (counsel-file-jump): Fix file expansion

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2473,8 +2473,8 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
    (list nil
          (when current-prefix-arg
            (read-directory-name "From directory: "))))
-  (counsel-require-program "find")
-  (let* ((default-directory (or initial-directory default-directory)))
+  (counsel-require-program find-program)
+  (let ((default-directory (or initial-directory default-directory)))
     (ivy-read "Find file: "
               (split-string
                (shell-command-to-string
@@ -2482,9 +2482,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
                "\n" t)
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input
-              :action (lambda (x)
-                        (with-ivy-window
-                          (find-file (expand-file-name x ivy--directory))))
+              :action #'find-file
               :preselect (counsel--preselect-file)
               :require-match 'confirm-after-completion
               :history 'file-name-history


### PR DESCRIPTION
Expand candidate file names relative to original `default-directory`, not that of `ivy-state-window` (`ivy--directory` seems to always be `nil` in the action function).

Cc: @vornado63, @justbur 
Fixes: #1903 