### PR TITLE
fix empty counsel-imenu items list on Emacs 27

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4244,7 +4244,7 @@ PREFIX is used to create the key."
          (imenu-auto-rescan-maxout (if current-prefix-arg
                                        (buffer-size)
                                      imenu-auto-rescan-maxout))
-         (items (imenu--make-index-alist t))
+         (items (progn (imenu--make-index-alist t) imenu--index-alist))
          (items (delete (assoc "*Rescan*" items) items))
          (items (counsel-imenu-categorize-functions items)))
     (ivy-read "imenu items: " (counsel-imenu-get-candidates-from items)


### PR DESCRIPTION
Is this the best way to fix #2241?