### PR TITLE
Fix error in ivy-make-magic-action

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2872,7 +2872,7 @@ bound to `self-insert-command'."
        (interactive "p")
        (if (string= "" ivy-text)
            (execute-kbd-macro
-            (kbd (concat "M-o " key)))
+            (kbd ,(concat "M-o " key)))
          (self-insert-command arg)))))
 
 (defcustom ivy-magic-tilde t


### PR DESCRIPTION
The lambda created in `ivy-make-magic-action` is not a closure, so we need to evaluate all free variables in it. Otherwise we get a void variable error referencing `key`.