### PR TITLE
Fix ivy-read-action

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -806,29 +806,30 @@ key (a string), cmd and doc (a string)."
 Return nil for `minibuffer-keyboard-quit' or wrong key during the
 selection, non-nil otherwise."
   (interactive)
-  (let ((actions (ivy-state-action ivy-last)))
-    (if (not (ivy--actionp actions))
-        t
-      (let* ((hint (funcall ivy-read-action-format-function (cdr actions)))
-             (resize-mini-windows t)
-             (key "")
-             action-idx)
-        (while (and (setq action-idx (cl-position-if
-                                      (lambda (x)
-                                        (string-prefix-p key (car x)))
-                                      (cdr actions)))
-                    (not (string= key (car (nth action-idx (cdr actions))))))
-          (setq key (concat key (string (read-key hint)))))
-        (cond ((member key '("" ""))
-               nil)
-              ((null action-idx)
-               (message "%s is not bound" key)
-               nil)
-              (t
-               (message "")
-               (setcar actions (1+ action-idx))
-               (ivy-set-action actions))))))
-  (ivy-shrink-after-dispatching))
+  (prog1
+      (let ((actions (ivy-state-action ivy-last)))
+        (if (not (ivy--actionp actions))
+            t
+          (let* ((hint (funcall ivy-read-action-format-function (cdr actions)))
+                 (resize-mini-windows t)
+                 (key "")
+                 action-idx)
+            (while (and (setq action-idx (cl-position-if
+                                          (lambda (x)
+                                            (string-prefix-p key (car x)))
+                                          (cdr actions)))
+                        (not (string= key (car (nth action-idx (cdr actions))))))
+              (setq key (concat key (string (read-key hint)))))
+            (cond ((member key '("" ""))
+                   nil)
+                  ((null action-idx)
+                   (message "%s is not bound" key)
+                   nil)
+                  (t
+                   (message "")
+                   (setcar actions (1+ action-idx))
+                   (ivy-set-action actions))))))
+    (ivy-shrink-after-dispatching)))
 
 (defun ivy-shrink-after-dispatching ()
   "Shrink the window after dispatching when action list is too large."


### PR DESCRIPTION
The two action dispatching commands rely on the return value of `ivy-read-action` ([`ivy.el#L840`](https://github.com/abo-abo/swiper/blob/332f990fc1b68f84ebb9d0557ce4abac8392cd79/ivy.el#L840)), so #2079 makes those commands not working any more.

By the way, I do not have an Emacs CA yet, but I think this is a trivial change and does not require one?

Thanks!