### PR TITLE
counsel.el (counsel-ag): Set :require-match to t.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2863,6 +2863,7 @@ CALLER is passed to `ivy-read'."
               :keymap counsel-ag-map
               :history 'counsel-git-grep-history
               :action #'counsel-git-grep-action
+              :require-match t
               :caller (or caller 'counsel-ag))))
 
 (ivy-configure 'counsel-ag


### PR DESCRIPTION
But strangely I can still select the prompt. A better solution, I think, might be to set :require-match to t
for all callers that have set :grep-p to t.