### PR TITLE
Counsel compile env

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5267,6 +5267,15 @@ trees."
                                 (match-string-no-properties 1)))))))
     (sort targets #'string-lessp)))
 
+(defun counsel-compile--pretty-propertize (leader text face)
+  "Return a pretty string of the form \" LEADER TEXT\".
+LEADER is propertized with a warning face and the remaining
+text with FACE."
+  (concat (propertize (concat " " leader " ")
+                      'face
+                      'font-lock-warning-face)
+          (propertize text 'face face)))
+
 (defun counsel--compile-get-make-targets (srcdir &optional blddir)
   "Return a list of Make targets for a given SRCDIR/BLDDIR combination.
 

--- a/counsel.el
+++ b/counsel.el
@@ -5171,6 +5171,8 @@ The properties include:
     the root directory of the source code
 `blddir'
     the root directory of the build (in or outside the `srcdir')
+`bldenv'
+    the build environment as passed to `compilation-environment'
 `recursive'
     the completion should be run again in `blddir' of this result
 `cmd'
@@ -5234,6 +5236,12 @@ You may, for example, want to add \"-jN\" for the number of cores
 N in your system."
   :type 'string)
 
+(defcustom counsel-compile-env nil
+  "List of environment variables for compilation to inherit.
+Each element should be a string of the form ENVVARNAME=VALUE.  This
+list is passed to `compilation-environment'."
+  :type '(repeat (string :tag "ENVVARNAME=VALUE")))
+
 (defcustom counsel-compile-make-pattern "\\`\\(?:GNUm\\|[Mm]\\)akefile\\'"
   "Regexp for matching the names of Makefiles."
   :type 'regexp)
@@ -5286,11 +5294,16 @@ The resulting strings are tagged with properties that
   (let ((fmt (format (propertize "make %s %%s" 'cmd t)
                      counsel-compile-make-args))
         (suffix (and blddir
-                     (concat (propertize " in " 'face 'font-lock-warning-face)
-                             (propertize blddir 'face 'dired-directory))))
-        (props `(srcdir ,srcdir blddir ,blddir)))
+                     (counsel-compile--pretty-propertize "in" blddir
+                                                         'dired-directory)))
+        (build-env (and counsel-compile-env
+                        (counsel-compile--pretty-propertize
+                         "with"
+                         (mapconcat #'identity counsel-compile-env " ")
+                         'font-lock-variable-name-face)))
+        (props `(srcdir ,srcdir blddir ,blddir bldenv ,counsel-compile-env)))
     (mapcar (lambda (target)
-              (setq target (concat (format fmt target) suffix))
+              (setq target (concat (format fmt target) suffix build-env))
               (add-text-properties 0 (length target) props target)
               target)
             (counsel-compile--probe-make-targets (or blddir srcdir)))))
@@ -5367,12 +5380,18 @@ This is determined by `counsel-compile-local-builds', which see."
   "Update `counsel-compile-history' from the compilation state."
   (let* ((srcdir (counsel--compile-root))
          (blddir default-directory)
+         (bldenv compilation-environment)
          (cmd (concat
                (propertize (car compilation-arguments) 'cmd t)
                (unless (file-equal-p blddir srcdir)
-                 (concat (propertize " in " 'face 'font-lock-warning-face)
-                         (propertize blddir 'face 'dired-directory))))))
-    (add-text-properties 0 (length cmd) `(srcdir ,srcdir blddir ,blddir) cmd)
+                 (counsel-compile--pretty-propertize "in" blddir
+                                                     'dired-directory))
+               (when bldenv
+                 (counsel-compile--pretty-propertize "with"
+                                                     (mapconcat #'identity bldenv " ")
+                                                     'font-lock-variable-name-face)))))
+    (add-text-properties 0 (length cmd)
+                         `(srcdir ,srcdir blddir ,blddir bldenv ,bldenv) cmd)
     (add-to-history 'counsel-compile-history cmd)))
 
 (defun counsel-compile--action (cmd)
@@ -5381,13 +5400,15 @@ This is determined by `counsel-compile-local-builds', which see."
 If CMD has the `recursive' property set we call `counsel-compile'
 again to further refine the compile options in the directory
 specified by the `blddir' property."
-  (let ((blddir (get-text-property 0 'blddir cmd)))
+  (let ((blddir (get-text-property 0 'blddir cmd))
+        (bldenv (get-text-property 0 'bldenv cmd)))
     (if (get-text-property 0 'recursive cmd)
         (counsel-compile blddir)
       (when (get-char-property 0 'cmd cmd)
         (setq cmd (substring-no-properties
                    cmd 0 (next-single-property-change 0 'cmd cmd))))
-      (let ((default-directory blddir))
+      (let ((default-directory blddir)
+            (compilation-environment bldenv))
         ;; No need to specify `:history' because of this hook.
         (add-hook 'compilation-start-hook #'counsel-compile--update-history)
         (unwind-protect

--- a/counsel.el
+++ b/counsel.el
@@ -5414,7 +5414,7 @@ specified by the `blddir' property."
       (when (get-char-property 0 'cmd cmd)
         (setq cmd (substring-no-properties
                    cmd 0 (next-single-property-change 0 'cmd cmd))))
-      (let ((default-directory blddir)
+      (let ((default-directory (or blddir default-directory))
             (compilation-environment bldenv))
         ;; No need to specify `:history' because of this hook.
         (add-hook 'compilation-start-hook #'counsel-compile--update-history)

--- a/counsel.el
+++ b/counsel.el
@@ -5245,6 +5245,10 @@ list is passed to `compilation-environment'."
 (defvar counsel-compile-env-history nil
   "History for `counsel-compile-env'.")
 
+(defvar counsel-compile-env-pattern
+  "[_[:digit:][:upper:]]+=[/[:album:]]*"
+  "Pattern to match valid environment variables.")
+
 (defcustom counsel-compile-make-pattern "\\`\\(?:GNUm\\|[Mm]\\)akefile\\'"
   "Regexp for matching the names of Makefiles."
   :type 'regexp)
@@ -5445,9 +5449,11 @@ specified by the `blddir' property."
 
 (defun counsel-compile-env--update (var)
   "Update `counsel-compile-env' either adding or removing VAR."
-  (if (member var counsel-compile-env)
-      (setq counsel-compile-env (delete var counsel-compile-env))
-    (add-to-list 'counsel-compile-env var)))
+  (cond ((member var counsel-compile-env)
+         (setq counsel-compile-env (delete var counsel-compile-env)))
+        ((string-match-p counsel-compile-env-pattern var)
+         (push var counsel-compile-env))
+        (t (user-error "Ignoring malformed variable: '%s'" var))))
 
 ;;;###autoload
 (defun counsel-compile-env ()
@@ -5458,6 +5464,9 @@ specified by the `blddir' property."
               (delete-dups (append
                             counsel-compile-env counsel-compile-env-history))
               :action #'counsel-compile-env--update
+              :predicate (lambda (cand)
+                           (string-match-p counsel-compile-env-pattern
+                                           cand))
               :history 'counsel-compile-env-history
               :caller 'counsel-compile-env)))
 

--- a/counsel.el
+++ b/counsel.el
@@ -5242,6 +5242,9 @@ Each element should be a string of the form ENVVARNAME=VALUE.  This
 list is passed to `compilation-environment'."
   :type '(repeat (string :tag "ENVVARNAME=VALUE")))
 
+(defvar counsel-compile-env-history nil
+  "History for `counsel-compile-env'.")
+
 (defcustom counsel-compile-make-pattern "\\`\\(?:GNUm\\|[Mm]\\)akefile\\'"
   "Regexp for matching the names of Makefiles."
   :type 'regexp)
@@ -5423,6 +5426,40 @@ specified by the `blddir' property."
             (counsel--get-compile-candidates dir)
             :action #'counsel-compile--action
             :caller 'counsel-compile))
+
+
+(defun counsel-compile-env--format-hint (cands)
+  "Return a formatter for compile-env CANDS."
+  (let ((rmstr
+         (propertize "remove" 'face 'font-lock-warning-face))
+        (addstr
+         (propertize "add" 'face 'font-lock-variable-name-face)))
+    (ivy--format-function-generic
+     (lambda (selected)
+       (format "%s %s"
+               (if (member selected counsel-compile-env) rmstr addstr)
+               selected))
+     #'identity
+     cands
+     "\n")))
+
+(defun counsel-compile-env--update (var)
+  "Update `counsel-compile-env' either adding or removing VAR."
+  (if (member var counsel-compile-env)
+      (setq counsel-compile-env (delete var counsel-compile-env))
+    (add-to-list 'counsel-compile-env var)))
+
+;;;###autoload
+(defun counsel-compile-env ()
+  "Update `counsel-compile-env' interactively."
+  (interactive)
+  (let ((ivy-format-function #'counsel-compile-env--format-hint))
+    (ivy-read "Compile environment variable: "
+              (delete-dups (append
+                            counsel-compile-env counsel-compile-env-history))
+              :action #'counsel-compile-env--update
+              :history 'counsel-compile-env-history
+              :caller 'counsel-compile-env)))
 
 ;;** `counsel-minor'
 (defun counsel--minor-candidates ()

--- a/counsel.el
+++ b/counsel.el
@@ -5279,7 +5279,7 @@ The resulting strings are tagged with properties that
         (suffix (and blddir
                      (concat (propertize " in " 'face 'font-lock-warning-face)
                              (propertize blddir 'face 'dired-directory))))
-        (props `(srcdir ,srcdir blddir ,default-directory)))
+        (props `(srcdir ,srcdir blddir ,blddir)))
     (mapcar (lambda (target)
               (setq target (concat (format fmt target) suffix))
               (add-text-properties 0 (length target) props target)


### PR DESCRIPTION
This contains a bug fix, a little re-factoring and an enhancement to counsel-compile to support different environment variables.