### PR TITLE
Add ivy-switch-buffer-map to counsel-switch-buffer

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5285,6 +5285,7 @@ in the current window."
   (interactive)
   (ivy-read "Switch to buffer: " 'internal-complete-buffer
             :preselect (buffer-name (other-buffer (current-buffer)))
+            :keymap ivy-switch-buffer-map
             :action #'ivy--switch-buffer-action
             :matcher #'ivy--switch-buffer-matcher
             :caller 'counsel-switch-buffer


### PR DESCRIPTION
This is useful so that I can use C-c C-k to clean up my buffers (I actually have it rebound to just C-k in my config) within counsel-switch-buffer so I can use that instead of ivy-switch-buffer.