### PR TITLE
New history variables for counsel-minor and counsel-package

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3580,6 +3580,9 @@ Position of selected mark outside accessible part of buffer")))
 (declare-function package-delete "package")
 (declare-function package-desc-extras "package")
 
+(defvar counsel-package-history nil
+  "History for `counsel-package'.")
+
 (defun counsel--package-candidates ()
   "Return completion alist for `counsel-package'."
   (unless package--initialized
@@ -3612,6 +3615,7 @@ Additional actions:\\<ivy-minibuffer-map>
             (counsel--package-candidates)
             :action #'counsel-package-action
             :require-match t
+            :history 'counsel-package-history
             :caller 'counsel-package))
 
 (cl-pushnew '(counsel-package . "^+") ivy-initial-inputs-alist :key #'car)

--- a/counsel.el
+++ b/counsel.el
@@ -5493,6 +5493,9 @@ specified by the `blddir' property."
               :caller 'counsel-compile-env)))
 
 ;;** `counsel-minor'
+(defvar counsel-minor-history nil
+  "History for `counsel-minor'.")
+
 (defun counsel--minor-candidates ()
   "Return completion alist for `counsel-minor'.
 
@@ -5533,6 +5536,7 @@ Additional actions:\\<ivy-minibuffer-map>
   (ivy-read "Minor modes (enable +mode or disable -mode): "
             (counsel--minor-candidates)
             :require-match t
+            :history 'counsel-minor-history
             :sort t
             :action (lambda (x)
                       (call-interactively (cdr x)))))


### PR DESCRIPTION
Add `counsel-minor-history` and `counsel-package-history` variables.

I think inputs of these commands are hardly shared with other commands because of `+` and `-` signs.