### PR TITLE
Shrink ivy window after read action.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -827,7 +827,8 @@ selection, non-nil otherwise."
               (t
                (message "")
                (setcar actions (1+ action-idx))
-               (ivy-set-action actions)))))))
+               (ivy-set-action actions))))))
+  (ivy-shrink-after-dispatching))
 
 (defun ivy-shrink-after-dispatching ()
   "Shrink the window after dispatching when action list is too large."


### PR DESCRIPTION
Fixed for OCD...

Related to #764. 

Before:

<img width="644" alt="Screen Shot 2019-05-27 at 15 06 05" src="https://user-images.githubusercontent.com/16749790/58401662-04c2cf80-8091-11e9-8e06-8de7cc0c2328.png">

After:

<img width="643" alt="Screen Shot 2019-05-27 at 15 06 20" src="https://user-images.githubusercontent.com/16749790/58401679-0b514700-8091-11e9-9efb-29913f750d21.png">
