### PR TITLE
Fix ripgrep pcre2 feature detection

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3079,7 +3079,7 @@ Example input with inclusion and exclusion file patterns:
         (counsel--grep-tool-look-around
          (let ((rg (car (split-string counsel-rg-base-command)))
                (switch "--pcre2"))
-           (and (eq 0 (call-process rg nil nil nil switch "--version"))
+           (and (eq 0 (call-process rg nil nil nil switch "--pcre2-version"))
                 switch))))
     (counsel-ag initial-input initial-directory extra-rg-args rg-prompt
                 :caller 'counsel-rg)))


### PR DESCRIPTION
Some versions of ripgrep ignore the --pcre2 flag when --version is
used. This defeats the test for pcre2 support.

This commit changes this to search one well known file (/dev/null) and
only prints the files it would have searched.  In this mode ripgrep
checks for pcre2 support and sets exit status as expected.

 See Issue #2478