### PR TITLE
Revert last change to counsel-yank-pop-action

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3745,12 +3745,9 @@ buffer position."
     (barf-if-buffer-read-only)
     (setq last-command 'yank)
     (setq yank-window-start (window-start))
-    (condition-case nil
-        ;; Avoid unexpected additions to `kill-ring'
-        (let (interprogram-paste-function)
-          (yank-pop (counsel--yank-pop-position s)))
-      (error
-       (insert s)))
+    ;; Avoid unexpected additions to `kill-ring'
+    (let (interprogram-paste-function)
+      (yank-pop (counsel--yank-pop-position s)))
     (when (funcall (if counsel-yank-pop-after-point #'> #'<)
                    (point) (mark t))
       (exchange-point-and-mark t))))


### PR DESCRIPTION
This reverts commit 18d7f84c2ffea655b61730cba52ea0347a430292 "counsel.el (counsel-yank-pop-action): Also works for strings".

Programs should use `kill-new` instead of trying to hack the complicated kill+yank subsystem, which will inevitably lead to problems.