### PR TITLE
Fix for counsel-register file registers in Emacs 27

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4206,14 +4206,14 @@ Note: Duplicate elements of `kill-ring' are always deleted."
 
 ;;** `counsel-register'
 (defvar counsel-register-actions
-  '(("\\`buffer position" . jump-to-register)
+  '(("\\`buffer" . jump-to-register)
     ("\\`text" . insert-register)
     ("\\`rectangle" . insert-register)
-    ("\\`window configuration" . jump-to-register)
-    ("\\`frame configuration" . jump-to-register)
+    ("\\`window" . jump-to-register)
+    ("\\`frame" . jump-to-register)
     ("\\`[-+]?[0-9]+\\(?:\\.[0-9]\\)?\\'" . insert-register)
-    ("\\`the file" . jump-to-register)
-    ("\\`keyboard macro" . jump-to-register)
+    ("\\`\\(?:the \\)?file " . jump-to-register)
+    ("\\`keyboard" . jump-to-register)
     ("\\`file-query" . jump-to-register))
   "Alist of (REGEXP . FUNCTION) pairs for `counsel-register'.
 Selecting a register whose description matches REGEXP specifies


### PR DESCRIPTION
This should fix an issue where `counsel-register` doesn't recognize file registers in Emacs 27. At some point the wording in the description of a file register changed from "the file" to "file", and `counsel-register` expected the former only. Both should now be recognized and invoke `jump-to-register` as expected.