### PR TITLE
Check if ivy--done is accepting a string.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -746,12 +746,13 @@ N is obtained from `ivy-more-chars-alist'."
   "Insert TEXT and exit minibuffer."
   (if (member (ivy-state-prompt ivy-last) '("Create directory: " "Make directory: "))
       (ivy-immediate-done)
-    (insert
-     (setf (ivy-state-current ivy-last)
-           (if (and ivy--directory
-                    (not (eq (ivy-state-history ivy-last) 'grep-files-history)))
-               (expand-file-name text ivy--directory)
-             text)))
+    (if (stringp text)
+        (insert
+         (setf (ivy-state-current ivy-last)
+               (if (and ivy--directory
+                        (not (eq (ivy-state-history ivy-last) 'grep-files-history)))
+                   (expand-file-name text ivy--directory)
+                 text))))
     (setq ivy-exit 'done)
     (exit-minibuffer)))
 


### PR DESCRIPTION
Some ivy commands (e.g. swiper-isearch) provide an int instead of a
string. It won't work when the integer value is larger than unicode
which cannot be converted to a char.

```
Debugger entered--Lisp error: (wrong-type-argument char-or-string-p 5557661)
  ivy--done(5557661)
  ivy-done()
  funcall-interactively(ivy-done)
  call-interactively(ivy-done nil nil)
  command-execute(ivy-done)
  read-from-minibuffer(...)
  ivy-read(...)
  swiper-isearch()
```