### PR TITLE
Make counsel-recentf select window with file if one is open

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2136,8 +2136,11 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
   (recentf-mode)
   (ivy-read "Recentf: " (mapcar #'substring-no-properties recentf-list)
             :action (lambda (f)
-                      (with-ivy-window
-                        (find-file f)))
+                      (if-let* ((buffer (find-file-noselect f t))
+                                (buffer-window (get-buffer-window buffer)))
+                          (select-window buffer-window)
+                        (with-ivy-window
+                          (find-file f))))
             :require-match t
             :caller 'counsel-recentf))
 (ivy-set-actions


### PR DESCRIPTION
When using `counsel-recentf`, I'm used to it selecting the window with the file if one is already open, like in `helm`. However, it currently does not do this, leading to confusion. This PR will change the behavior so `counsel-recentf` will switch to an active window with the selected file if one is open.