### PR TITLE
ivy-occur: set next-error-function.

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4732,7 +4732,9 @@ There is no limit on the number of *ivy-occur* buffers."
         (setf (ivy-state-text ivy-last) ivy-text)
         (setq ivy-occur-last ivy-last))
       (ivy-exit-with-action
-       (lambda (_) (pop-to-buffer buffer))))))
+       (lambda (_)
+         (pop-to-buffer buffer)
+         (setq next-error-last-buffer buffer))))))
 
 (defun ivy-occur-revert-buffer ()
   "Refresh the buffer making it up-to date with the collection.

--- a/ivy.el
+++ b/ivy.el
@@ -4636,6 +4636,16 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
       (ivy-occur-previous-line arg)
       (ivy-occur-press-and-switch))))
 
+(defun ivy-occur-next-error (n &optional reset)
+  "A `next-error-function' for `ivy-occur-mode'."
+  (interactive "p")
+  (when reset
+    (goto-char (point-min)))
+  (setq n (or n 1))
+  (let ((ivy-calling t))
+    (cond ((< n 0) (ivy-occur-previous-line (- n)))
+          (t (ivy-occur-next-line n)))))
+
 (define-derived-mode ivy-occur-mode fundamental-mode "Ivy-Occur"
   "Major mode for output from \\[ivy-occur].
 

--- a/swiper.el
+++ b/swiper.el
@@ -677,7 +677,8 @@ When capture groups are present in the input, print them instead of lines."
         (lambda (cand) (concat "./" cand))
         cands))
       (goto-char (point-min))
-      (forward-line 4))))
+      (forward-line 4)
+      (setq-local next-error-function #'ivy-occur-next-error))))
 
 (ivy-set-occur 'swiper 'swiper-occur)
 


### PR DESCRIPTION
This set of changes allows to use next-error and previous-error
as a replacement for ivy-occur-toggle-calling, ivy-occur-next-line
and ivy-occur-previous-line.

For example with next-error and bound to M-n and M-p:

- "C-h f" (`describe-funtion')
- "run" (`self-insert-command')
- "C-c C-o" (`ivy-occur'); "C-o u" also works.
- "M-n M-n M-n M-k M-k M-k"

this problem seems to be like #1353.

also see commit 1c45b2940432fa0ee08ec3acfc151e556939308a.




NOTE: the existing pop-to-buffer at the end of ivy-occur makes the UI of ivy-occur different from occur; this PR aims at getting ivy-occur closer to occur in that regards.  

@abo-abo please let me know if that is of interest, this can probably be extended.

The second commit happens to fix #1354.