### PR TITLE
Add `counsel-read-directory-name'

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -975,6 +975,13 @@ will bring the behavior in line with the newer Emacsen."
            "DEL C-M-j"
            :dir "/tmp"))))
 
+(ert-deftest ivy-counsel-read-directory-name ()
+  (should
+   (equal (expand-file-name "/tmp/")
+          (ivy-with
+           '(counsel-read-directory-name "cd: " "/tmp")
+           "RET"))))
+
 (ert-deftest ivy-partial-files ()
   (when (file-exists-p "/tmp/ivy-partial-test")
     (delete-directory "/tmp/ivy-partial-test" t))


### PR DESCRIPTION
This is a partial replacement of read-directory-name, except that
DEFAULT-DIRNAME does not have any effect. This should be able to
mitigate the issue mentioned in #1646 to allow more flexibility
regarding customized key bindings.

I replaced all occurrences of read-directory-name with counsel-read-directory-name in counsel.el with some minimum test.

Maybe this should be called `ivy-read-directory-name` (given the existence of `ido-read-directory-name`), but I'm not 100% sure about this.