### PR TITLE
Fix C-<backspace> not working in counsel-file-jump

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2773,7 +2773,6 @@ INITIAL-DIRECTORY, if non-nil, is used as the root directory for search."
               :preselect (counsel--preselect-file)
               :require-match 'confirm-after-completion
               :history 'file-name-history
-              :keymap counsel-find-file-map
               :caller 'counsel-file-jump)))
 
 (ivy-set-actions


### PR DESCRIPTION
`counsel-find-file-map` rebinds `C-<backspace>` to `counsel-up-directory`, which is not a valid command in this context. This means that it is not cannot be used as `backward-kill-word`. There are no useful bindings that `counsel-find-file-map` adds to `counsel-file-jump`.