### PR TITLE
Simpler logic choosing match faces?

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3859,6 +3859,14 @@ Note: The usual last two arguments are flipped for convenience.")
          (cons (flx-score str flx-name ivy--flx-cache) str)))
     (ivy--highlight-default str)))
 
+(defcustom ivy-use-group-face-if-no-groups t
+  "If t, and the expression has no subgroups, highlight whole match as a group.
+
+It will then use the second face (first of the \"group\" faces)
+of `ivy-minibuffer-faces'.  Otherwise, always use the first face
+in this case."
+  :type 'boolean)
+
 (defun ivy--highlight-default (str)
   "Highlight STR, using the default method."
   (unless ivy--old-re
@@ -3883,7 +3891,8 @@ Note: The usual last two arguments are flipped for convenience.")
                   (unless (and prev (= prev beg))
                     (cl-incf n))
                   (let ((face
-                         (cond ((zerop ivy--subexps)
+                         (cond ((and ivy-use-group-face-if-no-groups
+                                     (zerop ivy--subexps))
                                 (cadr ivy-minibuffer-faces))
                                ((zerop i)
                                 (car ivy-minibuffer-faces))

--- a/swiper.el
+++ b/swiper.el
@@ -1030,13 +1030,22 @@ WND, when specified is the window."
                                                 (line-end-position)))))))
                 (swiper--add-properties faces adder-fn re-idx)))))))))
 
+
+(defcustom swiper-use-group-face-if-no-groups t
+  "If t, and the expression has no subgroups, highlight whole match as a group.
+
+It will then use the second face (first of the \"group\" faces)
+of `swiper-faces' (or `swiper-background-faces').  Otherwise,
+always use the first face in this case."
+  :type 'boolean)
+
 (defun swiper--add-properties (faces adder-fn &optional re-idx)
   (let ((mb (match-beginning 0))
         (me (match-end 0)))
     (unless (> (- me mb) 2017)
       (funcall adder-fn
                mb me
-               (if (zerop ivy--subexps)
+               (if (and swiper-use-group-face-if-no-groups (zerop ivy--subexps))
                    (nth (1+ (mod (or re-idx 0) (1- (length faces)))) faces)
                  (car faces))
                0)))


### PR DESCRIPTION
All of `{ivy-minibuffer,swiper,swiper-background}-match-face-{1,2,3,4}` use the -2 face for the whole match if there are no subgroups, and the -1 face for the whole match *iff* there are subgroups.

This seems intentional, presumably so that the starting face of a match (especially when using `swiper-isearch` or the like) does not change when it turns from "whole match" into "first subgroup".

For me, this makes face customization painful, because the faces change roles depending on the match.  I also cannot make it consistent with things like the `re-builder`, which always highlights the whole match with the same face, and possible subgroups with other faces.

Is there a chance to make the "fancier" behavior optional?  If so, I can take a stab at implementing that..