### PR TITLE
Respect counsel-describe-function-function from counsel-M-x

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -914,7 +914,7 @@ when available, in that order of precedence."
 (ivy-set-actions
  'counsel-M-x
  `(("d" counsel--find-symbol "definition")
-   ("h" ,(lambda (x) (describe-function (intern x))) "help")))
+   ("h" ,(lambda (x) (funcall counsel-describe-function-function (intern x))) "help")))
 
 (ivy-set-display-transformer
  'counsel-M-x


### PR DESCRIPTION
This enables users to overide the describe function for counsel-M-x,
to use packages like helpful.

See discussion in https://github.com/Wilfred/helpful/issues/218