### PR TITLE
String before prompt

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -179,6 +179,12 @@ Set this to \"(%d/%d) \" to display both the index and the count."
           (const :tag "Count matches and show current match" "(%d/%d) ")
           string))
 
+(defcustom ivy-pre-prompt-function #'ignore
+  "When non-nil, add strings before the `ivy-read' prompt."
+  :type '(choice
+          (const :tag "Do nothing" ignore)
+          (function :tag "Custom function")))
+
 (defcustom ivy-add-newline-after-prompt nil
   "When non-nil, add a newline after the `ivy-read' prompt."
   :type 'boolean)
@@ -2904,6 +2910,9 @@ parts beyond their respective faces `ivy-confirm-face' and
                          (concat n-str d-str "\n"))
                         (t
                          (concat n-str d-str)))))
+          (let ((p-str (funcall ivy-pre-prompt-function)))
+            (when (stringp p-str)
+              (setq n-str (concat p-str n-str))))
           (when ivy-add-newline-after-prompt
             (setq n-str (concat n-str "\n")))
           (let ((regex (format "\\([^\n]\\{%d\\}\\)[^\n]" (window-width))))

--- a/ivy.el
+++ b/ivy.el
@@ -2910,7 +2910,8 @@ parts beyond their respective faces `ivy-confirm-face' and
                          (concat n-str d-str "\n"))
                         (t
                          (concat n-str d-str)))))
-          (let ((p-str (funcall ivy-pre-prompt-function)))
+          (let ((p-str (when (functionp ivy-pre-prompt-function)
+                         (funcall ivy-pre-prompt-function))))
             (when (stringp p-str)
               (setq n-str (concat p-str n-str))))
           (when ivy-add-newline-after-prompt


### PR DESCRIPTION
Hi!

I've attempted to integrate an icon and a separator before the ivy prompt.
I added a new custom variable to control the appearance.

(Setup)
1. User can implement a function that will return a string
2. Set the function to `ivy-pre-prompt-function` defined as a new custom variable in this PR

(Example code: depends on `all-the-icons.el`)
```elisp
(defun my-pre-prompt-function ()
      (if window-system
          (format "%s\n%s "
                  (make-string (frame-width) ?\x5F) ;; "__"
                  (all-the-icons-faicon "sort-amount-asc"))
        (format "%s\n" (make-string (1- (frame-width)) ?\x2D))))
(setq ivy-pre-prompt-function #'my-pre-prompt-function)
```

(Result)
![Screen Shot 2019-08-06 at 0 57 27](https://user-images.githubusercontent.com/136673/62478327-ca3e8700-b7e5-11e9-8031-0256deddb6e3.png)

What do you think?
