### PR TITLE
ivy.el (ivy--buffer-list): Avoid unnecessarily touching remote connections

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4115,7 +4115,7 @@ possible match.  See `all-completions' for further information."
               (dir (buffer-local-value 'default-directory buf))
               (face (if (and dir
                              (ignore-errors
-                               (file-remote-p (abbreviate-file-name dir))))
+                               (file-remote-p dir)))
                         'ivy-remote
                       (cdr (assq (buffer-local-value 'major-mode buf)
                                  ivy-switch-buffer-faces-alist)))))


### PR DESCRIPTION
`abbreviate-file-name` in `ivy--buffer-list` may trigger TRAMP to re-connect to remote buffer (see a backtrace below).

However, this is annoying if one has the following workflow:
1. editing files in a virtual machine and the virtual machine is frequently shutdown/reboot due to development.
2. editing files in a remote server and the server is only accessible when at work.

In these cases, every time  `ivy-switch-buffer` is invoked, Emacs will busy wait connecting to the remote buffers if these buffers are not currently accessible.

It seems that `ivy` here only has to check whether a buffer is remote or not so as to set faces.  If so, `file-remote-p` is enough.

----

A backtrace of TRAMP connecting to remote buffers when `ivy-switch-buffer` is invoked:
```
Debugger entered--entering a function:
* tramp-signal-hook-function(quit nil)
  tramp-get-hash-table(#<process *tramp/ssh fan@vm00*>)
  tramp-get-connection-property(#<process *tramp/ssh fan@vm00*> "check-remote-echo" nil)
  tramp-check-for-regexp(#<process *tramp/ssh fan@vm00*> "\\(\\(TERM = (.*)\\|Terminal type\\? \\[.*\\]\\)\\s-*\\)\\'")
  tramp-process-one-action(#<process *tramp/ssh fan@vm00*> (tramp-file-name "ssh" "fan" nil "vm00" nil "" nil) ((tramp-login-prompt-regexp tramp-action-login) (tramp-password-prompt-regexp tramp-action-password) (tramp-wrong-passwd-regexp tramp-action-permission-denied) (shell-prompt-pattern tramp-action-succeed) (tramp-shell-prompt-pattern tramp-action-succeed) (tramp-yesno-prompt-regexp tramp-action-yesno) (tramp-yn-prompt-regexp tramp-action-yn) (tramp-terminal-prompt-regexp tramp-action-terminal) (tramp-antispoof-regexp tramp-action-confirm-message) (tramp-process-alive-regexp tramp-action-process-alive)))
  tramp-process-actions(#<process *tramp/ssh fan@vm00*> (tramp-file-name "ssh" "fan" nil "vm00" nil "" nil) 1 ((tramp-login-prompt-regexp tramp-action-login) (tramp-password-prompt-regexp tramp-action-password) (tramp-wrong-passwd-regexp tramp-action-permission-denied) (shell-prompt-pattern tramp-action-succeed) (tramp-shell-prompt-pattern tramp-action-succeed) (tramp-yesno-prompt-regexp tramp-action-yesno) (tramp-yn-prompt-regexp tramp-action-yn) (tramp-terminal-prompt-regexp tramp-action-terminal) (tramp-antispoof-regexp tramp-action-confirm-message) (tramp-process-alive-regexp tramp-action-process-alive)) 60)
  tramp-maybe-open-connection((tramp-file-name "ssh" "fan" nil "vm00" nil "" nil))
  tramp-send-command((tramp-file-name "ssh" "fan" nil "vm00" nil "" nil) "cd ~ && pwd")
  tramp-sh-handle-expand-file-name("/ssh:fan@vm00:" nil)
  apply(tramp-sh-handle-expand-file-name ("/ssh:fan@vm00:" nil))
  tramp-sh-file-name-handler(expand-file-name "/ssh:fan@vm00:" nil)
  apply(tramp-sh-file-name-handler expand-file-name ("/ssh:fan@vm00:" nil))
  tramp-file-name-handler(expand-file-name "/ssh:fan@vm00:" nil)
  file-name-case-insensitive-p("/ssh:fan@vm00:")
  abbreviate-file-name("/ssh:fan@vm00:")
  (file-remote-p (abbreviate-file-name dir))
  (progn (file-remote-p (abbreviate-file-name dir)))
  (condition-case nil (progn (file-remote-p (abbreviate-file-name dir))) (error nil))
  (ignore-errors (file-remote-p (abbreviate-file-name dir)))
  (and dir (ignore-errors (file-remote-p (abbreviate-file-name dir))))
  (if (and dir (ignore-errors (file-remote-p (abbreviate-file-name dir)))) 'ivy-remote (cdr (assq (buffer-local-value 'major-mode buf) ivy-switch-buffer-faces-alist)))
  (let* ((buf (get-buffer x)) (dir (buffer-local-value 'default-directory buf)) (face (if (and dir (ignore-errors (file-remote-p (abbreviate-file-name dir)))) 'ivy-remote (cdr (assq (buffer-local-value 'major-mode buf) ivy-switch-buffer-faces-alist))))) (if face (propertize x 'face face) x))
  (closure ((predicate) (virtual ivy-switch-buffer ivy-switch-buffer-other-window counsel-switch-buffer) (str . "") Info-complete-menu-buffer t) (x) (let* ((buf (get-buffer x)) (dir (buffer-local-value 'default-directory buf)) (face (if (and dir (ignore-errors ...)) 'ivy-remote (cdr (assq ... ivy-switch-buffer-faces-alist))))) (if face (propertize x 'face face) x)))("*tramp/ssh fan@vm00*")
  mapcar((closure ((predicate) (virtual ivy-switch-buffer ivy-switch-buffer-other-window counsel-switch-buffer) (str . "") Info-complete-menu-buffer t) (x) (let* ((buf (get-buffer x)) (dir (buffer-local-value 'default-directory buf)) (face (if (and dir (ignore-errors ...)) 'ivy-remote (cdr (assq ... ivy-switch-buffer-faces-alist))))) (if face (propertize x 'face face) x))) ("<my buffers>"  ...))
  (nconc (mapcar (lambda (x) (let* ((buf (get-buffer x)) (dir (buffer-local-value 'default-directory buf)) (face (if (and dir ...) 'ivy-remote (cdr ...)))) (if face (propertize x 'face face) x))) (all-completions str #'internal-complete-buffer predicate)) (and virtual (ivy--virtual-buffers)))
  (delete-dups (nconc (mapcar (lambda (x) (let* ((buf (get-buffer x)) (dir (buffer-local-value ... buf)) (face (if ... ... ...))) (if face (propertize x 'face face) x))) (all-completions str #'internal-complete-buffer predicate)) (and virtual (ivy--virtual-buffers))))
  ivy--buffer-list("" (ivy-switch-buffer ivy-switch-buffer-other-window counsel-switch-buffer) nil)
  ivy--reset-state(#s(ivy-state :prompt "Switch to buffer: " :collection internal-complete-buffer :predicate nil :require-match nil :initial-input nil :history nil :preselect ",t" :keymap (keymap (11 . ivy-switch-buffer-kill)) :update-fn nil :sort nil :frame #<frame /Users/fan/.emacs.d/local.el 0x7fce88877030> :window #<window 308 on local.el> :buffer #<buffer local.el> :text nil :action (1 ("o" ivy--switch-buffer-action "default") ("i" #f(compiled-function (x) #<bytecode 0x1ff3a22bd4b9>) "insert") ("w" #f(compiled-function (x) #<bytecode 0x1ff3a22bd4c5>) "copy") ("f" ivy--find-file-action "find file") ("j" ivy--switch-buffer-other-window-action "other window") ("k" ivy--kill-buffer-action "kill") ("r" ivy--rename-buffer-action "rename") ("x" counsel-open-buffer-file-externally "open externally") ("s" ivy-switch-buffer-action-other-window-not-focus "show") ("F" ivy-switch-buffer-action-other-frame "other frame")) :unwind nil :re-builder nil :matcher ivy--switch-buffer-matcher :dynamic-collection nil :display-transformer-fn ivy-switch-buffer-transformer :directory "/Users/fan/.emacs.d/" :caller ivy-switch-buffer :current nil :def nil :ignore t :multi-action nil :extra-props nil))
  ivy-read("Switch to buffer: " internal-complete-buffer :keymap (keymap (11 . ivy-switch-buffer-kill)) :preselect ",t" :action ivy--switch-buffer-action :matcher ivy--switch-buffer-matcher :caller ivy-switch-buffer)
  ivy-switch-buffer()
  funcall-interactively(ivy-switch-buffer)
  call-interactively(ivy-switch-buffer nil nil)
  command-execute(ivy-switch-buffer)
```