### PR TITLE
counsel.el (counsel--file-name-filter): Move ignore-re binding.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1925,8 +1925,6 @@ one that exists will be used.")
 If USE-IGNORE is non-nil, try to generate a command that respects
 `counsel-find-file-ignore-regexp'."
   (let ((regex ivy--old-re)
-        (ignore-re (list (counsel--elisp-to-pcre
-                          counsel-find-file-ignore-regexp)))
         (filter-cmd (cl-find-if
                      (lambda (x)
                        (executable-find
@@ -1939,9 +1937,11 @@ If USE-IGNORE is non-nil, try to generate a command that respects
                (not (string-match-p "\\`\\." ivy-text))
                (not (string-match-p counsel-find-file-ignore-regexp
                                     (or (car ivy--old-cands) ""))))
-      (setq regex (if (stringp regex)
-                      (list ignore-re (cons regex t))
-                    (cons ignore-re regex))))
+      (let ((ignore-re (list (counsel--elisp-to-pcre
+                              counsel-find-file-ignore-regexp))))
+        (setq regex (if (stringp regex)
+                        (list ignore-re (cons regex t))
+                      (cons ignore-re regex)))))
     (setq cmd (format (car filter-cmd)
                       (counsel--elisp-to-pcre regex (cdr filter-cmd))))
     (if (string-match-p "csh\\'" shell-file-name)


### PR DESCRIPTION
Closes #2094. 

One of the tests, `counsel-find-file-with-dotfiles` seems to fail for me on Emacs 26.2 installed via the Guix package manager, with or without my changes---even if I clone a fresh repo and `git checkout` the exact commit (2221a5c) from several months ago in which it was added, that test fails for me. A `.foobar1` and a `.foobar2` are generated in the `./tests/find-file/dotfiles/` directory. I don't think this patch I'm submitting affects that test.