### PR TITLE
Make ivy-switch-buffer-occur work with multi-pass regex builders

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3992,11 +3992,11 @@ Skip buffers that match `ivy-ignore-buffers'."
   "Occur function for `ivy-switch-buffer' using `ibuffer'."
   (ibuffer
    nil (buffer-name)
-   `((or ,@(cl-loop for cand in ivy--old-cands
-                    unless (eq (get-text-property 0 'face cand)
-                               'ivy-virtual)
-                    collect `(name . ,(format "\\_<%s\\_>"
-                                              (regexp-quote cand))))))))
+   `((or ,@(cl-mapcan
+            (lambda (cand)
+              (unless (eq (get-text-property 0 'face cand) 'ivy-virtual)
+                `((name . ,(format "\\_<%s\\_>" (regexp-quote cand))))))
+            ivy--old-cands)))))
 
 ;;;###autoload
 (defun ivy-switch-buffer ()

--- a/ivy.el
+++ b/ivy.el
@@ -3990,7 +3990,13 @@ Skip buffers that match `ivy-ignore-buffers'."
 
 (defun ivy-switch-buffer-occur ()
   "Occur function for `ivy-switch-buffer' using `ibuffer'."
-  (ibuffer nil (buffer-name) (list (cons 'name ivy--old-re))))
+  (ibuffer
+   nil (buffer-name)
+   `((or ,@(cl-loop for cand in ivy--old-cands
+                    unless (eq (get-text-property 0 'face cand)
+                               'ivy-virtual)
+                    collect `(name . ,(format "\\_<%s\\_>"
+                                              (regexp-quote cand))))))))
 
 ;;;###autoload
 (defun ivy-switch-buffer ()


### PR DESCRIPTION
Currently `ivy-switch-buffer-occur` is broken if you are using a multi-pass regex builder such as `ivy--regex-plus` or `ivy--regex-ignore-order`. The ibuffer list will include all buffers because the qualifier passed to it is invalid. Even if you were using a single pass regex builder, the occur buffer did not respect `ivy-ignore-buffers`. That has all been fixed with this change. 