### PR TITLE
ivy.el read-directory-name: fix parent dirs

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -950,7 +950,13 @@ will bring the behavior in line with the newer Emacsen."
           (ivy-with
            '(read-directory-name "cd: ")
            "tmp C-j C-M-j"
-           :dir "/"))))
+           :dir "/")))
+  (should
+   (equal "/"
+          (ivy-with
+           '(read-directory-name "cd: ")
+           "DEL C-M-j"
+           :dir "/tmp"))))
 
 (ert-deftest ivy-partial-files ()
   (when (file-exists-p "/tmp/ivy-partial-test")

--- a/ivy.el
+++ b/ivy.el
@@ -1164,7 +1164,7 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                     (eq (ivy-state-collection ivy-last)
                         #'read-file-name-internal))
                (if (ivy-state-def ivy-last)
-                   (if (> (length ivy--directory)
+                   (if (/= (length ivy--directory)
                           (1+ (length (expand-file-name (ivy-state-def ivy-last)))))
                        ivy--directory
                      (copy-sequence (ivy-state-def ivy-last)))


### PR DESCRIPTION
When selecting a directory, if you removed elements from the default
directory (e.g. by pressing DEL) and then used ivy-immediate-done, you
were getting back the starting directory instead of the ancestor
directory.

Fixes #2165