### PR TITLE
Fix ivy-completion-in-region return value

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2713,8 +2713,10 @@ See `completion-in-region' for further information."
                                      (goto-char ivy-completion-beg)
                                      (when initial
                                        (insert initial))))
-                         :caller 'ivy-completion-in-region)
-               t))))))
+                         :caller 'ivy-completion-in-region)))
+           ;; Return value should be non-nil on valid completion;
+           ;; see `completion-in-region'.
+           t))))
 
 (defun ivy-completion-in-region-prompt ()
   "Prompt function for `ivy-completion-in-region'.


### PR DESCRIPTION
`ivy.el` (`ivy-completion-in-region`): Return non-`nil` on valid completion, even if there is only a single candidate, as per the docstring of `completion-in-region`.

I intend to push this in a few days unless there are any comments/objections before then.