### PR TITLE
Ensure that ripgrep on windows uses '/' as the path separator

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2935,7 +2935,7 @@ This uses `counsel-ag' with `counsel-ack-base-command' replacing
 ;;** `counsel-rg'
 (defcustom counsel-rg-base-command
   (if (memq system-type '(ms-dos windows-nt))
-      "rg --with-filename --no-heading --line-number --color never %s ."
+      "rg --with-filename --no-heading --line-number --path-separator / --color never %s ."
     "rg --with-filename --no-heading --line-number --color never %s")
   "Alternative to `counsel-ag-base-command' using ripgrep.
 


### PR DESCRIPTION
By default ripgrep uses '\\' as the path separator on Windows. This causes jumps from the occur buffer to fail. Fix the issue by setting '/' as the path separator on Windows.

Fixes: https://github.com/abo-abo/swiper/issues/2207