### PR TITLE
counsel.el (counsel-fonts): Add

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4949,6 +4949,23 @@ selected color."
  '(("h" counsel-colors-action-insert-hex "insert hexadecimal value")
    ("H" counsel-colors-action-kill-hex "kill hexadecimal value")))
 
+;;** `counsel-fonts'
+(defvar counsel-fonts-history ()
+  "History for `counsel-fonts'.")
+
+;;;###autoload
+(defun counsel-fonts ()
+  "Show a list of all supported font families for a particular frame.
+
+You can insert or kill the name of the selected font."
+  (interactive)
+  (let ((fonts (delete-dups (font-family-list))))
+    (ivy-read "Font: " fonts
+              :require-match t
+              :history 'counsel-fonts-history
+              :action #'insert
+              :caller 'counsel-fonts)))
+
 ;;* Misc. OS
 ;;** `counsel-rhythmbox'
 (declare-function dbus-call-method "dbus")


### PR DESCRIPTION
Add a function to search all font families and insert them in the current buffer in a similar way to **counsel-color-emacs**