### PR TITLE
ivy.el (ivy-read-action-by-key): Fix keys to quit action selection

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -956,7 +956,7 @@ selection, non-nil otherwise."
                 (not (string= key (car (nth action-idx (cdr actions))))))
       (setq key (concat key (key-description (string (read-key hint))))))
     (ivy-shrink-after-dispatching)
-    (cond ((member key '("" ""))
+    (cond ((member key '("ESC" "C-g"))
            nil)
           ((null action-idx)
            (message "%s is not bound" key)


### PR DESCRIPTION
Fixes #2485 .

`ivy-read-action-by-key` was checking whether an exit key was pressed by comparing two incompatible representations of keys:

  * a "pretty" key string from `key-description`
  * a string where the first character is a "raw" key event (N.B. these special characters don't show up in the GitHub diff, at least on my browser)

The comparison never succeeded. Now it compares only "pretty" keystrings. I have tested the fix on Emacs 26.3/Linux.

Maybe as a future improvement `ivy-read-action-by-key` could use a keymap instead of hardcoding the keys. It would be nice to be able to configure them.