### PR TITLE
Clean up compatibility code

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -90,7 +90,6 @@ Then attach the overlay to the character before point."
 (defvar ivy-last)
 (defvar ivy-text)
 (defvar ivy-completion-beg)
-(declare-function ivy-add-face-text-property "ivy")
 (declare-function ivy--get-window "ivy")
 (declare-function ivy-state-current "ivy")
 (declare-function ivy-state-window "ivy")
@@ -115,8 +114,8 @@ Hide the minibuffer contents and cursor."
         (save-excursion
           (forward-line 1)
           (insert str)))
-    (ivy-add-face-text-property (minibuffer-prompt-end) (point-max)
-                                '(:foreground "white"))
+    (add-face-text-property (minibuffer-prompt-end) (point-max)
+                            '(:foreground "white"))
     (setq cursor-type nil)
     (with-selected-window (ivy--get-window ivy-last)
       (when cursor-type
@@ -145,8 +144,8 @@ Hide the minibuffer contents and cursor."
                                (goto-char ivy-completion-beg))
                              (current-column)))))))))
         (let ((cursor-offset (1+ (length ivy-text))))
-          (ivy-add-face-text-property cursor-offset (1+ cursor-offset)
-                                      'ivy-cursor overlay-str t))
+          (add-face-text-property cursor-offset (1+ cursor-offset)
+                                  'ivy-cursor t overlay-str))
         (ivy-overlay-show-after overlay-str)))))
 
 (provide 'ivy-overlay)

--- a/swiper.el
+++ b/swiper.el
@@ -468,6 +468,7 @@ such as `scroll-conservatively' are set to a high value.")
   (unless (swiper-font-lock-ensure-p)
     (unless (or (> (buffer-size) 100000) (null font-lock-mode))
       (if (fboundp 'font-lock-ensure)
+          ;; Added in Emacs 25.1.
           (font-lock-ensure)
         (with-no-warnings (font-lock-fontify-buffer))))))
 
@@ -504,8 +505,6 @@ such as `scroll-conservatively' are set to a high value.")
      " "
      (buffer-substring beg end))))
 
-(declare-function outline-show-all "outline")
-
 (defvar swiper-use-visual-line-p
   (lambda (n-lines)
     (and visual-line-mode
@@ -527,6 +526,7 @@ numbers; replaces calculating the width from buffer line count."
           (when (eq major-mode 'org-mode)
             (require 'outline)
             (if (fboundp 'outline-show-all)
+                ;; Added in Emacs 25.1.
                 (outline-show-all)
               (with-no-warnings
                 (show-all))))
@@ -766,6 +766,7 @@ line numbers.  For the buffer, use `ivy--regex' instead."
                        (setq ivy--subexps 1)))
                     (t
                      (format "^ %s" re)))))
+               ;; Added in Emacs 25.1.
                ((fboundp (bound-and-true-p search-default-mode))
                 (if (string-match "\\`\\\\_<\\(.+\\)\\\\_>\\'" str)
                     (concat
@@ -1607,8 +1608,7 @@ When not running `swiper-isearch' already, start it."
              swiper-faces
            swiper-background-faces)
          (lambda (beg end face _priority)
-           (ivy-add-face-text-property
-            beg end face str)))
+           (add-face-text-property beg end face nil str)))
         (cl-incf i)))
     str))
 


### PR DESCRIPTION
`counsel.el`: Add comments noting Emacs versions required where applicable.
(`counsel-recentf-candidates`): Silence pre-Emacs 26 byte-compiler.
(`counsel--recentf-get-xdg-recent-files`): Use `counsel--xdg-data-home` compatibility shim.
(`counsel--imenu-candidates`): Simply load built-in library `imenu.el`.
(`counsel--minor-candidates`): Avoid using `alist-get` which was added in Emacs 25.1.
(`counsel-mode`): Assume `nadvice.el` functions are defined now that Counsel requires Emacs 24.5 or later.

`ivy-test.el` (`require-features`): Rename as...
(`ivy-features`): ...this, using an appropriate package prefix. All users changed.
(`ivy-tests-require-hook`): Convert obsolete `defadvice`...
(`ivy-test--record-feature`): ...to this `:after-while` advice which populates `ivy-features` only if `require` succeeded and while avoiding duplicate elements.
(`no-void-function`): Remove unneeded `defadvice` now that Ivy requires Emacs 24.5 or later.
(`ivy-partial-2`): Assume `read--expression` is defined now that Ivy requires Emacs 24.5 or later.

`ivy.el`: Add comments noting Emacs versions required where applicable.
(`ivy-display-style`): Default to `fancy` now that Ivy requires Emacs 24.5 or later.
(`defvar-local`, `setq-local`): Don't define now that Ivy requires Emacs 24.5 or later.
(`ivy--compute-extra-actions`): Avoid using `assoc-delete-all` which was added in Emacs 27.1
(`ivy--avy-handler-function`): Don't write characters as numbers.
(`ivy--file-local-name`): New compatibility shim for Emacs 26.1 function `file-local-name`.
(`ivy--magic-tilde-directory`): Use it.
(`ivy-add-face-text-property`): Remove compatibility shim now that Ivy requires Emacs 24.5 or later.  All callers changed to call `add-face-text-property` directly.
(`ivy-yank-symbol`): Assume `forward-symbol` is always defined now that Ivy requires Emacs 24.5 or later.

`swiper.el`: Add comments noting Emacs versions required where applicable.

---

I intend to push this in a few days unless there are any comments/objections before then.