### PR TITLE
ivy--format: argument cands can be an alist, fix #2355

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4089,6 +4089,10 @@ in this case."
 (defun ivy--format (cands)
   "Return a string for CANDS suitable for display in the minibuffer.
 CANDS is a list of candidates that :display-transformer can turn into strings."
+  (setq cands
+        (mapcar (lambda (x)
+                  (if (consp x) (car x) x))
+                cands))
   (setq ivy--length (length cands))
   (when (>= ivy--index ivy--length)
     (ivy-set-index (max (1- ivy--length) 0)))


### PR DESCRIPTION
* ivy.el (ivy--format): argument cands can be an alist.

```
(ivy-read "ARGH"
	  (lambda (_input)
	    '(("one" . 1)
	      ("two" . 2)))
	  :dynamic-collection t
	  :action (lambda (choice)
		    (message "%s" choice)))
```