### PR TITLE
Don't bury killed buffers after counsel-switch-buffer

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5077,8 +5077,10 @@ When ARG is non-nil, ignore NoDisplay property in *.desktop files."
 (defun counsel--switch-buffer-unwind ()
   "Clear temporary file buffers and restore `buffer-list'.
 The buffers are those opened during a session of `counsel-switch-buffer'."
-  (mapc 'kill-buffer counsel--switch-buffer-temporary-buffers)
-  (mapc 'bury-buffer counsel--switch-buffer-previous-buffers)
+  (mapc #'kill-buffer counsel--switch-buffer-temporary-buffers)
+  (mapc #'bury-buffer (cl-remove-if-not
+                       #'buffer-live-p
+                       counsel--switch-buffer-previous-buffers))
   (setq counsel--switch-buffer-temporary-buffers nil
         counsel--switch-buffer-previous-buffers nil))
 


### PR DESCRIPTION
It's possible for a killed buffer to remain on buffer-list, causing bury-buffer to error while restoring the original buffer-list.  Erroring here leaves `counsel--switch-buffer-temporary-buffers` and `counsel--switch-buffer-previous-buffers` set with old values, leading to abnormal behavior on subsequent calls to `counsel-switch-buffer`.