### PR TITLE
Use the current prompt for shell history initial input

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4432,12 +4432,20 @@ An extra action allows to switch to the process buffer."
 ;;** `counsel-esh-history'
 (defun counsel--browse-history (ring)
   "Use Ivy to navigate through RING."
-  (setq ivy-completion-beg (point))
-  (setq ivy-completion-end (point))
-  (ivy-read "History: " (ivy-history-contents ring)
-            :keymap ivy-reverse-i-search-map
-            :action #'ivy-completion-in-region-action
-            :caller 'counsel-shell-history))
+  (let* ((proc (get-buffer-process (current-buffer)))
+         (end (point))
+         (beg (if proc
+                  (min (process-mark proc) end)
+                end))
+         (input (when (< beg end)
+                  (concat "^" (buffer-substring beg end)))))
+    (setq ivy-completion-beg beg
+          ivy-completion-end end)
+    (ivy-read "History: " (ivy-history-contents ring)
+              :keymap ivy-reverse-i-search-map
+              :initial-input input
+              :action #'ivy-completion-in-region-action
+              :caller 'counsel-shell-history)))
 
 (defvar eshell-history-ring)
 


### PR DESCRIPTION
This is one of the features of `helm-comint-input-ring` that is really nice. If you are typing a prompt and can't remember the rest of the command, you can use `counsel-shell-history` to get completions that match what you are typing without needing to re enter it. And if that is not what you want you can use `C-S-Del` to clear the prompt. 