### PR TITLE
Make nonexistent parent dirs in counsel-find-file-mkdir-action

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1833,12 +1833,12 @@ choose between `yes-or-no-p' and `y-or-n-p'; otherwise default to
                         'counsel-find-file-move))
 
 (defun counsel-find-file-mkdir-action (_x)
-  "Create a directory from `ivy-text'."
+  "Create a directory and any nonexistent parent dirs from `ivy-text'."
   (let ((dir (file-name-as-directory
               (expand-file-name ivy-text ivy--directory)))
         (win (and (not (eq ivy-exit 'done))
                   (active-minibuffer-window))))
-    (make-directory dir)
+    (make-directory dir t)
     (when win (with-selected-window win (ivy--cd dir)))))
 
 (ivy-set-actions


### PR DESCRIPTION
Currently if you dispatch the `mkdir` action from `counsel-find-file` with input (`ivy-text`, I think?) "multi/level/dirs", it will fail in `make-directory` because "multi" (relative to the default directory) doesn't exist.  I *think* the intent in such a case would to make the all the directories and this change enables that by passing a non-nil optional argument `PARENTS` to `make-directory`.

Since this is such a small change, I don't think I need to worry about the copyright assignment and there doesn't seem to be any difference between my branch and master for the `make` checks.

I have an ERT test I can add too, but it feels a little weird since it involves modifying the filesystem and then cleaning up the changes.