### PR TITLE
ivy-test.el (swiper-isearch-backward): Test match at point

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1147,7 +1147,21 @@ a buffer visiting a file."
      "(defun foo)\nasdf\n(defvar bar)|"
      (global-set-key (kbd "C-r") #'swiper-isearch-backward)
      ("C-r" "defun\\|defvar" "C-n RET"))
-    "(defun foo)\nasdf\n(|defvar bar)")))
+    "(defun foo)\nasdf\n(|defvar bar)"))
+  (should
+   (string=
+    (ivy-with-text
+     "(defun foo)\nasdf\n(|defun bar)"
+     (global-set-key (kbd "C-r") #'isearch-backward)
+     ("C-r" "defun" "RET"))
+    "(|defun foo)\nasdf\n(defun bar)"))
+  (should
+   (string=
+    (ivy-with-text
+     "(defun foo)\nasdf\n(|defun bar)"
+     (global-set-key (kbd "C-r") #'swiper-isearch-backward)
+     ("C-r" "defun" "RET"))
+    "(|defun foo)\nasdf\n(defun bar)")))
 
 (ert-deftest swiper-isearch-backward-backspace ()
   (should


### PR DESCRIPTION
`isearch-backward` never selects a match at the point, it always goes to
the first match before the point. This test demonstrates the expected
behavior.