### PR TITLE
counsel.el: Fix candidate splitting when eol is CR or CRLF

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -164,7 +164,7 @@ descriptions.")
                      cmd
                      (plist-put plist number str)))))
 
-(defvar counsel-async-split-string-re-alist '((t . "\n"))
+(defvar counsel-async-split-string-re-alist '((t . "[\r\n]"))
   "Store the regexp for splitting shell command output.")
 
 (defvar counsel-async-ignore-re-alist nil

--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1467,6 +1467,21 @@ a buffer visiting a file."
                         :dir "tests/find-file/directories-with-spaces/"))
              "tests/find-file/directories-with-spaces/bar baz ii/file2"))))
 
+(ert-deftest counsel--split-string-with-eol-cr ()
+  (should
+     (equal (counsel--split-string "one\rtwo")
+            '("one" "two"))))
+
+(ert-deftest counsel--split-string-with-eol-lf ()
+  (should
+     (equal (counsel--split-string "one\ntwo")
+            '("one" "two"))))
+
+(ert-deftest counsel--split-string-with-eol-crlf ()
+  (should
+     (equal (counsel--split-string "one\r\ntwo")
+            '("one" "two"))))
+
 (ert-deftest ivy-avy ()
   (when (require 'avy nil t)
     (let ((enable-recursive-minibuffers t)


### PR DESCRIPTION
When searching in files with CRLF eol, a ^M was being shown at the end of each line and in ivy-occur editing via C-c C-p didn't work.
I changed the line splitting regexp to take into account all possible eol and now everything works as expected.