### PR TITLE
ivy.el: fix next-error randomly jumping to previous match

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4983,7 +4983,11 @@ When `ivy-calling' isn't nil, call `ivy-occur-press'."
   (setq n (or n 1))
   (let ((ivy-calling t))
     (cond ((< n 0) (ivy-occur-previous-line (- n)))
-          (t (ivy-occur-next-line n)))))
+          (t (ivy-occur-next-line n))))
+  ;; the window's point overrides the buffer's point every time it's redisplayed
+  (cl-dolist (window (get-buffer-window-list nil nil t))
+    (set-window-point window (point)))
+  )
 
 (define-derived-mode ivy-occur-mode fundamental-mode "Ivy-Occur"
   "Major mode for output from \\[ivy-occur].


### PR DESCRIPTION
Fixes #2492

Problem happens only when *ivy-occur ...* is not the active window.

Explanation of the problem:
https://emacs.stackexchange.com/questions/21464/how-to-persistently-move-the-cursor-in-a-buffer-other-than-the-current-one/21478