### PR TITLE
Improvements for swiper-isearch

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1271,6 +1271,7 @@ come back to the same place as when \"a\" was initially entered.")
 (defun swiper-isearch (&optional initial-input)
   "A `swiper' that's not line-based."
   (interactive)
+  (swiper-font-lock-ensure)
   (swiper--init)
   (setq swiper--isearch-point-history
         (list

--- a/swiper.el
+++ b/swiper.el
@@ -1275,9 +1275,7 @@ come back to the same place as when \"a\" was initially entered.")
   (swiper--init)
   (setq swiper--isearch-point-history
         (list
-         (cons "" (if executing-kbd-macro
-                      (point)
-                    (line-beginning-position)))))
+         (cons "" (point))))
   (let ((ivy-fixed-height-minibuffer t)
         (cursor-in-non-selected-windows nil)
         (swiper-min-highlight 1)

--- a/swiper.el
+++ b/swiper.el
@@ -1203,6 +1203,14 @@ corresponds to it.
 This ensures that if the user enters \"ab\", the point will
 come back to the same place as when \"a\" was initially entered.")
 
+(defvar swiper-isearch-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map swiper-map)
+    (define-key map (kbd "C-s") 'ivy-next-line)
+    (define-key map (kbd "C-r") 'ivy-previous-line)
+    map)
+  "Keymap for swiper-isearch.")
+
 (defun swiper-isearch-function (str)
   "Collect STR matches in the current buffer for `swiper-isearch'."
   (let* ((re-full (funcall ivy--regex-function str))
@@ -1280,7 +1288,7 @@ come back to the same place as when \"a\" was initially entered.")
                  "Swiper: "
                  #'swiper-isearch-function
                  :initial-input initial-input
-                 :keymap swiper-map
+                 :keymap swiper-isearch-map
                  :dynamic-collection t
                  :require-match t
                  :action #'swiper-isearch-action

--- a/swiper.el
+++ b/swiper.el
@@ -1228,8 +1228,11 @@ come back to the same place as when \"a\" was initially entered.")
               (cl-incf idx)
               (let ((line (buffer-substring
                            (line-beginning-position)
-                           (line-end-position))))
-                (put-text-property 0 1 'point (point) line)
+                           (line-end-position)))
+                    (pos (if swiper-goto-start-of-match
+                             (match-beginning 0)
+                           (point))))
+                (put-text-property 0 1 'point pos line)
                 (push line cands)))))
         (setq ivy--old-re re)
         (when idx-found


### PR DESCRIPTION
Adds `swiper-goto-start-of-match` support for swiper-isearch.

Adds swiper-isearch-map with `C-s` and `C-r` bindings, matching the isearch bindings for continuing/reversing the search.

Adds a call to `swiper-font-lock-ensure` to prevent showing unformatted candidates.

Fixes #2025 by always keeping the exact start point in `swiper--isearch-point-history`.