### PR TITLE
counsel.el (counsel-recentf): Require match

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2100,6 +2100,7 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
             :action (lambda (f)
                       (with-ivy-window
                         (find-file f)))
+            :require-match t
             :caller 'counsel-recentf))
 (ivy-set-actions
  'counsel-recentf


### PR DESCRIPTION
or else `Wrong type argument: stringp, nil`