### PR TITLE
Add swiper-isearch-backward

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1082,6 +1082,13 @@ a buffer visiting a file."
    (string=
     (ivy-with-text
      "|(defun foo)\nasdf\n(defvar bar)"
+     (global-set-key (kbd "C-s") #'isearch-forward-regexp)
+     ("C-s" "defun\\|defvar" "RET"))
+    "(defun| foo)\nasdf\n(defvar bar)"))
+  (should
+   (string=
+    (ivy-with-text
+     "|(defun foo)\nasdf\n(defvar bar)"
      (global-set-key (kbd "C-s") #'swiper-isearch)
      ("C-s" "defun\\|defvar" "RET"))
     "(defun| foo)\nasdf\n(defvar bar)"))
@@ -1092,6 +1099,48 @@ a buffer visiting a file."
      (global-set-key (kbd "C-s") #'swiper-isearch)
      ("C-s" "defun\\|defvar" "C-n RET"))
     "(defun foo)\nasdf\n(defvar| bar)")))
+
+(ert-deftest swiper-isearch-backward ()
+  (should
+   (string=
+    (ivy-with-text
+     "abc\nasdf123 def\ndem|"
+     (global-set-key (kbd "C-r") #'isearch-backward-regexp)
+     ("C-r" "de" "" "RET"))
+    "abc\nasdf123 def\n|dem"))
+  (should
+   (string=
+    (ivy-with-text
+     "abc\nasdf123 def\ndem|"
+     (global-set-key (kbd "C-r") #'swiper-isearch-backward)
+     ("C-r" "de" "" "RET"))
+    "abc\nasdf123 def\n|dem"))
+  (should
+   (string=
+    (ivy-with-text
+     "(defun foo)\nasdf\n(defvar bar)|"
+     (global-set-key (kbd "C-r") #'isearch-backward-regexp)
+     ("C-r" "defun\\|defvar" "RET"))
+    "(defun foo)\nasdf\n(|defvar bar)"))
+  ;; NOTE: The following two behaviors do not match
+  ;; `isearch-backward-regexp', but they match that of
+  ;; `swiper-isearch-forward', as `swiper-isearch' does not reset the
+  ;; point when the regexp becomes invalid, meaning the point is left
+  ;; at the initial match of the first part of the regexp.
+  (should
+   (string=
+    (ivy-with-text
+     "(defun foo)\nasdf\n(defvar bar)|"
+     (global-set-key (kbd "C-r") #'swiper-isearch-backward)
+     ("C-r" "defun\\|defvar" "RET"))
+    "(|defun foo)\nasdf\n(defvar bar)"))
+  (should
+   (string=
+    (ivy-with-text
+     "(defun foo)\nasdf\n(defvar bar)|"
+     (global-set-key (kbd "C-r") #'swiper-isearch-backward)
+     ("C-r" "defun\\|defvar" "C-n RET"))
+    "(defun foo)\nasdf\n(|defvar bar)")))
 
 (ert-deftest swiper-isearch-case-fold ()
   (should


### PR DESCRIPTION
This adds a `swiper-isearch-backward` implementation for #1172. Its behavior doesn't match `isearch-backward-regexp` perfectly, but it matches that of `swiper-isearch`. The fix for that discrepancy should be separate from this, and then fixed for both.