### PR TITLE
split up ivy--directory-done to use for tramp completion

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -1014,6 +1014,16 @@ bindings that work here:
      On a directory, restarts completion from that directory.
 
      On a file or =./=, exit completion with the selected candidate.
+- (=ivy-partial-tramp=) ::
+     Alternative to =ivy-partial-or-done= intended to be bound to
+     ~TAB~.
+
+     This command tries to complete minibuffers current file or
+     directory name.  If that fails, it tries to complete current
+     minibuffer text with help of tramp method, username, etc.
+
+     It does not end minibuffer, so it enables the user to edit and
+     complete the minibuffer text any further.
 - ~DEL~ (=ivy-backward-delete-char=) ::
      Restart the completion in the parent directory if current input
      is empty.

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -1333,6 +1333,19 @@ On a directory, restarts completion from that directory.
 
 On a file or @code{./}, exit completion with the selected candidate.
 @end indentedblock
+@subsubheading (@code{ivy-partial-tramp})
+@vindex ivy-partial-tramp
+@kindex TAB
+@indentedblock
+Alternative to @code{ivy-partial-or-done} intended to be bound to @kbd{TAB}.
+
+This command tries to complete minibuffers current file or directory
+name. If that fails, it tries to complete current minibuffer text with
+help of tramp method, username, etc.
+
+It does not end minibuffer, so it enables the user to edit and complete
+the minibuffer text any further.
+@end indentedblock
 @subsubheading @kbd{DEL} (@code{ivy-backward-delete-char})
 @vindex ivy-backward-delete-char
 @kindex DEL

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -1333,19 +1333,6 @@ On a directory, restarts completion from that directory.
 
 On a file or @code{./}, exit completion with the selected candidate.
 @end indentedblock
-@subsubheading (@code{ivy-partial-tramp})
-@vindex ivy-partial-tramp
-@kindex TAB
-@indentedblock
-Alternative to @code{ivy-partial-or-done} intended to be bound to @kbd{TAB}.
-
-This command tries to complete minibuffers current file or directory
-name. If that fails, it tries to complete current minibuffer text with
-help of tramp method, username, etc.
-
-It does not end minibuffer, so it enables the user to edit and complete
-the minibuffer text any further.
-@end indentedblock
 @subsubheading @kbd{DEL} (@code{ivy-backward-delete-char})
 @vindex ivy-backward-delete-char
 @kindex DEL

--- a/ivy.el
+++ b/ivy.el
@@ -4105,9 +4105,12 @@ possible match.  See `all-completions' for further information."
 
 The default value is given as an example.
 
-Each element is a list of (NAME TREE).  NAME is a string, it's
+Each element is a list of (NAME VIEW). NAME is a string, it's
 recommended to end it with a distinctive snippet e.g. \"{}\" so
 that it's easy to distinguish the window configurations.
+
+VIEW is either a TREE or a window-configuration (see
+`ivy--get-view-config').
 
 TREE is a nested list with the following valid cars:
 - vert: split the window vertically
@@ -4150,6 +4153,22 @@ TREE can be nested multiple times to have multiple window splits.")
           (t
            default-view-name))))
 
+(defun ivy--get-view-config ()
+  "Get `current-window-configuration' for `ivy-views'."
+  (dolist (w (window-list))
+    (set-window-parameter w 'ivy-view-data
+                          (with-current-buffer (window-buffer w)
+                            (cond (buffer-file-name
+                                   (list 'file buffer-file-name (point)))
+                                  ((eq major-mode 'dired-mode)
+                                   (list 'file default-directory (point)))
+                                  (t
+                                   (list 'buffer (buffer-name) (point)))))))
+  (let ((window-persistent-parameters
+         (append window-persistent-parameters
+                 (list (cons 'ivy-view-data t)))))
+    (current-window-configuration)))
+
 (defun ivy-push-view (&optional arg)
   "Push the current window tree on `ivy-views'.
 
@@ -4159,22 +4178,7 @@ Currently, the split configuration (i.e. horizontal or vertical)
 and point positions are saved, but the split positions aren't.
 Use `ivy-pop-view' to delete any item from `ivy-views'."
   (interactive "P")
-  (let* ((view (cl-labels
-                   ((ft (tr)
-                      (if (consp tr)
-                          (if (eq (car tr) t)
-                              (cons 'vert
-                                    (mapcar #'ft (cddr tr)))
-                            (cons 'horz
-                                  (mapcar #'ft (cddr tr))))
-                        (with-current-buffer (window-buffer tr)
-                          (cond (buffer-file-name
-                                 (list 'file buffer-file-name (point)))
-                                ((eq major-mode 'dired-mode)
-                                 (list 'file default-directory (point)))
-                                (t
-                                 (list 'buffer (buffer-name) (point))))))))
-                 (ft (car (window-tree)))))
+  (let* ((view (ivy--get-view-config))
          (view-name
           (if arg
               (ivy-read "Update view: " ivy-views)
@@ -4212,7 +4216,13 @@ Use `ivy-pop-view' to delete any item from `ivy-views'."
 
 (defun ivy-set-view-recur (view)
   "Set VIEW recursively."
-  (cond ((eq (car view) 'vert)
+  (cond  ((window-configuration-p view)
+          (set-window-configuration view)
+          (dolist (w (window-list))
+            (with-selected-window w
+              (ivy-set-view-recur
+               (window-parameter w 'ivy-view-data)))))
+         ((eq (car view) 'vert)
          (let* ((wnd1 (selected-window))
                 (wnd2 (split-window-vertically))
                 (views (cdr view))

--- a/ivy.el
+++ b/ivy.el
@@ -1127,6 +1127,19 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
            (file-directory-p (ivy-state-current ivy-last))))
     (ivy--directory-done)))
 
+(defun ivy-partial-tramp ()
+  "Complete the minibuffer text as much as possible, else use tramp to complete it.
+This command is useful to be bound to `TAB', it doesn't call done after completion,
+so minibuffer text can be edited and completed further, even with remote files."
+  (interactive)
+  (or (ivy-partial)
+      (let ((dir (ivy--handle-directory ivy-text))
+	    (inhibit-message t))
+	(and dir
+	     (ivy--cd dir)))
+      (and (ivy--tramp-prefix-p)
+	   (ivy--tramp-completion-list))))
+
 (defun ivy-partial ()
   "Complete the minibuffer text as much as possible."
   (interactive)


### PR DESCRIPTION
Split up `ivy--directory-done` to be able to reuse source code of tramp completion for a new command `ivy-partial-tramp`, which completes file names, directory names and tramp methods/names, but does not call `done`. This new command is useful to be bound to `TAB`. 

There is not much new source code I only split up an existing function and called those new functions.