### PR TITLE
Increase swiper-isearch cursor overlay priority

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -848,6 +848,7 @@ Matched candidates should have `swiper-invocation-face'."
         (overlay-put ov 'after-string (propertize " " 'face 'ivy-cursor))
       (overlay-put ov 'face 'ivy-cursor))
     (overlay-put ov 'window wnd)
+    (overlay-put ov 'priority 2)
     (push ov swiper--overlays)))
 
 (defun swiper--add-line-overlay (wnd)


### PR DESCRIPTION
Otherwise the swiper match overlays can make the cursor disappear when using `swiper-isearch-backward`.

Priority 2 seems to work for me, but I haven't really tried to understand why or if it should be higher. Feel free to bump it.

### How to reproduce

Using the default `ivy--regex-plus` re builder:

1. Visit a buffer with the text "foo bar".
2. `swiper-isearch-backward`
3. Enter search expression "foo bar".

### Actual behavior

4. The cursor overlay in the buffer disappears when "b" is entered.

### Expected behavior

4. The cursor overlay in the buffer is always visible at the start of the match.
