### PR TITLE
Add history delete action for counsel-compile

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5991,6 +5991,14 @@ specified by the `blddir' property."
             :action #'counsel-compile--action
             :caller 'counsel-compile))
 
+(defun counsel-compile-forget-command (cmd)
+  "Delete CMD from `counsel-compile-history'."
+  (setq counsel-compile-history
+        (delete cmd counsel-compile-history)))
+
+(ivy-add-actions
+ 'counsel-compile
+ '(("d" counsel-compile-forget-command "delete")))
 
 (defun counsel-compile-env--format-hint (cands)
   "Return a formatter for compile-env CANDS."


### PR DESCRIPTION
Adds a delete action to forget commands in `counsel-compile-history`. This is particularly useful when persisting the history with `savehist`.