### PR TITLE
counsel.el (counsel-git-log): Add `counsel-git-log-show-commit-action`.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1577,7 +1577,7 @@ done") "\n" t)))
 (defvar counsel-git-log-cmd "GIT_PAGER=cat git log --grep '%s'"
   "Command used for \"git log\".")
 
-(defvar counsel-git-log-split-string-re "\ncommit "
+(defvar counsel-git-log-split-string-re "^commit "
   "The `split-string' separates when split output of `counsel-git-log-cmd'.")
 
 (defun counsel-git-log-function (str)

--- a/counsel.el
+++ b/counsel.el
@@ -1599,6 +1599,18 @@ done") "\n" t)))
   "Add candidate X to kill ring."
   (message "%S" (kill-new x)))
 
+(declare-function magit-show-commit "ext:magit-diff")
+
+(defun counsel-git-log-show-commit-action (log-entry)
+  "Visit the commit corresponding to LOG-ENTRY."
+  (require 'magit-diff)
+  (let ((commit (substring-no-properties log-entry 0 (string-match-p "\n" log-entry))))
+    (magit-show-commit commit)))
+
+(ivy-set-actions
+ 'counsel-git-log
+ '(("v" counsel-git-log-show-commit-action "visit commit")))
+
 ;;** `counsel-git-change-worktree'
 (defun counsel-git-change-worktree-action (git-root-dir tree)
   "Find the corresponding file in the worktree located at tree.


### PR DESCRIPTION
`counsel-git-log-show-commit-action` uses Magit to visit the commit
corresponding to the currently selected log entry.

Use case for this feature: when you remember some part of a commit log and want to view the full diff, but the commit isn't the head of its containing branch and thus can't be directly accessed through `counsel-git-checkout`.

The proposed setting for `counsel-git-log-split-string-re` should be safe since `git log` outputs padding for commit bodies, precluding spurious matches.