### PR TITLE
Modify counsel-unicode-char's copy action to use actual result

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4573,6 +4573,14 @@ COUNT defaults to 1."
                         (setq ivy-completion-end (point))))
             :caller 'counsel-unicode-char))
 
+(defun counsel-unicode-copy (name)
+  "Ivy action to copy the unicode from NAME to the kill ring."
+  (kill-new (char-to-string (get-text-property 0 'code name))))
+
+(ivy-set-actions
+ 'counsel-unicode-char
+ '(("w" counsel-unicode-copy "copy")))
+
 ;;** `counsel-colors'
 (defun counsel-colors-action-insert-hex (color)
   "Insert the hexadecimal RGB value of COLOR."


### PR DESCRIPTION
I don't think anyone actually wants to copy the whole completion line including description - this changes copy to extract just the unicode character.  

My use case is I use exwm, and it's a great way for me to get characters into the web browser.

( FSF RT:1334217 )