### PR TITLE
Fix ivy-previous-line-or-history

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1249,7 +1249,7 @@ If the input is empty, select the previous history element instead."
   "Move cursor vertically up ARG candidates.
 If the input is empty, select the previous history element instead."
   (interactive "p")
-  (when (and (zerop ivy--index) (string= ivy-text ""))
+  (when (string= ivy-text "")
     (ivy-previous-history-element 1))
   (ivy-previous-line arg))
 


### PR DESCRIPTION
Fixes #2137.

Note also that this reverts the fix in #1137.