### PR TITLE
More compatibility fixes

### DIFF
--- a/ivy-overlay.el
+++ b/ivy-overlay.el
@@ -26,6 +26,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'subr-x))
+
 (defface ivy-cursor
   '((((class color) (background light))
      :background "black" :foreground "white")
@@ -93,7 +96,6 @@ Then attach the overlay to the character before point."
 (declare-function ivy--get-window "ivy")
 (declare-function ivy-state-current "ivy")
 (declare-function ivy-state-window "ivy")
-(declare-function ivy--remove-prefix "ivy")
 
 (defun ivy-overlay-impossible-p (_str)
   (or
@@ -131,7 +133,7 @@ Hide the minibuffer contents and cursor."
               (and (> (length str) 0)
                    (list "\n"
                          (ivy-left-pad
-                          (ivy--remove-prefix "\n" str)
+                          (string-remove-prefix "\n" str)
                           (+
                            (if (and (eq major-mode 'org-mode)
                                     (bound-and-true-p org-indent-mode))

--- a/ivy.el
+++ b/ivy.el
@@ -38,10 +38,14 @@
 
 ;;; Code:
 
-(require 'cl-lib)
-(require 'ivy-overlay)
 (require 'colir)
+(require 'ivy-overlay)
+
+(require 'cl-lib)
 (require 'ring)
+
+(eval-when-compile
+  (require 'subr-x))
 
 ;;* Customization
 (defgroup ivy nil
@@ -1176,12 +1180,6 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                    (eq ivy--length 1))
            (ivy-alt-done))))))
 
-(defun ivy--remove-prefix (prefix string)
-  "Compatibility shim for `string-remove-prefix'."
-  (if (string-prefix-p prefix string)
-      (substring string (length prefix))
-    string))
-
 (defun ivy--partial-cd-for-single-directory ()
   (when (and
          (eq (ivy-state-collection ivy-last) #'read-file-name-internal)
@@ -1199,7 +1197,7 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
          (postfix (car tail))
          (case-fold-search (ivy--case-fold-p ivy-text))
          (completion-ignore-case case-fold-search)
-         (new (try-completion (ivy--remove-prefix "^" postfix)
+         (new (try-completion (string-remove-prefix "^" postfix)
                               (if (ivy-state-dynamic-collection ivy-last)
                                   ivy--all-candidates
                                 (mapcar (lambda (str)
@@ -3755,7 +3753,7 @@ CANDS are the current candidates."
                (and (> (length cands) 10000) (eq func #'ivy-recompute-index-zero)))
            0
          (or
-          (cl-position (ivy--remove-prefix "^" re-str)
+          (cl-position (string-remove-prefix "^" re-str)
                        cands
                        :test #'ivy--case-fold-string=)
           (and ivy--directory
@@ -4018,7 +4016,7 @@ It has it by default, but the current theme also needs to set it."
   "Highlight STR, using the fuzzy method."
   (if (and ivy--flx-featurep
            (eq (ivy-alist-setting ivy-re-builders-alist) 'ivy--regex-fuzzy))
-      (let ((flx-name (ivy--remove-prefix "^" ivy-text)))
+      (let ((flx-name (string-remove-prefix "^" ivy-text)))
         (ivy--flx-propertize
          (cons (flx-score str flx-name ivy--flx-cache) str)))
     (ivy--highlight-default str)))


### PR DESCRIPTION
* `counsel.el`: Require `subr-x.el` which was added in Emacs 24.4.
(`counsel--string-trim-left`): Remove unneeded duplicate of `string-trim-left`.
(`counsel-M-x-action`): Replace `counsel--string-trim-left` with simpler `string-remove-prefix`.
(`counsel-recentf-include-xdg-list`): Fix URL hyperlink.
(`counsel--strip-prefix`): Remove unneeded duplicate of `ivy--remove-prefix`.
(`counsel--xml-parse-region`): New compatibility shim for `libxml-parse-xml-region` which falls back to using `xml-parse-region` when libxml2 is not available.
(`counsel--recentf-get-xdg-recent-files`): Use it.  Replace `counsel--strip-prefix` with `string-remove-prefix`.  Assume every bookmark node has a `href` attribute, as mandated by the spec.  Fix decoding of file names that include newlines.  Allow `decode-coding-string` to return its argument unchanged.  Simplify using `cl-mapcan`.  Improve error reporting and docstring.

* `ivy.el` (`ivy--remove-prefix`): Remove unneeded duplicate of `string-remove-prefix` and change all callers to use the latter.

Fixes #2527
Cc: @tam17aki, @okamsn