### PR TITLE
Use prompt text for "M-o" actions when match list is empty

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -787,7 +787,10 @@ candidate, not the prompt."
       (ivy-immediate-done)
     (setq ivy-current-prefix-arg current-prefix-arg)
     (delete-minibuffer-contents)
-    (cond ((or (> ivy--length 0)
+    (cond ((and (= ivy--length 0)
+                (eq this-command 'ivy-dispatching-done))
+           (ivy--done ivy-text))
+          ((or (> ivy--length 0)
                ;; the action from `ivy-dispatching-done' may not need a
                ;; candidate at all
                (eq this-command 'ivy-dispatching-done))


### PR DESCRIPTION
Alternative to #2364.

With this change, when you pick an action with `M-o`, and the candidate list is empty, Ivy will use the prompt text, rather than ignoring it (and, for instance in the case of `counsel-find-file`, opening the parent directory of the file you had wished to create).