### PR TITLE
Make ivy--magic-file-slash less aggressive

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3014,6 +3014,7 @@ Possible choices are 'ivy-magic-slash-non-match-cd-selected,
                (and (or (> ivy--index 0)
                         (= ivy--length 1)
                         magic)
+                    (not (ivy--prompt-selected-p))
                     (not (equal (ivy-state-current ivy-last) ""))
                     (file-directory-p (ivy-state-current ivy-last))
                     (or (eq ivy-magic-slash-non-match-action


### PR DESCRIPTION
In counsel-find-file, when the user types "foo", selects the prompt, and
presses "/", the result should be "foo/".

If the directory "foobar" exists, but "foo" does not, typing "foo",
selecting the prompt, and pressing "/" results in "cd"ing to "foobar"
(assuming ivy-magic-slash-non-match-action is
'ivy-magic-slash-non-match-cd-selected). This commit changes
ivy--magic-file-slash to check that the prompt is not selected before
performing the ivy-magic-slash-non-match-cd-selected action.