### PR TITLE
ivy-test.el: Make friendlier

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1096,7 +1096,9 @@ a buffer visiting a file."
                      ""))))
 
 (ert-deftest counsel-find-file-with-dollars ()
-  (skip-unless (file-exists-p "test"))
+  ;; This should be `skip-unless' instead,
+  ;; but it was only added in Emacs 24.4.
+  :expected-result (if (file-exists-p "test") :passed :failed)
   (should (string=
            (file-relative-name
             (ivy-with '(counsel-find-file) "fo C-m"
@@ -1104,8 +1106,12 @@ a buffer visiting a file."
            "test/find-file/files-with-dollar/foo$")))
 
 (ert-deftest counsel-find-file-with-dotfiles ()
-  (skip-unless (and (file-exists-p "test")
-                    (= emacs-major-version 26)))
+  ;; This should be `skip-unless' instead,
+  ;; but it was only added in Emacs 24.4.
+  :expected-result (if (and (file-exists-p "test")
+                            (= emacs-major-version 26))
+                       :passed
+                     :failed)
   (should (string=
            (file-relative-name
             (ivy-with '(counsel-find-file) "f C-m"

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -35,7 +35,7 @@
 (require 'ivy)
 (require 'counsel)
 
-(message (emacs-version))
+(message "%s" (emacs-version))
 
 (defvar ivy-expr nil
   "Holds a test expression to evaluate with `ivy-eval'.")
@@ -1095,10 +1095,8 @@ a buffer visiting a file."
                                "C-p C-m")
                      ""))))
 
-(unless (file-exists-p "test")
-  (shell-command "git clone -b test --single-branch https://github.com/abo-abo/swiper/ test"))
-
 (ert-deftest counsel-find-file-with-dollars ()
+  (skip-unless (file-exists-p "test"))
   (should (string=
            (file-relative-name
             (ivy-with '(counsel-find-file) "fo C-m"
@@ -1106,18 +1104,18 @@ a buffer visiting a file."
            "test/find-file/files-with-dollar/foo$")))
 
 (ert-deftest counsel-find-file-with-dotfiles ()
-  (when (and (version<= emacs-version "26.2")
-             (not (version< emacs-version "26.1")))
-    (should (string=
-             (file-relative-name
-              (ivy-with '(counsel-find-file) "f C-m"
-                        :dir "test/find-file/dotfiles/"))
-             "test/find-file/dotfiles/foo/"))
-    (should (string=
-             (file-relative-name
-              (ivy-with '(counsel-find-file) "foob C-m"
-                        :dir "test/find-file/dotfiles/"))
-             "test/find-file/dotfiles/.foobar1"))))
+  (skip-unless (and (file-exists-p "test")
+                    (= emacs-major-version 26)))
+  (should (string=
+           (file-relative-name
+            (ivy-with '(counsel-find-file) "f C-m"
+                      :dir "test/find-file/dotfiles/"))
+           "test/find-file/dotfiles/foo/"))
+  (should (string=
+           (file-relative-name
+            (ivy-with '(counsel-find-file) "foob C-m"
+                      :dir "test/find-file/dotfiles/"))
+           "test/find-file/dotfiles/.foobar1")))
 
 (provide 'ivy-test)
 


### PR DESCRIPTION
Do not pass arbitrary text as first argument to `message`.  Do not clone remote Git repositories at toplevel.  Cloning repositories shouldn't be needed at all for the purpose of accessing test data, but even if it were, those commands belong in `Makefile` or similar, not at the test suite's toplevel.

For discussion, see the following commits:
* 7e735808e966d70340b5a2cef0430f913151d9b6
* fa87b977aecbc7ee5f3b77ddf94c6f040e17c348
* 4171364ab3cdb21eabb45657a8d20bd85f3ecc9b