### PR TITLE
Handle case correctly in `counsel-grep-like-occur'

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2946,7 +2946,10 @@ Works for `counsel-git-grep', `counsel-ag', etc."
             (let* ((command-args (counsel--split-command-args ivy-text))
                    (regex (counsel--grep-regex (cdr command-args)))
                    (switches (concat (car command-args)
-                                     (counsel--ag-extra-switches regex))))
+                                     (counsel--ag-extra-switches regex)
+                                     (if (ivy--case-fold-p ivy-text)
+                                         " -i "
+                                       " -s "))))
               (format cmd-template
                       (concat
                        switches


### PR DESCRIPTION
I've just noticed that the ivy-occur buffer had fewer entries than the minibuffer when running counsel-rg.  Entries with different case were missing.