### PR TITLE
counsel.el: Strip space from initial input of counsel-package

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3537,7 +3537,7 @@ Additional actions:\\<ivy-minibuffer-map>
             :require-match t
             :caller 'counsel-package))
 
-(cl-pushnew '(counsel-package . "^+ ") ivy-initial-inputs-alist :key #'car)
+(cl-pushnew '(counsel-package . "^+") ivy-initial-inputs-alist :key #'car)
 
 (defun counsel-package-action (package)
   "Delete or install PACKAGE."


### PR DESCRIPTION
This could reduce key presses in most cases.

| Filter packages to ...              | # of key presses with `^+ ` (space) | # of key presses with `^+` (no space) |
| ---                                 | ---                                 | ---                                   |
| install package starting with `x`   | 2                                   | 1                                     |
| uninstall package starting with `x` | 4                                   | 3                                     |
| install package containing `x`      | 1                                   | 2                                     |
| uninstall package containing `x`    | 5                                   | 4                                     |

For example,

* If initial input is `^+ ` (space), it requires <kbd>Backspace</kbd> <kbd>Backspace</kbd> <kbd>-</kbd> <kbd>x</kbd> to filter packages to uninstall package starting with `x`
* If initial input is `^+` (no space), it requires <kbd>Backspace</kbd> <kbd>-</kbd> <kbd>x</kbd> to filter packages to uninstall package starting with `x`

I'd like to do this small change before #1987.
