### PR TITLE
Add {swiper,counsel-grep,consel-grep-or-swiper}-backward commands

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2948,6 +2948,16 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
       (unless res
         (goto-char init-point)))))
 
+;;;###autoload
+(defun counsel-grep-backward (&optional initial-input)
+  "Grep for a string in the file visited by the current buffer going
+backward similar to `swiper-backward'. When non-nil, INITIAL-INPUT is
+the initial search pattern."
+  (interactive)
+  (let ((ivy-index-functions-alist
+         '((counsel-grep . ivy-recompute-index-swiper-async-backward))))
+    (counsel-grep initial-input)))
+
 ;;** `counsel-grep-or-swiper'
 (defcustom counsel-grep-swiper-limit 300000
   "Buffer size threshold for `counsel-grep-or-swiper'.
@@ -2983,6 +2993,17 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
     (when (file-writable-p buffer-file-name)
       (save-buffer))
     (counsel-grep initial-input)))
+
+;;** `counsel-grep-or-swiper-backward'
+;;;###autoload
+(defun counsel-grep-or-swiper-backward (&optional initial-input)
+  "Call `swiper-backward' for small buffers and `counsel-grep-backward' for
+large ones.  When non-nil, INITIAL-INPUT is the initial search pattern."
+  (interactive)
+  (let ((ivy-index-functions-alist
+         '((swiper . ivy-recompute-index-swiper-backward)
+           (counsel-grep . ivy-recompute-index-swiper-async-backward))))
+    (counsel-grep-or-swiper initial-input)))
 
 ;;** `counsel-recoll'
 (defun counsel-recoll-function (str)

--- a/ivy.el
+++ b/ivy.el
@@ -3220,7 +3220,8 @@ CANDIDATES are assumed to be static."
         (if (memq (cdr (assq (ivy-state-caller ivy-last)
                              ivy-index-functions-alist))
                   '(ivy-recompute-index-swiper
-                    ivy-recompute-index-swiper-async))
+                    ivy-recompute-index-swiper-async
+                    ivy-recompute-index-swiper-backward))
             (progn
               (ivy--recompute-index name re-str cands)
               (setq ivy--old-cands (ivy--sort name cands)))
@@ -3442,6 +3443,16 @@ CANDS are the current candidates."
                 (cl-incf i))
               res))))
     (error 0)))
+
+(defun ivy-recompute-index-swiper-backward (re-str cands)
+  "Recompute index of selected candidate when using `swiper-backward'.
+CANDS are the current candidates."
+  (let ((idx (ivy-recompute-index-swiper re-str cands)))
+    (if (or (= idx -1)
+            (<= (read (get-text-property 0 'swiper-line-number (nth idx cands)))
+                (line-number-at-pos)))
+        idx
+      (- idx 1))))
 
 (defun ivy-recompute-index-swiper-async (_re-str cands)
   "Recompute index of selected candidate when using `swiper' asynchronously.

--- a/ivy.el
+++ b/ivy.el
@@ -3221,6 +3221,7 @@ CANDIDATES are assumed to be static."
                              ivy-index-functions-alist))
                   '(ivy-recompute-index-swiper
                     ivy-recompute-index-swiper-async
+                    ivy-recompute-index-swiper-async-backward
                     ivy-recompute-index-swiper-backward))
             (progn
               (ivy--recompute-index name re-str cands)
@@ -3477,6 +3478,18 @@ CANDS are the current candidates."
               (setq idx (cl-position (pop tail) cands :test #'equal)))
             (or idx 0))
         ivy--index))))
+
+(defun ivy-recompute-index-swiper-async-backward (re-str cands)
+  "Recompute index of selected candidate when using `swiper-backward'
+asynchronously. CANDS are the current candidates."
+  (if (= (length cands) 0)
+      0
+    (let ((idx (ivy-recompute-index-swiper-async re-str cands)))
+      (if
+          (<= (string-to-number (nth idx cands))
+              (with-ivy-window (line-number-at-pos)))
+          idx
+        (- idx 1)))))
 
 (defun ivy-recompute-index-zero (_re-str _cands)
   "Recompute index of selected candidate.

--- a/swiper.el
+++ b/swiper.el
@@ -527,10 +527,19 @@ numbers; replaces calculating the width from buffer line count."
 
 ;;;###autoload
 (defun swiper (&optional initial-input)
-  "`isearch' with an overview.
+  "`isearch-forward' with an overview.
 When non-nil, INITIAL-INPUT is the initial search pattern."
   (interactive)
   (swiper--ivy (swiper--candidates) initial-input))
+
+;;;###autoload
+(defun swiper-backward (&optional initial-input)
+  "`isearch-backward' with an overview.
+When non-nil, INITIAL-INPUT is the initial search pattern."
+  (interactive)
+  (let ((ivy-index-functions-alist
+         '((swiper . ivy-recompute-index-swiper-backward))))
+    (swiper initial-input)))
 
 ;;;###autoload
 (defun swiper-thing-at-point ()


### PR DESCRIPTION
Implements and closes #1172, with `counsel-grep-backward` and `counsel-grep-or-swiper-backward` commands as a bonus. Just tell me if you want me to separate these into separate PRs or if you're not interested in some of the commands.

Side notes:

* I wrote the above mentioned commands 5-6 months ago and intended to create a PR after completing the FSF copyright assignment procedure. It turned out to take quite some time to get a signed disclaimer from the company I work for, but it's finally finished now.
* Regarding #2125 ("Add swiper-isearch-backward"), it looks like it won't be possible to use the same approach for that command as for `swiper-backward` since the implementations of `swiper` and `swiper-isearch` seem quite different.