### PR TITLE
Adapt tests to when wgrep is not installed

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1365,11 +1365,9 @@ a buffer visiting a file."
     "Foo\nfoo|\nFOO\n")))
 
 (ert-deftest ivy-swiper-wgrep ()
-  :expected-result (if (and (= emacs-major-version 24)
-                            (<= emacs-minor-version 3))
-                       ;; `wgrep' requires at least 24.5
-                       :failed
-                     :passed)
+  ;; `wgrep' requires Emacs 25 or later.
+  (skip-unless (and (>= emacs-major-version 25)
+                    (require 'wgrep nil t)))
   (dolist (search-cmd '(swiper swiper-isearch))
     (should
      (string=


### PR DESCRIPTION
`ivy-test.el` (`ivy-swiper-wgrep`): Make test more reliable by skipping if conditions aren't met instead of trying to predict whether things will fail.  Skip test if `wgrep` is not installed and bump its Emacs version requirement to Emacs 25 or later, which has been the case since 2018:

https://github.com/mhayashi1120/Emacs-wgrep/commit/6f04cd7aa2ad67983082f778f0e34fb28970866a

I intend to push this in a few days unless there are any comments/objections before then.