### PR TITLE
fix: make counsel-git work with utf-8 characters

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1233,7 +1233,7 @@ selected face."
 
 ;;* Git
 ;;** `counsel-git'
-(defvar counsel-git-cmd "git ls-files --full-name --"
+(defvar counsel-git-cmd "git ls-files -z --full-name --"
   "Command for `counsel-git'.")
 
 (ivy-set-actions
@@ -1257,7 +1257,7 @@ Like `locate-dominating-file', but DIR defaults to
   (let ((default-directory (counsel-locate-git-root)))
     (split-string
      (shell-command-to-string counsel-git-cmd)
-     "\n"
+     "\0"
      t)))
 
 ;;;###autoload


### PR DESCRIPTION
`counsel-git` won't show utf-8 characters in filenames:

![counsel-git-before](https://user-images.githubusercontent.com/28714352/70811586-d88a5880-1e00-11ea-8d66-0dfd7630b8a9.png)

This can be fixed by using `-z` argument for `git --ls-files`, so it produces a NUL separated list:

![counsel-git-after](https://user-images.githubusercontent.com/28714352/70811731-2a32e300-1e01-11ea-9142-570a19d195e3.png)

magit also did this, see https://github.com/magit/magit/blob/a7699f868f6fd32aae8aa8e64a72ea989a5c25cf/lisp/magit-git.el#L484

I haven't used other `counsel-git-xxx` commands. If similar problems can happen, please comment and I'll fix them too.