### PR TITLE
Don't assume ivy-read always returns a string

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2434,7 +2434,7 @@ INHERIT-INPUT-METHOD is currently ignored."
         (setq history (car history)))
       (when (consp def)
         (setq def (car def)))
-      (let ((str (ivy-read
+      (let ((res (ivy-read
                   prompt collection
                   :predicate predicate
                   :require-match (and collection require-match)
@@ -2455,11 +2455,12 @@ INHERIT-INPUT-METHOD is currently ignored."
                   :caller (if (and collection (symbolp collection))
                               collection
                             this-command))))
-        (if (string= str "")
+        (if (and (stringp res)
+                 (string= res ""))
             ;; For `completing-read' compat, return the first element of
             ;; DEFAULT, if it is a list; "", if DEFAULT is nil; or DEFAULT.
             (or def "")
-          str)))))
+          res)))))
 
 (defun ivy-completing-read-with-empty-string-def
     (prompt collection


### PR DESCRIPTION
Currently this gives an error when completing an alist for example:

    (ivy-completing-read "Test: " '(("1" . "a") ("2" . "b")))

Another thing I noticed is that the above returns the cons of selected string, normal `completing-read` returns just the string for full compat `ivy-completing-read` would need to do that, too. But I agree that returning the cons is more useful but it's not compatible to regular API. Let me know if I should add this to my PR.
