### PR TITLE
Add counsel-compile

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5122,8 +5122,22 @@ properties include:
 If you want to persist history between Emacs sessions you can as this
 to variable to `savehist-additional-variables'.")
 
-(defvar counsel-compile-root-function 'counsel-locate-git-root
+(defvar counsel-compile-root-function 'counsel-locate-project-dwim
   "Function to find the project root for compile commands.")
+
+;; alternative project root finder for counsel-compile-root-function
+(defun counsel-locate-dir-locals ()
+  "Locate the root of the project by looking for .dir-locals."
+  (or (counsel--find-project-root ".dir-locals.el")
+      (error "Couldn't find .dir-locals")))
+
+(defun counsel-locate-project-dwim ()
+  "Locate the root of the project by trying a series of things."
+  (or (when (fboundp 'project-current)
+        (project-current))
+      (counsel-locate-dir-locals)
+      (counsel-locate-git-root)
+      (error "Couldn't find project root")))
 
 (defvar counsel-compile-local-builds
   '(counsel-compile-get-filtered-history

--- a/counsel.el
+++ b/counsel.el
@@ -1172,9 +1172,17 @@ selected face."
  '(("j" find-file-other-window "other window")
    ("x" counsel-find-file-extern "open externally")))
 
+;; Common helper for counsel
+(defun counsel--find-project-root (&optional domfile startdir)
+  "Traverse up from `default-directory' or STARTDIR until we find DOMFILE.
+Returns a fully expanded path."
+  (expand-file-name (locate-dominating-file
+                     (or startdir default-directory)
+                     (or domfile ".git"))))
+
 (defun counsel-locate-git-root ()
   "Locate the root of the git repository containing the current buffer."
-  (or (locate-dominating-file default-directory ".git")
+  (or (counsel--find-project-root ".git")
       (error "Not in a git repository")))
 
 ;;;###autoload
@@ -2632,7 +2640,7 @@ AG-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
                                      (car (split-string counsel-ag-command)))))))
   (setq counsel-ag-command (counsel--format-ag-command (or extra-ag-args "") "%s"))
   (let ((default-directory (or initial-directory
-                               (locate-dominating-file default-directory ".git")
+                               (counsel-locate-git-root)
                                default-directory)))
     (ivy-read (or ag-prompt
                   (concat (car (split-string counsel-ag-command)) ": "))

--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -264,6 +264,7 @@ with some sample bindings:
 - Ivy-based interface to shell and system tools ::
 
      #+begin_src elisp
+     (global-set-key (kbd "C-c c") 'counsel-compile)
      (global-set-key (kbd "C-c g") 'counsel-git)
      (global-set-key (kbd "C-c j") 'counsel-git-grep)
      (global-set-key (kbd "C-c k") 'counsel-ag)


### PR DESCRIPTION
My paperwork is into the fsf for copyright contribution. As you can see I've re-worked the patch as a proper series starting with some basic machinery before adding additional helpers. I would hope we can add checks for other build systems by adding a new helper and configuring the list.

I would appreciate any comments on the code especially the later commits which try and prevent counsel locking up the system if you have a lot of out of date builds. The option of using the prefix key does beg the question of if we should use the prefix to trigger the gathering of extra build types and default just to history (which would be the common case).

Currently the CI fails for older Emacsen because of the require of cl-extra. Do I need to add it somewhere in the test harness as well?