### PR TITLE
counsel.el (counsel-mark-ring): Add the latest mark to selection

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3768,7 +3768,10 @@ Obeys `widen-automatically', which see."
                   (line (buffer-substring
                          (line-beginning-position) (line-end-position))))
               (cons (format fmt linum line) (point)))))
-         (marks (sort (delete-dups (copy-sequence mark-ring)) #'<))
+         (marks (copy-sequence mark-ring))
+         (marks (if (equal (mark-marker) (make-marker)) ; mark-marker is empty?
+                    marks (cons (copy-marker (mark-marker)) marks)))
+         (marks (sort (delete-dups marks) #'<))
          (cands
           ;; Widen, both to save `line-number-at-pos' the trouble
           ;; and for `buffer-substring' to work.


### PR DESCRIPTION
The mark-ring has the list of saved former marks.
So, it does not have the latest mark.
The latest mark is held by mark-marker.
This change add the latest mark to counsel-mark-ring selection.