### PR TITLE
counsel-org-tag-action: message when a tag has been removed.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3393,7 +3393,9 @@ otherwise continue prompting for tags."
                              (delete-dups
                               (append (counsel--org-get-tags) add-tags)))
                        (counsel-org--set-tags))))))
-           (counsel-org--set-tags)))
+           (counsel-org--set-tags)
+           (unless (member x counsel-org-tags)
+             (message "Tag %S has been removed." x))))
         ((eq this-command 'ivy-call)
          (with-selected-window (active-minibuffer-window)
            (delete-minibuffer-contents)))))


### PR DESCRIPTION
* counsel.el (counsel-org-tag-action): message when a tag has been
removed.

Some headlines of my org-files have many tags, so tags are often
deleted by mistake, so message user seem to be a good idea.