### PR TITLE
counsel.el (counsel-unicode-char): Fix sorting

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4471,11 +4471,6 @@ COUNT defaults to 1."
   (interactive "p")
   (setq ivy-completion-beg (point))
   (setq ivy-completion-end (point))
-  (unless (listp counsel--unicode-table)
-    (setq counsel--unicode-table
-          (sort
-           (all-completions "" counsel--unicode-table)
-           (ivy--sort-function 'counsel-unicode-char))))
   (ivy-read "Unicode name: " counsel--unicode-table
             :history 'counsel-unicode-char-history
             :sort t


### PR DESCRIPTION
`ivy--sort-function` may return `nil`, but doing this is redundant anyway, since `counsel--unicode-table` is sorted and cached lazily, and `ivy-read` later obeys `ivy-sort-functions-alist` and `ivy-sort-max-size`.

Re: dc250bd7b577cefadbe89856f2e5e36ae17aa4ed