### PR TITLE
fix counsel-evil-registers and implement counsel-evil-marks

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4182,7 +4182,7 @@ matching the register's value description against a regexp in
                 :caller 'counsel-evil-registers)
     (user-error "Required feature `evil' not installed.")))
 (add-to-list 'ivy-format-functions-alist '(counsel-evil-registers . counsel--yank-pop-format-function))
-(add-to-list 'ivy-height-alist '(counsel-evil-registers . 5))
+(add-to-list 'ivy-height-alist `(counsel-evil-registers . ,counsel-evil-registers-height))
 
 (defun counsel-evil-registers-action (s)
   "Paste contents of S, trimming the register part.

--- a/counsel.el
+++ b/counsel.el
@@ -3892,6 +3892,10 @@ Obeys `widen-automatically', which see."
       (message "Mark ring is empty"))))
 
 ;;** `counsel-evil-marks'
+(defvar counsel--evil-marks-exclude-registers nil
+  "list of evil registers to not display in `counsel-evil-marks' by default.
+each member of the list should be a character (stored as an integer).")
+
 (defun counsel-mark--get-evil-candidates ()
   "Convert all evil MARKS in the current buffer to mark candidates.
 works like `counsel-mark--get-candidates' but also prepends the
@@ -3913,8 +3917,12 @@ register tied to a mark in the message string."
                                (not (markerp (cdr m)))))
                          (default-value 'evil-markers-alist))))
 
-         ;; order marks by evil register in the same way as `evil-show-marks'
-         ;; (all-markers (sort all-markers (lambda (i j) (< (car j) (car i)))))
+         (all-markers
+          (if prefix-arg
+              all-markers ;; with prefix, ignore register exclusion list.
+            (let ((filter (lambda (_) (not (member (car _)
+                                              counsel--evil-marks-exclude-registers)))))
+              (seq-filter filter all-markers))))
 
          ;; seperate the markers from the evil registers
          ;; for call to `counsel-mark--get-candidates'
@@ -3942,7 +3950,9 @@ register tied to a mark in the message string."
 
 ;;;###autoload
 (defun counsel-evil-marks ()
-  "Ivy replacement for `evil-show-marks'."
+  "Ivy replacement for `evil-show-marks'.
+By default, this function respects `counsel--evil-marks-exclude-registers'.
+Pass a prefix argument to display all active evil registers."
   (interactive)
 
   (if (and (boundp 'evil-markers-alist)


### PR DESCRIPTION
this pull request addresses issues [2246](https://github.com/abo-abo/swiper/issues/2246) & [2221](https://github.com/abo-abo/swiper/issues/2221). 

I've abstracted out a lot of the code in `counsel-mark-ring` to minimise the amount of code duplication in `counsel-evil-marks`.

~~Full disclosure, I can't seem to pass all the tests cases. Test 45 keeps failing for me with the error trace:~~

```
Test ivy-swiper-wgrep backtrace:
  signal(error ("Package wgrep isn’t installed"))
  apply(signal (error ("Package wgrep isn’t installed")))
  (setq value-1152 (apply fn-1150 args-1151))
  (unwind-protect (setq value-1152 (apply fn-1150 args-1151)) (setq fo
  (if (unwind-protect (setq value-1152 (apply fn-1150 args-1151)) (set
  (let (form-description-1154) (if (unwind-protect (setq value-1152 (a
  (let ((value-1152 (quote ert-form-evaluation-aborted-1153))) (let (f
  (let* ((fn-1150 (function string=)) (args-1151 (condition-case err (
  (let ((search-cmd (car --dolist-tail--))) (let* ((fn-1150 (function
  (while --dolist-tail-- (let ((search-cmd (car --dolist-tail--))) (le
  (let ((--dolist-tail-- (quote (swiper swiper-isearch)))) (while --do
  (closure (t) nil (let ((--dolist-tail-- (quote (swiper swiper-isearc
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name ivy-swiper-wgrep :documentation nil :
  ert-run-or-rerun-test(#s(ert--stats :selector (not ivy--lazy-load-ff
  ert-run-tests((not ivy--lazy-load-ffap--ffap-url-p) #f(compiled-func
  ert-run-tests-batch((not ivy--lazy-load-ffap--ffap-url-p))
  (ert-stats-completed-unexpected (ert-run-tests-batch test-set))
  (+ unexpected (ert-stats-completed-unexpected (ert-run-tests-batch t
  (setq unexpected (+ unexpected (ert-stats-completed-unexpected (ert-
  (let ((test-set (car --dolist-tail--))) (setq unexpected (+ unexpect
  (while --dolist-tail-- (let ((test-set (car --dolist-tail--))) (setq
  (let ((--dolist-tail-- test-sets)) (while --dolist-tail-- (let ((tes
  (let ((test-sets (quote (ivy--lazy-load-ffap--ffap-url-p (not ivy--l
  ivy-test-run-tests()
  command-line-1(("-l" "elpa.el" "-l" "colir.el" "-l" "ivy-overlay.el"
  command-line()
  normal-top-level()
Test ivy-swiper-wgrep condition:
    (error "Package wgrep isn’t installed")
   FAILED  45/54  ivy-swiper-wgrep
```

~~this is the only test that's failing and I have installed `wgrep` which I've verified by opening emacs and running `M-: (require 'wgrep)` without any errors, so I'm not sure why this is happening. I'd like to ask you run the tests yourself before accepting this request. There aren't any compilation warnings.~~

~~Update: yeah, I tried cloning you're repository ([abo-abo/swiper](https://github.com/abo-abo/swiper)) & running the tests again and test 45 is still failing for me, so I can only surmise my code has nothing to do with it 😌.~~