### PR TITLE
Fix counsel-org-tag-agenda

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3072,13 +3072,13 @@ otherwise continue prompting for tags."
 (defun counsel-org-tag-agenda ()
   "Set tags for the current agenda item."
   (interactive)
-  (let ((store (symbol-function 'org-set-tags)))
+  (let ((store (symbol-function 'org-set-tags-command)))
     (unwind-protect
          (progn
-           (fset 'org-set-tags
+           (fset 'org-set-tags-command
                  (symbol-function 'counsel-org-tag))
            (org-agenda-set-tags nil nil))
-      (fset 'org-set-tags store))))
+      (fset 'org-set-tags-command store))))
 
 (define-obsolete-variable-alias 'counsel-org-goto-display-tags
     'counsel-org-headline-display-tags "0.10.0")


### PR DESCRIPTION
As of Org 9.2.3, this function is not working because `org-set-tags` is the function that received the tags list or string, while the counsel substitute doesn't have any parameters.

Changing this to `org-set-tags-command`, which is called from `org-agenda-set-tags` fixes the issue.