### PR TITLE
counsel.el:  Fix bad counsel-rg-base-command on windows  (#2486)

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3039,7 +3039,7 @@ This uses `counsel-ag' with `counsel-ack-base-command' replacing
 ;;** `counsel-rg'
 (defcustom counsel-rg-base-command
   (if (memq system-type '(ms-dos windows-nt))
-      "rg -M 120 --with-filename --no-heading --line-number --color never %s --path-separator /."
+      "rg -M 120 --with-filename --no-heading --line-number --color never %s --path-separator / ."
     "rg -M 120 --with-filename --no-heading --line-number --color never %s")
   "Alternative to `counsel-ag-base-command' using ripgrep.
 


### PR DESCRIPTION
As mentioned in #2486 `counsel-rg` will cause `error code 2` when searching.
There seems to be a space missing between '/' and '.'.

This commit fixes it.