### PR TITLE
Update ivy-help.org

### DIFF
--- a/doc/ivy-help.org
+++ b/doc/ivy-help.org
@@ -132,7 +132,7 @@ Additionally, here are the keys that are otherwise not bound:
 - ~<~ and ~>~ adjust the height of the minibuffer.
 - ~c~ (=ivy-toggle-calling=) - toggle calling the current action each
   time a different candidate is selected.
-- ~m~ (=ivy-rotate-preferred-builders=) - rotate regex matcher.
+- ~M~ (=ivy-rotate-preferred-builders=) - rotate regex matcher.
 - ~w~ and ~s~ scroll the actions list.
 
 Minibuffer editing is disabled when Hydra is active.


### PR DESCRIPTION
m was replaced to M in latest version.