### PR TITLE
Anchor PCRE lookaround patterns to bol

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -63,14 +63,16 @@ Note that incorrect results may be returned for sufficiently
 complex regexes."
   (if (consp regex)
       (if look-around
-          (mapconcat
-           (lambda (pair)
-             (let ((subexp (counsel--elisp-to-pcre (car pair))))
-               (format "(?%c.*%s)"
-                       (if (cdr pair) ?= ?!)
-                       subexp)))
-           regex
-           "")
+          (concat
+           "^"
+           (mapconcat
+            (lambda (pair)
+              (let ((subexp (counsel--elisp-to-pcre (car pair))))
+                (format "(?%c.*%s)"
+                        (if (cdr pair) ?= ?!)
+                        subexp)))
+            regex
+            ""))
         (mapconcat
          (lambda (pair)
            (let ((subexp (counsel--elisp-to-pcre (car pair))))
@@ -2621,7 +2623,7 @@ NEEDLE is the search string."
        (let ((default-directory (ivy-state-directory ivy-last))
              (regex (counsel--grep-regex search-term)))
          (if (and (stringp counsel--regex-look-around)
-                  (string-match-p "\\`(\\?[=!]" regex)) ;; using look-arounds
+                  (string-match-p "\\`\\^(\\?[=!]" regex)) ;; using look-arounds
              (setq switches (concat switches " " counsel--regex-look-around)))
          (counsel--async-command (counsel--format-ag-command
                                   switches

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -347,7 +347,7 @@ will bring the behavior in line with the newer Emacsen."
                  "(?:foo|bar).*blick.*(?:(baz)|quux)"))
   (should (equal (counsel--elisp-to-pcre
                   '(("ivy" . t) ("-")) t)
-                 "(?=.*ivy)(?!.*-)")))
+                 "^(?=.*ivy)(?!.*-)")))
 
 (defmacro ivy--string-buffer (text &rest body)
   "Test helper that wraps TEXT in a temp buffer while running BODY."
@@ -989,7 +989,7 @@ a buffer visiting a file."
     (let ((counsel--regex-look-around t)
           (ivy--regex-function 'ivy--regex-plus))
       (counsel--grep-regex "ivy ! -"))
-    "(?=.*ivy)(?!.*-)"))
+    "^(?=.*ivy)(?!.*-)"))
   (should
    (string=
     (let ((counsel--regex-look-around t)


### PR DESCRIPTION
closes #1976 

Anchoring the PCRE pattern greatly improves performance for ripgrep and seems to speedup `ag` as well. 