### PR TITLE
Restore buffer-list after counsel-switch-buffers

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5043,14 +5043,20 @@ When ARG is non-nil, ignore NoDisplay property in *.desktop files."
 (defvar counsel--switch-buffer-temporary-buffers nil
   "Internal.")
 
+(defvar counsel--switch-buffer-previous-buffers nil
+  "Internal.")
+
 (defun counsel--switch-buffer-unwind ()
-  "Clear temporary file buffers.
+  "Clear temporary file buffers and restore `buffer-list'.
 The buffers are those opened during a session of `counsel-switch-buffer'."
-  (while counsel--switch-buffer-temporary-buffers
-    (let ((buf (pop counsel--switch-buffer-temporary-buffers)))
-      (kill-buffer buf))))
+  (mapc 'kill-buffer counsel--switch-buffer-temporary-buffers)
+  (mapc 'bury-buffer counsel--switch-buffer-previous-buffers)
+  (setq counsel--switch-buffer-temporary-buffers nil
+        counsel--switch-buffer-previous-buffers nil))
 
 (defun counsel--switch-buffer-update-fn ()
+  (unless counsel--switch-buffer-previous-buffers
+    (setq counsel--switch-buffer-previous-buffers (buffer-list)))
   (let ((current (ivy-state-current ivy-last)))
     ;; This check is necessary, otherwise typing into the completion
     ;; would create empty buffers.


### PR DESCRIPTION
Previewing the buffers calls `switch-to-buffer` without the NORECORD flag, so the buffer-list is modified (previewed buffers are bumped up the list).  This change keeps a backup of buffer-list and restores it during unwind.

Copyright:  I believe this change is small enough to not be "legally significant".  I'm currently in the process of sorting out copyright assignment.