### PR TITLE
counsel.el (counsel-mark-ring): Fix highlight line of selected candidate

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3754,7 +3754,8 @@ This variable has no effect unless
   (let ((pos (get-text-property 0 'point (ivy-state-current ivy-last))))
     (counsel--mark-ring-delete-highlight)
     (with-ivy-window
-      (goto-char pos))))
+      (goto-char pos)
+      (counsel--mark-ring-add-highlight))))
 
 ;;;###autoload
 (defun counsel-mark-ring ()


### PR DESCRIPTION
Now, `counsel-mark-ring` does not highlight the line.
This change makes it correctly.

Forgotten line when merge #2078. 😝 