### PR TITLE
Fix swiper handling of bol regex

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -221,12 +221,13 @@ Since `execute-kbd-macro' doesn't pick up a let-bound `default-directory'.")
 
 (ert-deftest swiper--re-builder ()
   (setq swiper--width 4)
+  (setf (ivy-state-caller ivy-last) 'swiper)
   (should (string= (swiper--re-builder "^")
-                   "."))
+                   "^ "))
   (should (string= (swiper--re-builder "^a")
-                   "^ ?\\(a\\)"))
+                   "^ a"))
   (should (string= (swiper--re-builder "^a b")
-                   "^ \\(a\\).*?\\(b\\)"))
+                   "\\(^ a\\).*?\\(b\\)"))
   (should
    (string-match-p
     "\\`\\\\_<.*\\\\_>\\'"


### PR DESCRIPTION
Closes #2418

This PR makes swiper handle the regex bol (`^`) correctly. Its works in all of my testing, but there are still some interesting behaviors related to highlighting I can't explain.

- when you add the bol pattern in the middle of your prompt (i.e. `foo ^bar`) it does not highlight that pattern (in this case `bar`)
- When you add a bol pattern to the start of the prompt (i.e. `^bar foo`) it will highlight it but also get the numbers highlighted as well
- it does not do the usual highlighting for a re-builder. For example, if I am using `ivy-regex--ignore-order` it will normally highlight each new match with a different face. Swiper has never done this correctly and the PR does not change that. It highlights all matches with the same face.