### PR TITLE
Update test instructions for contributing

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -49,6 +49,7 @@ warning:
 
 Before submitting a change, run:
 - =make compile= - check for new compilation warnings
+- =make deps= - install dependencies for testing
 - =make test= - check for failing tests
 - =make checkdoc= - check documentation guidelines
 


### PR DESCRIPTION
A small change for newcomers, so they don't miss installing the dependencies before testing.