### PR TITLE
counsel-fonts:  add a sample of the font.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -5380,6 +5380,15 @@ You can insert or kill the name of the selected font."
               :action #'insert
               :caller 'counsel-fonts)))
 
+(ivy-configure 'counsel-fonts
+  :display-transformer-fn #'counsel--font-with-sample)
+
+(defun counsel--font-with-sample (font-name)
+  "Format function for `counsel-fonts'."
+  (format "%-75s%s" font-name
+          (propertize "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                      'face (list :family font-name))))
+
 ;;** `counsel-kmacro'
 (defvar counsel-kmacro-map
   (let ((map (make-sparse-keymap)))

--- a/counsel.el
+++ b/counsel.el
@@ -5371,11 +5371,14 @@ selected color."
 
 You can insert or kill the name of the selected font."
   (interactive)
-  (ivy-read "Font: " (delete-dups (font-family-list))
-            :require-match t
-            :history 'counsel-fonts-history
-            :action #'insert
-            :caller 'counsel-fonts))
+  (let ((current-font
+         (symbol-name (font-get (face-attribute 'default :font) :family))))
+    (ivy-read "Font: " (delete-dups (font-family-list))
+              :preselect current-font
+              :require-match t
+              :history 'counsel-fonts-history
+              :action #'insert
+              :caller 'counsel-fonts)))
 
 ;;** `counsel-kmacro'
 (defvar counsel-kmacro-map


### PR DESCRIPTION
Request for comments: I guess it is a nice improvement over the default behaviour of the command.

In image:
![image](https://user-images.githubusercontent.com/7757342/79076616-c90e1400-7cfb-11ea-9b81-fbeb7e028390.png)
