### PR TITLE
ivy-overlay.el: Do not assume in-buffer completion

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -134,7 +134,8 @@ Hide the minibuffer contents and cursor."
                                1
                              0)
                            (save-excursion
-                             (goto-char ivy-completion-beg)
+                             (when ivy-completion-beg
+                               (goto-char ivy-completion-beg))
                              (current-column)))))))))
         (let ((cursor-offset (1+ (length ivy-text))))
           (ivy-add-face-text-property cursor-offset (1+ cursor-offset)


### PR DESCRIPTION
(`ivy-display-function-overlay`): Pad to `current-column` when `ivy-completion-beg` is unset.

Fixes #2048