### PR TITLE
Allow selecting the prompt when there are no candidates

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3628,7 +3628,9 @@ RE-STR is the regexp, CANDS are the current candidates."
                           (string-match-p preselect current))))
                ivy--old-cands
                (cl-position current cands :test #'equal))
-          (funcall func re-str cands)))))
+          (if (= ivy--index -1)              ; prompt is selected?
+              -1                             ; then leave it selected
+            (funcall func re-str cands)))))) ; otherwise call fallback
     (when (or empty (string= name "^"))
       (ivy-set-index
        (or (ivy--preselect-index preselect cands)


### PR DESCRIPTION
If I want to dispatch a non-default action on the prompt text (rather than on a candidate), I first have to highlight the prompt (assuming we've enabled `ivy-use-selectable-prompt`). However, it is currently not possible to select the prompt when the candidate list is empty.

Why is this an issue? Suppose that I run `counsel-find-file`, type in the name of a nonexistent file, and hit RET. The new file opens in my window, as expected. Now suppose that, instead of RET, I hit `M-o j` to open a new file in another window. This time, the prompt text will be ignored, and the "default" i.e. the *parent directory* will be opened in the other window.

In order to tell Ivy "please use the prompt text when I pick an action with M-o", I have to select the prompt first. That's no problem as long as there's at least one match. But when there aren't any matches, I can't select the prompt. This commit attempts to change that behavior.

On the other hand: It might be better to change the behavior of `ivy-dispatching-done` to always use the prompt text when there are no matches. One less keystroke, and it's more in line with what I'd intuitively expect. I'll put together another PR for that.

Implementation details:

I found that, when there are no candidates, `ivy--recompute-index` (called by `ivy--exhibit` during display update) sets `ivy--index` to zero immediately after `ivy-previous-line` sets it to -1 (i.e. the prompt). Specifically, zero is returned by the "fallback" call to `ivy-recompute-index-zero`.

This commit wraps that fallback call with a check to see if `ivy--index` is -1, preserving it in that case. In my limited testing, this seems to give the desired result without breaking anything. However, I know practically nothing about the Ivy internals, so ¯\\_(ツ)_/¯.