### PR TITLE
swiper.el (swiper--isearch-format): Prepend swiper-line-face property

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1585,10 +1585,10 @@ When not running `swiper-isearch' already, start it."
         (dotimes (_ (1+ j))
           (string-match regex current-str start)
           (setq start (match-end 0)))
-        (swiper--isearch-highlight current-str j)
-        (font-lock-append-text-property
+        (font-lock-prepend-text-property
          0 (length current-str)
          'face 'swiper-line-face current-str)
+        (swiper--isearch-highlight current-str j)
         (push current-str res))
       (cl-incf len)
       (setq i (1+ index))


### PR DESCRIPTION
Hello!
I was trying `swiper-isearch` out today, and the text in the minibuffer preview would be invisible some times. It occurred mainly with the `doom-themes`, and in text with a specific background/foreground color, but it also occurred with other themes.

After reading the source, I found that the `swiper` properties were being appended. After changing the code to prepend the properties instead, and only setting the matches after, everything seems to be working as intended.

This was tested on Emacs 26.3.