### PR TITLE
counsel-org-goto-all: Add candidate prefixes & use org-mode settings

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4283,7 +4283,8 @@ setting in `counsel-outline-settings', which see."
   "Return an alist of outline heading completion candidates.
 Each element is a pair (HEADING . MARKER), where the string
 HEADING is located at the position of MARKER.  SETTINGS is a
-plist entry from `counsel-outline-settings', which see."
+plist entry from `counsel-outline-settings', which see. PREFIX is
+a string prepended to all candidates."
   (let* ((bol-regex (concat "^\\(?:"
                             (or (plist-get settings :outline-regexp)
                                 outline-regexp)

--- a/counsel.el
+++ b/counsel.el
@@ -4303,9 +4303,9 @@ a string prepended to all candidates."
                            counsel-outline-custom-faces))
          (stack-level 0)
          (orig-point (point))
-         (stack (if prefix
-                    (list (counsel-outline--add-face
-                           prefix 0 face-style custom-faces))))
+         (stack (and prefix
+                     (list (counsel-outline--add-face
+                            prefix 0 face-style custom-faces))))
          cands name level marker)
     (save-excursion
       (setq counsel-outline--preselect 0)

--- a/counsel.el
+++ b/counsel.el
@@ -3127,6 +3127,8 @@ otherwise continue prompting for tags."
 ;;;###autoload
 (defalias 'counsel-org-goto #'counsel-outline)
 
+(defvar counsel-outline-settings)
+
 ;;;###autoload
 (defun counsel-org-goto-all ()
   "Go to a different location in any org file."
@@ -3135,7 +3137,11 @@ otherwise continue prompting for tags."
     (dolist (b (buffer-list))
       (with-current-buffer b
         (when (derived-mode-p 'org-mode)
-          (setq entries (nconc entries (counsel-outline-candidates))))))
+          (setq entries
+                (nconc entries
+                       (counsel-outline-candidates
+                        (cdr (assq 'org-mode
+                                   counsel-outline-settings))))))))
     (ivy-read "Goto: " entries
               :history 'counsel-org-goto-history
               :action #'counsel-org-goto-action

--- a/counsel.el
+++ b/counsel.el
@@ -3128,21 +3128,26 @@ otherwise continue prompting for tags."
 (defalias 'counsel-org-goto #'counsel-outline)
 
 (defcustom counsel-org-goto-all-outline-path-prefix nil
-  "When the value is 'file, include the file name (without
-directory) into the outline path candidate.
+  "Prefix for outline candidates in `counsel-org-goto-all'.
 
-When 'full-file-path, include the full file name.
+When the value is symbol `file-name', use the full file name.
 
-When 'buffer-name, include the buffer name."
+When symbol `file-name-nondirectory', use the nondirectory part
+of the file name (as returned by `file-name-nondirectory').
+
+When symbol `buffer-name', use the buffer name.
+
+When nil, no prefix is used."
   :type '(choice (const :tag "None" nil)
-	         (const :tag "File name" file)
-	         (const :tag "Full file name" full-file-path)
+	         (const :tag "File name" file-name)
+	         (const :tag "File name (nondirectory part)"
+	                file-name-nondirectory)
 	         (const :tag "Buffer name" buffer-name)))
 
 (defun counsel-org-goto-all--outline-path-prefix ()
   (cl-case counsel-org-goto-all-outline-path-prefix
-    (file (file-name-nondirectory (buffer-file-name)))
-    (full-file-path (buffer-file-name))
+    (file-name buffer-file-name)
+    (file-name-nondirectory (file-name-nondirectory buffer-file-name))
     (buffer-name (buffer-name))))
 
 (defvar counsel-outline-settings)


### PR DESCRIPTION
Hi,

I'd like to contribute two changes to `counsel-org-goto-all` that make the command much more useful to me:

1. Pass the settings for `org-mode` to `counsel-outline-candidates` so that it respects Org-specific variables such as `counsel-org-goto-display-tags`, `counsel-org-goto-display-todo`, etc.

2. Add customization setting to prepend file/buffer name of a heading as a prefix in the candidate list, with the same choices as for `org-refile-use-outline-path`.

I believe the changes aren't legally significant (half of the diff is whitespace changes).