### PR TITLE
counsel (counsel-{file,dired}-jump): use temporary buffers as compared to split-string

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2530,11 +2530,12 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
                 (apply #'call-process find-program nil (current-buffer) nil
                        (split-string counsel-file-jump-args))
                 (let ((start (goto-char (point-min))) files)
-                  (while (search-forward "\n" nil t)
-                    (push (buffer-substring (+ start 2) (1- (point)))
-                          files)
-                    (setq start (point)))
-                  (nbutlast files)))
+                  (while (not (eobp))
+					(setq start (point))
+					(search-forward "\n")
+			  		(push (buffer-substring (+ 2 start) (1- (point)))
+			  			  files))
+                  files))
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input
               :action #'find-file
@@ -2572,12 +2573,12 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
                 (apply #'call-process find-program nil (current-buffer) nil
                        (split-string counsel-dired-jump-args))
                 (let ((start (goto-char (point-min))) files)
-                  (while (search-forward "\n" nil t)
-                    (unless (looking-at-p "$")
-                      (push (buffer-substring (+ start 2) (1- (point)))
-                            files))
-                    (setq start (point)))
-                  (nbutlast files)))
+                  (while (not (eobp))
+					(setq start (point))
+					(search-forward "\n")
+			  		(push (buffer-substring (+ 2 start) (1- (point)))
+			  			  files))
+                  files))
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input
               :action (lambda (d) (dired-jump nil (expand-file-name d)))


### PR DESCRIPTION
This basically just replaces the higher level "split-string" with a more low level loop to improve performance when indexing deep directory trees. On my system, I get a 10%-20% performance boost, together with up to 20% reduction in garbage collection. 

Another note would be that unless it's against some rule, it might not be bad to convert `counsel-file-jump-args` and `counsel-dired-jump-args` directly into lists, rather than strings that have to be split again.