### PR TITLE
Add swiper-region and swiper-isearch-region

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1303,15 +1303,15 @@ come back to the same place as when \"a\" was initially entered.")
         (cl-pushnew ivy-text swiper-history)))))
 
 ;;;###autoload
-(defun swiper-isearch-region-or-not ()
+(defun swiper-isearch-region ()
   "If region is selected, `swiper-isearch' with the keyword selected in region.
 If the region isn't selected, `swiper-isearch'."
   (interactive)
-  (if (region-active-p)
-      (progn (setq mark-active nil)
-             (swiper-isearch (buffer-substring
-                              (region-beginning) (region-end))))
-    (swiper-isearch)))
+  (if (not (use-region-p))
+      (swiper-isearch)
+    (deactivate-mark)
+    (swiper-isearch (buffer-substring-no-properties
+                     (region-beginning) (region-end)))))
 
 (ivy-set-occur 'swiper-isearch 'swiper-occur)
 

--- a/swiper.el
+++ b/swiper.el
@@ -510,7 +510,7 @@ If the region isn't selected, `swiper'."
   (interactive)
   (if (region-active-p)
       (progn (setq mark-active nil)
-	     (swiper (buffer-substring
+             (swiper (buffer-substring
                       (region-beginning) (region-end))))
     (swiper)))
 
@@ -1309,8 +1309,8 @@ If the region isn't selected, `swiper-isearch'."
   (interactive)
   (if (region-active-p)
       (progn (setq mark-active nil)
-	     (swiper-isearch (buffer-substring
-			      (region-beginning) (region-end))))
+             (swiper-isearch (buffer-substring
+                              (region-beginning) (region-end))))
     (swiper-isearch)))
 
 (ivy-set-occur 'swiper-isearch 'swiper-occur)

--- a/swiper.el
+++ b/swiper.el
@@ -503,6 +503,17 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
   (swiper--ivy (swiper--candidates) initial-input))
 
+;;;###autoload
+(defun swiper-region-or-not ()
+  "If region is selected, `swiper' with the keyword selected in region.
+If the region isn't selected, `swiper'."
+  (interactive)
+  (if (region-active-p)
+      (progn (setq mark-active nil)
+	     (swiper (buffer-substring
+                      (region-beginning) (region-end))))
+    (swiper)))
+
 (defvar swiper--current-window-start nil
   "Store `window-start' to restore it later.
 This prevents a \"jumping\" behavior which occurs when variables
@@ -1290,6 +1301,17 @@ come back to the same place as when \"a\" was initially entered.")
         (goto-char swiper--opoint))
       (unless (or res (string= ivy-text ""))
         (cl-pushnew ivy-text swiper-history)))))
+
+;;;###autoload
+(defun swiper-isearch-region-or-not ()
+  "If region is selected, `swiper-isearch' with the keyword selected in region.
+If the region isn't selected, `swiper-isearch'."
+  (interactive)
+  (if (region-active-p)
+      (progn (setq mark-active nil)
+	     (swiper-isearch (buffer-substring
+			      (region-beginning) (region-end))))
+    (swiper-isearch)))
 
 (ivy-set-occur 'swiper-isearch 'swiper-occur)
 

--- a/swiper.el
+++ b/swiper.el
@@ -504,15 +504,15 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
   (swiper--ivy (swiper--candidates) initial-input))
 
 ;;;###autoload
-(defun swiper-region-or-not ()
+(defun swiper-region ()
   "If region is selected, `swiper' with the keyword selected in region.
 If the region isn't selected, `swiper'."
   (interactive)
-  (if (region-active-p)
-      (progn (setq mark-active nil)
-             (swiper (buffer-substring
-                      (region-beginning) (region-end))))
-    (swiper)))
+  (if (not (use-region-p))
+      (swiper)
+    (deactivate-mark)
+    (swiper (buffer-substring-no-properties
+             (region-beginning) (region-end)))))
 
 (defvar swiper--current-window-start nil
   "Store `window-start' to restore it later.


### PR DESCRIPTION
I think this is a useful function in the swiper so please import it if you like.

swiper-isearch-region
If region is selected, swiper-isearch with the keyword selected in region.
If the region isn't selected, swiper-isearch.

swiper-region
If region is selected, swiper with the keyword selected in region.
If the region isn't selected, swiper.
