### PR TITLE
`ivy--reset-state`: Ensure default values are prepended

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2327,11 +2327,6 @@ This is useful for recursive `ivy-read'."
              (setq coll (all-completions "" collection predicate))))
       (unless (ivy-state-dynamic-collection ivy-last)
         (setq coll (delete "" coll)))
-      (when def
-        (cond ((stringp (car-safe def))
-               (setq coll (cl-union def coll :test #'equal)))
-              ((and (stringp def) (not (member def coll)))
-               (push def coll))))
       (when (and sort
                  (or (functionp collection)
                      (not (eq history 'org-refile-history)))
@@ -2340,6 +2335,13 @@ This is useful for recursive `ivy-read'."
                  (listp coll)
                  (null (nthcdr ivy-sort-max-size coll)))
         (setq coll (sort (copy-sequence coll) sort-fn)))
+      (when def
+        (cond ((stringp (car-safe def))
+               (setq coll
+                     (delete-dups
+                      (append def coll))))
+              ((and (stringp def) (not (member def coll)))
+               (push def coll))))
       (setq coll (ivy--set-candidates coll))
       (setq ivy--old-re nil)
       (setq ivy--old-cands nil)


### PR DESCRIPTION
Before this patch default values would get included in possible sort and even without sort would appear randomly in the collection. Usually you want to see the default values right away because they are suggested values you likely want to pick. This patch ensures default values are always prepended to the collection. This is especially useful with larger collections.

Before:

    (ivy-read "Test: " '("1" "2") :def '("a" "b" "c")) ;; =>  2, 1, a, b, c

After:

    (ivy-read "Test: " '("1" "2") :def '("a" "b" "c")) ;; => a, b, c, 1, 2
