### PR TITLE
Fix grep-occur when using multi-pass re-builders

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2598,7 +2598,7 @@ NEEDLE is the search string."
    counsel--regex-look-around))
 
 (defun counsel--ag-extra-switches (regex)
-  "Get additional switches needed for look-arounds"
+  "Get additional switches needed for look-arounds."
   (and (stringp counsel--regex-look-around)
        (string-match-p "\\`\\^(\\?[=!]" regex) ;; using look-arounds
        (concat " " counsel--regex-look-around " ")))


### PR DESCRIPTION
Currently `counsel-grep-like-occur` does not work with multi-pass regex builders. It reverts back to using `ivy--regex`. I updated it to work with all rebuilders and backends.