### PR TITLE
counsel-recentf: If using XDG list, sort all candidates by file access time.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2249,8 +2249,8 @@ https://www.freedesktop.org/wiki/Specifications/desktop-bookmark-spec/."
   "Return candidates for `counsel-recentf'.
 
 When `counsel-recentf-include-xdg-list' is non-nil, also include
-the list of recently used files as specified by XDG-compliant
-environments, and sort all candidates by access time."
+the files in said list, sorting the combined list by file access
+time."
   (if (and counsel-recentf-include-xdg-list
            (version< "25" emacs-version))
       (seq-uniq (sort (append (mapcar #'substring-no-properties recentf-list)
@@ -2262,6 +2262,7 @@ environments, and sort all candidates by access time."
     (mapcar #'substring-no-properties recentf-list)))
 
 (defun counsel--strip-prefix (prefix str)
+  "Strip PREFIX from STR."
   (let ((l (length prefix)))
     (when (string= (substring str 0 l) prefix)
       (substring str l))))
@@ -2277,7 +2278,7 @@ Requires Emacs 25.
 
 It searches for the file \"recently-used.xbel\" which lists files
 and directories, in the directory returned by the function
-`xdg-data-home'. This file is processed using functionality
+`xdg-data-home'.  This file is processed using functionality
 provided by the libxml2 bindings and the \"dom\" library."
   (require 'dom)
   (let ((file-of-recent-files


### PR DESCRIPTION
To interleave the XDG list with Emacs's `recentf-list`, sort the combined list by
access time using the `file-attributes` function.

Another approach would be to sort by modification time with
`file-newer-than-file-p`, but since not all viewed files are modified, access
time is probably the better choice.

Since the two lists can share values, `seq-uniq` is used with `string-equal` to
remove duplicate values.