### PR TITLE
ivy.el (ivy-done, ivy--prompt-selectable-p): Do not consider 'confirm or 'confirm-after-completion. They are undocumented.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1957,7 +1957,7 @@ The preselect behavior can be customized via user options
               :initial-input initial-input
               :action action
               :preselect (counsel--preselect-file)
-              :require-match 'confirm-after-completion
+              :require-match nil
               :history 'file-name-history
               :keymap counsel-find-file-map
               :caller caller)))
@@ -2675,7 +2675,7 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
               :initial-input initial-input
               :action #'find-file
               :preselect (counsel--preselect-file)
-              :require-match 'confirm-after-completion
+              :require-match nil
               :history 'file-name-history
               :keymap counsel-find-file-map
               :caller 'counsel-file-jump)))

--- a/ivy.el
+++ b/ivy.el
@@ -760,8 +760,7 @@ candidate, not the prompt."
 (defun ivy--prompt-selectable-p ()
   "Return t if the prompt line is selectable."
   (and ivy-use-selectable-prompt
-       (or (memq (ivy-state-require-match ivy-last)
-                 '(nil confirm confirm-after-completion))
+       (or (null (ivy-state-require-match ivy-last))
            ;; :require-match is t, but "" is in the collection
            (let ((coll (ivy-state-collection ivy-last)))
              (and (listp coll)
@@ -795,8 +794,7 @@ candidate, not the prompt."
              (setq ivy--prompt-extra " (confirm)")
              (insert ivy-text)
              (ivy--exhibit)))
-          ((memq (ivy-state-require-match ivy-last)
-                 '(nil confirm confirm-after-completion))
+          ((null (ivy-state-require-match ivy-last))
            (ivy--done ivy-text))
           (t
            (setq ivy--prompt-extra " (match required)")


### PR DESCRIPTION
* counsel.el (counsel-file-jump, counsel--find-file-1): Set :require-match to nil. Otherwise
counsel-find-file cannot select the prompt line.