### PR TITLE
* counsel.el (counsel-open-buffer-file-externally): Cleanup

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5311,7 +5311,7 @@ in the current window."
     (user-error "Can't open that"))
   (let* ((virtual (assoc buffer ivy--virtual-buffers))
          (filename (if virtual
-                       buffer
+                       (cdr virtual)
                      (buffer-file-name (get-buffer buffer)))))
     (unless filename
       (user-error "Can't open `%s' externally" buffer))


### PR DESCRIPTION
According to #2111, it's better to use `(cdr virtual)` than `buffer`.