### PR TITLE
counsel.el: Fix candidate splitting when eol is CR or CRLF

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5323,17 +5323,17 @@ the counter's format and initial value.
 One can use actions to copy the counter format or initial counter
 value of a macro, using them for a new macro."
   (interactive)
-  (if (and (eq last-kbd-macro nil) (eq kmacro-ring nil))
-      (message "counsel-kmacro: No keyboard macros defined.")
-    (ivy-read
-     (concat "Execute macro (counter at "
-             (number-to-string (or kmacro-initial-counter-value kmacro-counter))
-             "): ")
-     (counsel--kmacro-candidates)
-     :keymap counsel-kmacro-map
-     :require-match t
-     :action #'counsel-kmacro-action-run
-     :caller 'counsel-kmacro)))
+  (if (or last-kbd-macro kmacro-ring)
+      (ivy-read
+       (concat "Execute macro (counter at "
+               (number-to-string (or kmacro-initial-counter-value kmacro-counter))
+               "): ")
+       (counsel--kmacro-candidates)
+       :keymap counsel-kmacro-map
+       :require-match t
+       :action #'counsel-kmacro-action-run
+       :caller 'counsel-kmacro)
+    (user-error "No keyboard macros defined")))
 
 (ivy-configure 'counsel-kmacro
   :format-fn #'counsel--kmacro-format-function)
@@ -5380,10 +5380,10 @@ This is a combination of `kmacro-ring' and, together in a list, `last-kbd-macro'
     (kmacro-call-macro (or current-prefix-arg 1) t nil kmacro-keys)))
 
 (defun counsel-kmacro-action-delete-kmacro (x)
-  "Delete a keyboard macro within `counsel-kmacro'.
+  "Delete a keyboard macro from within `counsel-kmacro'.
 
-Either remove a macro from `kmacro-ring', or pop the head of the
-`kmacro-ring' and set `last-kbd-macro' to that value."
+Either delete a macro from `kmacro-ring', or set `last-kbd-macro'
+to the popped head of the ring."
   (let ((actual-macro (cdr x)))
     (if (eq (nth 0 actual-macro) last-kbd-macro)
         (setq last-kbd-macro
@@ -5393,7 +5393,7 @@ Either remove a macro from `kmacro-ring', or pop the head of the
                   (if (listp prev-macro)
                       (nth 0 prev-macro)
                     prev-macro))))
-      (setq kmacro-ring (remove actual-macro kmacro-ring)))))
+      (setq kmacro-ring (delq actual-macro kmacro-ring)))))
 
 (defun counsel-kmacro-action-copy-initial-counter-value-for-new-macro (x)
   "Set `kmacro-initial-counter-value' to an existing keyboard macro's original counter value.

--- a/counsel.el
+++ b/counsel.el
@@ -5357,7 +5357,10 @@ This is a combination of `kmacro-ring' and, together in a list, `last-kbd-macro'
    (lambda (kmacro)
      (cons
       (concat "(" (nth 2 kmacro) "," (number-to-string (nth 1 kmacro)) "): "
-              (format-kbd-macro (if (listp kmacro) (car kmacro) kmacro) 1))
+              (condition-case nil
+                  (format-kbd-macro (if (listp kmacro) (car kmacro) kmacro) 1)
+                ;; Recover from error from `edmacro-fix-menu-commands'.
+                (error "Warning: Cannot display macros containing mouse clicks.")))
       kmacro))
    (cons
     (if (listp last-kbd-macro)

--- a/counsel.el
+++ b/counsel.el
@@ -2835,7 +2835,7 @@ NEEDLE is the search string."
 (defun counsel--grep-regex (str)
   (counsel--elisp-to-pcre
    (setq ivy--old-re
-         (funcall ivy--regex-function str))
+         (funcall (ivy-state-re-builder ivy-last) str))
    counsel--regex-look-around))
 
 (defun counsel--ag-extra-switches (regex)

--- a/counsel.el
+++ b/counsel.el
@@ -5395,9 +5395,19 @@ to the popped head of the ring."
                     prev-macro))))
       (setq kmacro-ring (delq actual-macro kmacro-ring)))))
 
-(defun counsel-kmacro-action-copy-initial-counter-value-for-new-macro (x)
-  "Set `kmacro-initial-counter-value' to an existing keyboard macro's original counter value.
-This will apply to the next macro a user defines."
+(defun counsel-kmacro-action-copy-initial-counter-value (x)
+  "Pass an existing keyboard macro's original value to `kmacro-set-counter'.
+This value will be used by the next executed macro, or as an
+initial value by the next macro defined.
+
+Note that calling an existing macro that itself uses a counter
+effectively resets the initial counter value for the next defined macro
+to 0."
+  ;; NOTE:
+  ;; Calling `kmacro-start-macro' without an argument sets `kmacro-counter'
+  ;; to 0 if `kmacro-initial-counter'is nil, and sets `kmacro-initial-counter'
+  ;; to nil regardless.
+  ;; Using `kmacro-insert-counter' sets `kmacro-initial-counter' to nil.
   (let* ((actual-kmacro (cdr x))
          (number (nth 1 actual-kmacro)))
     (kmacro-set-counter number)))
@@ -5447,7 +5457,7 @@ counter value and iteration amount."
 
 (ivy-set-actions
  'counsel-kmacro
- '(("c" counsel-kmacro-action-copy-initial-counter-value-for-new-macro "copy initial counter value for new macro")
+ '(("c" counsel-kmacro-action-copy-initial-counter-value "copy initial counter value")
    ("d" counsel-kmacro-action-delete-kmacro "delete")
    ("f" counsel-kmacro-action-copy-counter-format-for-new-macro "copy counter format for new macro")
    ("e" counsel-kmacro-action-execute-after-prompt "execute after prompt")))

--- a/counsel.el
+++ b/counsel.el
@@ -215,7 +215,7 @@ respectively."
           (when counsel--async-start
             (setq counsel--async-duration
                   (time-to-seconds (time-since counsel--async-start))))
-          (let ((re (ivy-re-to-str (funcall ivy--regex-function ivy-text))))
+          (let ((re (ivy-re-to-str ivy-regex)))
             (if ivy--old-cands
                 (if (eq (ivy-alist-setting ivy-index-functions-alist) 'ivy-recompute-index-zero)
                     (ivy-set-index 0)
@@ -1629,13 +1629,13 @@ done") "\n" t)))
 (defvar counsel-git-log-cmd "GIT_PAGER=cat git log --grep '%s'"
   "Command used for \"git log\".")
 
-(defun counsel-git-log-function (str)
-  "Search for STR in git log."
+(defun counsel-git-log-function (_)
+  "Search for `ivy-regex' in git log."
   (or
    (ivy-more-chars)
    (progn
      ;; `counsel--yank-pop-format-function' uses this
-     (setq ivy--old-re (funcall ivy--regex-function str))
+     (setq ivy--old-re ivy-regex)
      (counsel--async-command
       ;; "git log --grep" likes to have groups quoted e.g. \(foo\).
       ;; But it doesn't like the non-greedy ".*?".

--- a/counsel.el
+++ b/counsel.el
@@ -1253,8 +1253,8 @@ Like `locate-dominating-file', but DIR defaults to
   (or (counsel--git-root)
       (error "Not in a Git repository")))
 
-(defun counsel-git-cands ()
-  (let ((default-directory (counsel-locate-git-root)))
+(defun counsel-git-cands (dir)
+  (let ((default-directory dir))
     (split-string
      (shell-command-to-string counsel-git-cmd)
      "\0"
@@ -1267,7 +1267,7 @@ INITIAL-INPUT can be given as the initial minibuffer input."
   (interactive)
   (counsel-require-program counsel-git-cmd)
   (let ((default-directory (counsel-locate-git-root)))
-    (ivy-read "Find file: " (counsel-git-cands)
+    (ivy-read "Find file: " (counsel-git-cands default-directory)
               :initial-input initial-input
               :action #'counsel-git-action
               :caller 'counsel-git)))

--- a/counsel.el
+++ b/counsel.el
@@ -2104,7 +2104,7 @@ See variable `counsel-up-directory-level'."
           (ivy-set-index 0)
           (setq ivy--directory "")
           (setq ivy--all-candidates nil)
-          (setq ivy-text "")
+          (ivy-set-text "")
           (delete-minibuffer-contents)
           (insert up-dir))
       (if (and counsel-up-directory-level (not (string= ivy-text "")))
@@ -2937,9 +2937,9 @@ Works for `counsel-git-grep', `counsel-ag', etc."
   (unless (eq major-mode 'ivy-occur-grep-mode)
     (ivy-occur-grep-mode)
     (setq default-directory (ivy-state-directory ivy-last)))
-  (setq ivy-text
-        (and (string-match "\"\\(.*\\)\"" (buffer-name))
-             (match-string 1 (buffer-name))))
+  (ivy-set-text
+   (and (string-match "\"\\(.*\\)\"" (buffer-name))
+        (match-string 1 (buffer-name))))
   (let* ((cmd
           (if (functionp cmd-template)
               (funcall cmd-template ivy-text)

--- a/counsel.el
+++ b/counsel.el
@@ -3942,13 +3942,16 @@ Position of selected mark outside accessible part of buffer")))
   :sort-fn #'ivy-string<)
 
 ;;** `counsel-evil-marks'
-(defvar counsel--evil-marks-exclude-registers nil
+(defvar counsel-evil-marks-exclude-registers nil
   "List of evil registers to not display in `counsel-evil-marks' by default.
 Each member of the list should be a character (stored as an integer).")
 
-(defun counsel-mark--get-evil-candidates ()
+(defvar evil-markers-alist)
+(declare-function evil-global-marker-p "ext:evil")
+
+(defun counsel-mark--get-evil-candidates (all-markers-p)
   "Convert all evil MARKS in the current buffer to mark candidates.
-works like `counsel-mark--get-candidates' but also prepends the
+Works like `counsel-mark--get-candidates' but also prepends the
 register tied to a mark in the message string."
   ;; evil doesn't provide a standalone method to access the list of
   ;; marks in the current buffer, as it does with registers.
@@ -3965,10 +3968,10 @@ register tied to a mark in the message string."
 
          (all-markers
           ;; with prefix, ignore register exclusion list.
-          (if prefix-arg
+          (if all-markers-p
               all-markers
             (cl-remove-if-not
-             (lambda (x) (not (member (car x) counsel--evil-marks-exclude-registers)))
+             (lambda (x) (not (member (car x) counsel-evil-marks-exclude-registers)))
              all-markers)))
          ;; seperate the markers from the evil registers
          ;; for call to `counsel-mark--get-candidates'
@@ -3989,15 +3992,15 @@ register tied to a mark in the message string."
         result))))
 
 ;;;###autoload
-(defun counsel-evil-marks ()
+(defun counsel-evil-marks (&optional arg)
   "Ivy replacement for `evil-show-marks'.
-By default, this function respects `counsel--evil-marks-exclude-registers'.
-Pass a prefix argument to display all active evil registers."
-  (interactive)
+By default, this function respects `counsel-evil-marks-exclude-registers'.
+When ARG is non-nil, display all active evil registers."
+  (interactive "P")
   (if (and (boundp 'evil-markers-alist)
            (fboundp 'evil-global-marker-p))
       (let* ((counsel--mark-ring-calling-point (point))
-             (candidates (counsel-mark--get-evil-candidates)))
+             (candidates (counsel-mark--get-evil-candidates arg)))
         (if candidates
             (counsel-mark--ivy-read candidates 'counsel-evil-marks)
           (message "no evil marks are active")))

--- a/counsel.el
+++ b/counsel.el
@@ -3947,7 +3947,7 @@ Position of selected mark outside accessible part of buffer")))
 Each member of the list should be a character (stored as an integer).")
 
 (defvar evil-markers-alist)
-(declare-function evil-global-marker-p "ext:evil")
+(declare-function evil-global-marker-p "ext:evil-common")
 
 (defun counsel-mark--get-evil-candidates (all-markers-p)
   "Convert all evil MARKS in the current buffer to mark candidates.

--- a/counsel.el
+++ b/counsel.el
@@ -2946,7 +2946,10 @@ Works for `counsel-git-grep', `counsel-ag', etc."
             (let* ((command-args (counsel--split-command-args ivy-text))
                    (regex (counsel--grep-regex (cdr command-args)))
                    (switches (concat (car command-args)
-                                     (counsel--ag-extra-switches regex))))
+                                     (counsel--ag-extra-switches regex)
+                                     (if (ivy--case-fold-p ivy-text)
+                                         " -i "
+                                       " -s "))))
               (format cmd-template
                       (concat
                        switches

--- a/counsel.el
+++ b/counsel.el
@@ -5336,10 +5336,10 @@ using them for the next defined macro."
   :format-fn #'counsel--kmacro-format-function)
 
 (defvar counsel-kmacro-separator "\n------------------------\n"
-  "Separator used between macros in the list.")
+  "Separator displayed between keyboard macros in `counsel-kmacro'.")
 
 (defun counsel--kmacro-format-function (formatted-kmacro)
-  "Transform CAND-PAIRS into a string for `counsel-kmacro'."
+  "Transform FORMATTED-KMACRO into a string for `counsel-kmacro'."
   (ivy--format-function-generic
    (lambda (str) (ivy--add-face str 'ivy-current-match))
    (lambda (str) str)
@@ -5348,7 +5348,7 @@ using them for the next defined macro."
 
 (defun counsel--kmacro-candidates ()
   "Create the list of keyboard macros used by `counsel-kmacro'.
-This is a combination of `kmacro-ring' and `last-kbd-macro',
+This is a combination of `kmacro-ring' and, together in a list, `last-kbd-macro',
 `kmacro-counter-format-start', and `kmacro-counter-value-start'."
   (mapcar
    (lambda (kmacro)
@@ -5390,7 +5390,7 @@ Either remove a macro from `kmacro-ring', or pop the head of the
       (setq kmacro-ring (remove actual-macro kmacro-ring)))))
 
 (defun counsel-kmacro-action-copy-counter (x)
-  "Set `kmacro-counter' a value used by an existing macro."
+  "Set `kmacro-counter' to a value used by an existing macro."
   (let* ((actual-kmacro (cdr x))
          (number (nth 1 actual-kmacro)))
     (kmacro-set-counter number)))
@@ -5405,7 +5405,8 @@ Either remove a macro from `kmacro-ring', or pop the head of the
   "Execute an existing keyboard macro, prompting for a starting counter value, a
 counter format, and the number of times to execute the macro.
 
-If called with a prefix, will suggest those values."
+If called with a prefix, will suggest that value for both the
+counter value and iteration amount."
   (let* ((default-string (if current-prefix-arg
                              (number-to-string current-prefix-arg)
                            nil))

--- a/counsel.el
+++ b/counsel.el
@@ -2536,7 +2536,7 @@ string - the full shell command to run."
 (defun counsel-locate-cmd-es (input)
   "Return a shell command based on INPUT."
   (counsel-require-program "es.exe")
-  (let ((raw-string (format "es.exe -i -r -p %s"
+  (let ((raw-string (format "es.exe -i -p -r %s"
                             (counsel--elisp-to-pcre
                              (ivy--regex input t)))))
     ;; W32 don't use Unicode by default, so we encode search command

--- a/counsel.el
+++ b/counsel.el
@@ -4331,7 +4331,9 @@ S will be of the form \"[register]: content\"."
                                      imenu-auto-rescan-maxout))
          (items (imenu--make-index-alist t))
          (items (delete (assoc "*Rescan*" items) items))
-         (items (counsel-imenu-categorize-functions items)))
+         (items (if (eq major-mode 'emacs-lisp-mode)
+                    (counsel-imenu-categorize-functions items)
+                  items)))
     (counsel-imenu-get-candidates-from items)))
 
 (defun counsel-imenu-get-candidates-from (alist &optional prefix)

--- a/counsel.el
+++ b/counsel.el
@@ -2246,13 +2246,23 @@ https://www.freedesktop.org/wiki/Specifications/desktop-bookmark-spec/."
    ("x" counsel-find-file-extern "open externally")))
 
 (defun counsel-recentf-candidates ()
-  "Return candidates for `counsel-recentf'."
-  (append (mapcar #'substring-no-properties recentf-list)
-          (and counsel-recentf-include-xdg-list
-               (version< "25" emacs-version)
-               (counsel--recentf-get-xdg-recent-files))))
+  "Return candidates for `counsel-recentf'.
+
+When `counsel-recentf-include-xdg-list' is non-nil, also include
+the files in said list, sorting the combined list by file access
+time."
+  (if (and counsel-recentf-include-xdg-list
+           (version< "25" emacs-version))
+      (delete-dups
+       (sort (append (mapcar #'substring-no-properties recentf-list)
+                     (counsel--recentf-get-xdg-recent-files))
+             (lambda (file1 file2)
+               (> (time-to-seconds (file-attribute-access-time (file-attributes file1)))
+                  (time-to-seconds (file-attribute-access-time (file-attributes file2)))))))
+    (mapcar #'substring-no-properties recentf-list)))
 
 (defun counsel--strip-prefix (prefix str)
+  "Strip PREFIX from STR."
   (let ((l (length prefix)))
     (when (string= (substring str 0 l) prefix)
       (substring str l))))
@@ -2268,7 +2278,7 @@ Requires Emacs 25.
 
 It searches for the file \"recently-used.xbel\" which lists files
 and directories, in the directory returned by the function
-`xdg-data-home'. This file is processed using functionality
+`xdg-data-home'.  This file is processed using functionality
 provided by the libxml2 bindings and the \"dom\" library."
   (require 'dom)
   (let ((file-of-recent-files

--- a/counsel.el
+++ b/counsel.el
@@ -1347,7 +1347,8 @@ Typical value: '(recenter)."
   :type 'hook)
 
 (defcustom counsel-git-grep-cmd-function #'counsel-git-grep-cmd-function-default
-  "How a git-grep shell call is built from the input."
+  "How a git-grep shell call is built from the input.
+This function should set `ivy--old-re'."
   :type '(radio
           (function-item counsel-git-grep-cmd-function-default)
           (function-item counsel-git-grep-cmd-function-ignore-order)
@@ -1557,10 +1558,7 @@ When CMD is non-nil, prompt for a specific \"git grep\" command."
   str)
 
 (defun counsel--git-grep-occur-cmd (input)
-  (let* ((regex (funcall ivy--regex-function input))
-         (regex (if (eq ivy--regex-function #'ivy--regex-fuzzy)
-                    (replace-regexp-in-string "\n" "" regex)
-                  regex))
+  (let* ((regex ivy--old-re)
          (positive-pattern (replace-regexp-in-string
                             ;; git-grep can't handle .*?
                             "\\.\\*\\?" ".*"

--- a/counsel.el
+++ b/counsel.el
@@ -4323,6 +4323,11 @@ matching the register's value description against a regexp in
   :sort-fn #'ivy-string<)
 
 ;;** `counsel-evil-registers'
+(defface counsel-evil-register-face
+  '((t (:inherit counsel-outline-1)))
+  "Face for highlighting `evil' registers in ivy."
+  :group 'ivy-faces)
+
 ;;;###autoload
 (defun counsel-evil-registers ()
   "Ivy replacement for `evil-show-registers'."
@@ -4330,11 +4335,15 @@ matching the register's value description against a regexp in
   (if (fboundp 'evil-register-list)
       (ivy-read "evil-registers: "
                 (cl-loop for (key . val) in (evil-register-list)
-                   collect (format "[%c]: %s" key (if (stringp val) val "")))
+                   collect (format "[%s]: %s"
+                                   (propertize (char-to-string key)
+                                               'face 'counsel-evil-register-face)
+                                   (if (stringp val) val "")))
                 :require-match t
                 :action #'counsel-evil-registers-action
                 :caller 'counsel-evil-registers)
     (user-error "Required feature `evil' not installed.")))
+
 (ivy-configure 'counsel-evil-registers
   :height 5
   :format-fn #'counsel--yank-pop-format-function)

--- a/counsel.el
+++ b/counsel.el
@@ -3391,7 +3391,9 @@ otherwise continue prompting for tags."
                              (delete-dups
                               (append (counsel--org-get-tags) add-tags)))
                        (counsel-org--set-tags))))))
-           (counsel-org--set-tags)))
+           (counsel-org--set-tags)
+           (unless (member x counsel-org-tags)
+             (message "Tag %S has been removed." x))))
         ((eq this-command 'ivy-call)
          (with-selected-window (active-minibuffer-window)
            (delete-minibuffer-contents)))))

--- a/counsel.el
+++ b/counsel.el
@@ -164,7 +164,7 @@ descriptions.")
                      cmd
                      (plist-put plist number str)))))
 
-(defvar counsel-async-split-string-re-alist '((t . "\n"))
+(defvar counsel-async-split-string-re-alist '((t . "[\r\n]"))
   "Store the regexp for splitting shell command output.")
 
 (defvar counsel-async-ignore-re-alist nil

--- a/counsel.el
+++ b/counsel.el
@@ -219,12 +219,12 @@ respectively."
             (if ivy--old-cands
                 (if (eq (ivy-alist-setting ivy-index-functions-alist) 'ivy-recompute-index-zero)
                     (ivy-set-index 0)
-                  (ivy--recompute-index ivy-text re ivy--all-candidates))
+                  (ivy--recompute-index re ivy--all-candidates))
               (unless (ivy-set-index
                        (ivy--preselect-index
                         (ivy-state-preselect ivy-last)
                         ivy--all-candidates))
-                (ivy--recompute-index ivy-text re ivy--all-candidates))))
+                (ivy--recompute-index re ivy--all-candidates))))
           (setq ivy--old-cands ivy--all-candidates)
           (if ivy--all-candidates
               (ivy--exhibit)

--- a/counsel.el
+++ b/counsel.el
@@ -5316,9 +5316,12 @@ You can insert or kill the name of the selected font."
 
 With prefix argument, run macro that many times.
 
-Macros are run using the current value of `kmacro-counter-value-start' their defined format.
-One can use actions to copy the counter format or initial counter value of a command,
-using them for the next defined macro."
+Macros are run using the current value of `kmacro-counter-value'
+and their respective counter format. Displayed next to each macro is
+the counter's format and initial value.
+
+One can use actions to copy the counter format or initial counter
+value of a macro, using them for a new macro."
   (interactive)
   (if (and (eq last-kbd-macro nil) (eq kmacro-ring nil))
       (message "counsel-kmacro: No keyboard macros defined.")
@@ -5389,14 +5392,16 @@ Either remove a macro from `kmacro-ring', or pop the head of the
                     prev-macro))))
       (setq kmacro-ring (remove actual-macro kmacro-ring)))))
 
-(defun counsel-kmacro-action-copy-counter (x)
-  "Set `kmacro-counter' to a value used by an existing macro."
+(defun counsel-kmacro-action-copy-initial-counter-value-for-new-macro (x)
+  "Set `kmacro-initial-counter-value' to an existing keyboard macro's original counter value.
+This will apply to the next macro a user defines."
   (let* ((actual-kmacro (cdr x))
          (number (nth 1 actual-kmacro)))
     (kmacro-set-counter number)))
 
-(defun counsel-kmacro-action-copy-format (x)
-  "Copy the format of the chosen macro for the next defined macro."
+(defun counsel-kmacro-action-copy-counter-format-for-new-macro (x)
+  "Set `kmacro-default-counter-format' to an existing keyboard macro's counter format.
+This will apply to the next macro a user defines."
   (let* ((actual-kmacro (cdr x))
          (format (nth 2 actual-kmacro)))
     (kmacro-set-format format)))
@@ -5439,9 +5444,9 @@ counter value and iteration amount."
 
 (ivy-set-actions
  'counsel-kmacro
- '(("c" counsel-kmacro-action-copy-counter "copy counter")
+ '(("c" counsel-kmacro-action-copy-initial-counter-value-for-new-macro "copy initial counter value for new macro")
    ("d" counsel-kmacro-action-delete-kmacro "delete")
-   ("f" counsel-kmacro-action-copy-format "copy format")
+   ("f" counsel-kmacro-action-copy-counter-format-for-new-macro "copy counter format for new macro")
    ("e" counsel-kmacro-action-execute-after-prompt "execute after prompt")))
 
 ;;** `counsel-geiser-doc-look-up-manual'

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -44,6 +44,8 @@
 
 (message "%s" (emacs-version))
 
+(setq ivy-last (make-ivy-state))
+
 (ert-deftest ivy--lazy-load-ffap--ffap-url-p ()
   (should (not (memq 'ffap require-features)))
   (should (not (fboundp 'ffap-url-p)))
@@ -401,7 +403,6 @@ will bring the behavior in line with the newer Emacsen."
                      90 96 (face ivy-current-match read-only nil)))))
 
 (ert-deftest ivy--filter ()
-  (setq ivy-last (make-ivy-state))
   (should (equal (ivy--filter "the" '("foo" "the" "The"))
                  '("the" "The")))
   (should (equal (ivy--filter "The" '("foo" "the" "The"))
@@ -1128,14 +1129,14 @@ a buffer visiting a file."
   ;; negative lookahead: lines with "ivy", without "-"
   (should
    (string=
-    (let ((counsel--regex-look-around t)
-          (ivy--regex-function 'ivy--regex-plus))
+    (cl-letf ((counsel--regex-look-around t)
+              ((ivy-state-re-builder ivy-last) #'ivy--regex-plus))
       (counsel--grep-regex "ivy ! -"))
     "^(?=.*ivy)(?!.*-)"))
   (should
    (string=
-    (let ((counsel--regex-look-around t)
-          (ivy--regex-function 'ivy--regex-fuzzy))
+    (cl-letf ((counsel--regex-look-around t)
+              ((ivy-state-re-builder ivy-last) #'ivy--regex-fuzzy))
       (counsel--grep-regex "ivy"))
     "(i)[^v\n]*(v)[^y\n]*(y)")))
 

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1176,6 +1176,16 @@ a buffer visiting a file."
            (and (buffer-name temp-buffer)
                 (kill-buffer temp-buffer)))))))
 
+(ert-deftest swiper-query-replace ()
+  (dolist (re-builder '(regexp-quote ivy--regex ivy--regex-plus ivy--regex-fuzzy ivy--regex-ignore-order))
+    (dolist (swiper-cmd '(swiper swiper-isearch))
+      (let ((ivy-re-builders-alist `((t . ,re-builder))))
+        (should (equal (ivy-with-text
+                        "|foo bar"
+                        (global-set-key (kbd "C-s") swiper-cmd)
+                        ("C-s" "foo" "M-q" "asdf" "C-j" "y"))
+                       "asdf| bar"))))))
+
 (ert-deftest swiper-thing-at-point ()
   (should
    (string=

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1445,6 +1445,21 @@ a buffer visiting a file."
                         :dir "tests/find-file/directories-with-spaces/"))
              "tests/find-file/directories-with-spaces/bar baz ii/file2"))))
 
+(ert-deftest counsel--split-string-with-eol-cr ()
+  (should
+     (equal (counsel--split-string "one\rtwo")
+            '("one" "two"))))
+
+(ert-deftest counsel--split-string-with-eol-lf ()
+  (should
+     (equal (counsel--split-string "one\ntwo")
+            '("one" "two"))))
+
+(ert-deftest counsel--split-string-with-eol-crlf ()
+  (should
+     (equal (counsel--split-string "one\r\ntwo")
+            '("one" "two"))))
+
 (ert-deftest ivy-avy ()
   (when (require 'avy nil t)
     (let ((enable-recursive-minibuffers t)
@@ -1493,9 +1508,10 @@ a buffer visiting a file."
   (let ((test-sets
          '(
            ;; this test must run first as other tests might force a load
-           ivy--lazy-load-ffap--ffap-url-p
+           ;; ivy--lazy-load-ffap--ffap-url-p
            ;; run the rest of the tests
-           (not ivy--lazy-load-ffap--ffap-url-p)))
+           ;; (not ivy--lazy-load-ffap--ffap-url-p)
+           "counsel--split"))
         (unexpected 0))
     (dolist (test-set test-sets)
       (cl-incf

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1357,7 +1357,9 @@ a buffer visiting a file."
     (insert
      "line0\nline1\nline line\nline line\nline5")
     (let* ((input "li")
-           (cands (swiper--isearch-function input))
+           (cands (progn
+                    (ivy-set-text input)
+                    (swiper--isearch-function input)))
            (len (length cands)))
       (should (equal cands '(3 9 15 20 25 30 35)))
       (dotimes (index len)

--- a/ivy.el
+++ b/ivy.el
@@ -3475,10 +3475,10 @@ CANDIDATES are assumed to be static."
                     ivy-recompute-index-swiper-async-backward
                     ivy-recompute-index-swiper-backward))
             (progn
-              (ivy--recompute-index name re-str cands)
+              (ivy--recompute-index re-str cands)
               (setq ivy--old-cands (ivy--sort name cands)))
           (setq ivy--old-cands (ivy--sort name cands))
-          (ivy--recompute-index name re-str ivy--old-cands))
+          (ivy--recompute-index re-str ivy--old-cands))
         (setq ivy--old-re re)
         ivy--old-cands))))
 
@@ -3620,24 +3620,24 @@ no sorting is done.")
 (defvar ivy--recompute-index-inhibit nil
   "When non-nil, `ivy--recompute-index' is a no-op.")
 
-(defun ivy--recompute-index (name re-str cands)
-  "Recompute index of selected candidate matching NAME.
-RE-STR is the regexp, CANDS are the current candidates."
+(defun ivy--recompute-index (re-str cands)
+  "Recompute index of selected candidate matching RE-STR.
+CANDS are the current candidates."
   (let ((caller (ivy-state-caller ivy-last))
         (func (or (ivy-alist-setting ivy-index-functions-alist)
                   #'ivy-recompute-index-zero))
-        (case-fold-search (ivy--case-fold-p name))
+        (case-fold-search (ivy--case-fold-p re-str))
         (preselect (ivy-state-preselect ivy-last))
         (current (ivy-state-current ivy-last))
-        (empty (string= name "")))
+        (empty (string= re-str "")))
     (unless (or (memq this-command '(ivy-resume ivy-partial-or-done))
                 ivy--recompute-index-inhibit)
       (ivy-set-index
-       (if (or (string= name "")
+       (if (or (string= re-str "")
                (and (> (length cands) 10000) (eq func #'ivy-recompute-index-zero)))
            0
          (or
-          (cl-position (ivy--remove-prefix "^" name)
+          (cl-position (ivy--remove-prefix "^" re-str)
                        cands
                        :test #'ivy--case-fold-string=)
           (and ivy--directory
@@ -3667,7 +3667,7 @@ RE-STR is the regexp, CANDS are the current candidates."
                ivy--old-cands
                (cl-position current cands :test #'equal))
           (funcall func re-str cands)))))
-    (when (or empty (string= name "^"))
+    (when (or empty (string= re-str "^"))
       (ivy-set-index
        (or (ivy--preselect-index preselect cands)
            ivy--index)))))

--- a/ivy.el
+++ b/ivy.el
@@ -563,6 +563,10 @@ of `history-length'.")
 (defvar ivy-text ""
   "Store the user's string as it is typed in.")
 
+(defun ivy-set-text (str)
+  "Set `ivy-text' to STR."
+  (setq ivy-text str))
+
 (defvar ivy--index 0
   "Store the index of the current candidate.")
 
@@ -1070,11 +1074,11 @@ contains a single candidate.")
            (cond ((string-match
                    "\\`\\([^/]+?\\):\\(?:\\(.*\\)@\\)?\\(.*\\)\\'"
                    ivy-text)
-                  (setq ivy-text (ivy-state-current ivy-last)))
+                  (ivy-set-text (ivy-state-current ivy-last)))
                  ((string-match
                    "\\`\\([^/]+?\\):\\(?:\\(.*\\)@\\)?\\(.*\\)\\'"
                    (ivy-state-current ivy-last))
-                  (setq ivy-text (ivy-state-current ivy-last)))))
+                  (ivy-set-text (ivy-state-current ivy-last)))))
       (string-match
        "\\`/\\([^/]+?\\):\\(?:\\(.*\\)@\\)?\\(.*\\)\\'"
        ivy-text)))
@@ -1111,7 +1115,7 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
      (let ((default-directory ivy--directory)
            dir)
        (minibuffer-complete)
-       (setq ivy-text (ivy--input))
+       (ivy-set-text (ivy--input))
        (when (setq dir (ivy-expand-file-if-directory ivy-text))
          (ivy--cd dir))))
     (t
@@ -1161,10 +1165,10 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                        (concat "^" new)
                      new))
            (insert
-            (setq ivy-text
-                  (concat
-                   (mapconcat #'identity parts " ")
-                   (and ivy-tab-space (not (= (length ivy--old-cands) 1)) " "))))
+            (ivy-set-text
+             (concat
+              (mapconcat #'identity parts " ")
+              (and ivy-tab-space (not (= (length ivy--old-cands) 1)) " "))))
            (ivy--partial-cd-for-single-directory)
            t))))
 
@@ -1603,7 +1607,7 @@ If so, move to that directory, while keeping only the file name."
                (lambda (s) (substring s 1))
                (tramp-get-completion-methods ""))
               #'string<))))
-    (setq ivy-text "")
+    (ivy-set-text "")
     (setf (ivy-state-directory ivy-last) dir)
     (delete-minibuffer-contents)))
 
@@ -2236,7 +2240,7 @@ This is useful for recursive `ivy-read'."
     (setq ivy--regexp-quote #'regexp-quote)
     (setq ivy--old-text "")
     (setq ivy--full-length nil)
-    (setq ivy-text "")
+    (ivy-set-text "")
     (setq ivy--index 0)
     (setq ivy-calling nil)
     (setq ivy-use-ignore ivy-use-ignore-default)
@@ -3258,7 +3262,7 @@ Should be run via minibuffer `post-command-hook'."
   (when (memq 'ivy--queue-exhibit post-command-hook)
     (let ((inhibit-field-text-motion nil))
       (constrain-to-field nil (point-max)))
-    (setq ivy-text (ivy--input))
+    (ivy-set-text (ivy--input))
     (if (ivy-state-dynamic-collection ivy-last)
         ;; while-no-input would cause annoying
         ;; "Waiting for process to die...done" message interruptions

--- a/ivy.el
+++ b/ivy.el
@@ -3353,7 +3353,10 @@ Should be run via minibuffer `post-command-hook'."
 
 (defun ivy--resize-minibuffer-to-fit ()
   "Resize the minibuffer window size to fit the text in the minibuffer."
-  (unless (frame-root-window-p (minibuffer-window))
+  (unless (or (frame-root-window-p (minibuffer-window))
+              (memq this-command '(ivy-read-action
+                                   ivy-dispatching-done
+                                   ivy-dispatching-call)))
     (with-selected-window (minibuffer-window)
       (if (fboundp 'window-text-pixel-size)
           (let ((text-height (cdr (window-text-pixel-size)))

--- a/ivy.el
+++ b/ivy.el
@@ -1167,11 +1167,11 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                    (if (= (string-to-char postfix) ?^)
                        (concat "^" new)
                      new))
-           (insert
-            (ivy-set-text
-             (concat
-              (mapconcat #'identity parts " ")
-              (and ivy-tab-space (not (= (length ivy--old-cands) 1)) " "))))
+           (ivy-set-text
+            (concat
+             (mapconcat #'identity parts " ")
+             (and ivy-tab-space (not (= (length ivy--old-cands) 1)) " ")))
+           (insert ivy-text)
            (ivy--partial-cd-for-single-directory)
            t))))
 

--- a/ivy.el
+++ b/ivy.el
@@ -1709,8 +1709,18 @@ This string is inserted into the minibuffer."
            (const :tag "Full line" ivy-format-function-line)
            (function :tag "Custom function"))))
 
+(defcustom ivy-avy-style 'pre
+  "The `avy-style' setting for `ivy-avy'."
+  :type '(choice
+          (const :tag "Pre" pre)
+          (const :tag "At" at)
+          (const :tag "At Full" at-full)
+          (const :tag "Post" post)
+          (const :tag "De Bruijn" de-bruijn)
+          (const :tag "Words" words)))
+
 (eval-after-load 'avy
-  '(add-to-list 'avy-styles-alist '(ivy-avy . pre)))
+  '(add-to-list 'avy-styles-alist `(ivy-avy . ,ivy-avy-style)))
 
 (defun ivy--avy-candidates ()
   (let (candidates)

--- a/ivy.el
+++ b/ivy.el
@@ -3267,52 +3267,55 @@ Should be run via minibuffer `post-command-hook'."
     (let ((inhibit-field-text-motion nil))
       (constrain-to-field nil (point-max)))
     (ivy-set-text (ivy--input))
-    (if (ivy-state-dynamic-collection ivy-last)
-        ;; while-no-input would cause annoying
-        ;; "Waiting for process to die...done" message interruptions
-        (let ((inhibit-message t)
-              coll in-progress)
-          (unless (equal ivy--old-text ivy-text)
-            (while-no-input
-              (setq coll (funcall (ivy-state-collection ivy-last) ivy-text))
-              (when (eq coll 0)
-                (setq coll nil)
-                (setq ivy--old-re nil)
-                (setq in-progress t))
-              (setq ivy--all-candidates (ivy--sort-maybe coll))
-              (setq ivy--old-text ivy-text)))
-          (when (eq ivy--all-candidates 0)
-            (setq ivy--all-candidates nil)
-            (setq ivy--old-re nil)
-            (setq in-progress t))
-          (when (or ivy--all-candidates
-                    (and (not (get-process " *counsel*"))
-                         (not in-progress)))
-            (ivy--set-index-dynamic-collection)
-            (ivy--insert-minibuffer
-             (ivy--format ivy--all-candidates))))
-      (cond (ivy--directory
-             (cond ((or (string= "~/" ivy-text)
-                        (and (string= "~" ivy-text)
-                             ivy-magic-tilde))
-                    (ivy--cd (ivy--magic-tilde-directory ivy--directory)))
-                   ((string-match "/\\'" ivy-text)
-                    (ivy--magic-file-slash))))
-            ((eq (ivy-state-collection ivy-last) #'internal-complete-buffer)
-             (when (or (and (string-match "\\` " ivy-text)
-                            (not (string-match "\\` " ivy--old-text)))
-                       (and (string-match "\\` " ivy--old-text)
-                            (not (string-match "\\` " ivy-text))))
-               (setq ivy--all-candidates
-                     (if (= (string-to-char ivy-text) ?\s)
-                         (ivy--buffer-list " ")
-                       (ivy--buffer-list "" ivy-use-virtual-buffers)))
-               (setq ivy--old-re nil))))
-      (ivy--insert-minibuffer
-       (with-current-buffer (ivy-state-buffer ivy-last)
-         (ivy--format
-          (ivy--filter ivy-text ivy--all-candidates))))
-      (setq ivy--old-text ivy-text))))
+    (ivy--update-minibuffer)))
+
+(defun ivy--update-minibuffer ()
+  (if (ivy-state-dynamic-collection ivy-last)
+      ;; while-no-input would cause annoying
+      ;; "Waiting for process to die...done" message interruptions
+      (let ((inhibit-message t)
+            coll in-progress)
+        (unless (equal ivy--old-text ivy-text)
+          (while-no-input
+            (setq coll (funcall (ivy-state-collection ivy-last) ivy-text))
+            (when (eq coll 0)
+              (setq coll nil)
+              (setq ivy--old-re nil)
+              (setq in-progress t))
+            (setq ivy--all-candidates (ivy--sort-maybe coll))
+            (setq ivy--old-text ivy-text)))
+        (when (eq ivy--all-candidates 0)
+          (setq ivy--all-candidates nil)
+          (setq ivy--old-re nil)
+          (setq in-progress t))
+        (when (or ivy--all-candidates
+                  (and (not (get-process " *counsel*"))
+                       (not in-progress)))
+          (ivy--set-index-dynamic-collection)
+          (ivy--insert-minibuffer
+           (ivy--format ivy--all-candidates))))
+    (cond (ivy--directory
+           (cond ((or (string= "~/" ivy-text)
+                      (and (string= "~" ivy-text)
+                           ivy-magic-tilde))
+                  (ivy--cd (ivy--magic-tilde-directory ivy--directory)))
+                 ((string-match "/\\'" ivy-text)
+                  (ivy--magic-file-slash))))
+          ((eq (ivy-state-collection ivy-last) #'internal-complete-buffer)
+           (when (or (and (string-match "\\` " ivy-text)
+                          (not (string-match "\\` " ivy--old-text)))
+                     (and (string-match "\\` " ivy--old-text)
+                          (not (string-match "\\` " ivy-text))))
+             (setq ivy--all-candidates
+                   (if (= (string-to-char ivy-text) ?\s)
+                       (ivy--buffer-list " ")
+                     (ivy--buffer-list "" ivy-use-virtual-buffers)))
+             (setq ivy--old-re nil))))
+    (ivy--insert-minibuffer
+     (with-current-buffer (ivy-state-buffer ivy-last)
+       (ivy--format
+        (ivy--filter ivy-text ivy--all-candidates))))
+    (setq ivy--old-text ivy-text)))
 
 (defun ivy-display-function-fallback (str)
   (let ((buffer-undo-list t))

--- a/ivy.el
+++ b/ivy.el
@@ -2225,12 +2225,13 @@ This is useful for recursive `ivy-read'."
     (setq ivy--extra-candidates (ivy--compute-extra-candidates caller))
     (setq ivy--directory nil)
     (setq ivy-case-fold-search ivy-case-fold-search-default)
-    (setq ivy--regex-function
-          (or re-builder
-              (and (functionp collection)
-                   (cdr (assq collection ivy-re-builders-alist)))
-              (ivy-alist-setting ivy-re-builders-alist)
-              #'ivy--regex))
+    (setf (ivy-state-re-builder ivy-last)
+          (setq ivy--regex-function
+                (or re-builder
+                    (and (functionp collection)
+                         (cdr (assq collection ivy-re-builders-alist)))
+                    (ivy-alist-setting ivy-re-builders-alist)
+                    #'ivy--regex)))
     (setq ivy--subexps 0)
     (setq ivy--regexp-quote #'regexp-quote)
     (setq ivy--old-text "")

--- a/swiper.el
+++ b/swiper.el
@@ -1695,7 +1695,7 @@ Intended to be bound in `isearch-mode-map' and `swiper-map'."
         (swiper-isearch query))
     (ivy-exit-with-action
      (lambda (_)
-       (when (looking-back ivy-regex (line-beginning-position))
+       (when (looking-back (ivy-re-to-str ivy-regex) (line-beginning-position))
          (goto-char (match-beginning 0)))
        (isearch-mode t)
        (unless (string= ivy-text "")

--- a/swiper.el
+++ b/swiper.el
@@ -1541,16 +1541,17 @@ When not running `swiper-isearch' already, start it."
 
 (defun swiper-isearch-format-function (cands)
   (if (numberp (car-safe cands))
-      (if (string= ivy-regex "^$")
-          ""
-        (mapconcat
-         #'identity
-         (swiper--isearch-format
-          ivy--index ivy--length ivy--old-cands
-          ivy-regex
-          (ivy-state-current ivy-last)
-          (ivy-state-buffer ivy-last))
-         "\n"))
+      (let ((re (ivy-re-to-str ivy-regex)))
+        (if (string= re "^$")
+            ""
+          (mapconcat
+           #'identity
+           (swiper--isearch-format
+            ivy--index ivy--length ivy--old-cands
+            re
+            (ivy-state-current ivy-last)
+            (ivy-state-buffer ivy-last))
+           "\n")))
     (funcall
      (ivy-alist-setting ivy-format-functions-alist t)
      cands)))
@@ -1568,9 +1569,10 @@ When not running `swiper-isearch' already, start it."
 
 (defun swiper--isearch-highlight (str &optional current)
   (let ((start 0)
-        (i 0))
+        (i 0)
+        (re (ivy-re-to-str ivy-regex)))
     (catch 'done
-      (while (string-match ivy-regex str start)
+      (while (string-match re str start)
         (if (= (match-beginning 0) (match-end 0))
             (throw 'done t)
           (setq start (match-end 0)))

--- a/swiper.el
+++ b/swiper.el
@@ -168,7 +168,7 @@ Treated as non-nil when searching backwards."
 (defun swiper--query-replace-setup ()
   (with-ivy-window
     (let ((end (window-end (selected-window) t))
-          (re ivy-regex))
+          (re (ivy-re-to-str ivy-regex)))
       (save-excursion
         (beginning-of-line)
         (while (re-search-forward re end t)
@@ -196,7 +196,7 @@ Treated as non-nil when searching backwards."
          (swiper--query-replace-setup)
          (unwind-protect
               (let* ((enable-recursive-minibuffers t)
-                     (from ivy-regex)
+                     (from (ivy-re-to-str ivy-regex))
                      (groups (number-sequence 1 ivy--subexps))
                      (default
                       (list


### PR DESCRIPTION
When searching in files with **CRLF** eol, a `^M` was being shown at the end of each line and in **ivy-occur** editing via `C-c C-p` didn't work.
I changed the line splitting regexp to take into account all possible eol and now everything works as expected.