### PR TITLE
When unwinding ivy-completion-in-region, do not insert initial input if nil

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2372,7 +2372,8 @@ See `completion-in-region' for further information."
                          :unwind (lambda ()
                                    (unless (eq ivy-exit 'done)
                                      (goto-char ivy-completion-beg)
-                                     (insert initial)))
+                                     (when initial
+                                       (insert initial))))
                          :caller 'ivy-completion-in-region)
                t))))))
 


### PR DESCRIPTION
An example where this occurs:

1. Start counsel-find-file;
2. Go to root and choose to SSH somewhere; and
3. When prompted with available hosts, cancel.