### PR TITLE
Revert ".dir-locals.el: Simplify outline-regexp"

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -8,7 +8,7 @@
   (sentence-end-double-space . t))
  (emacs-lisp-mode
   (indent-tabs-mode . nil)
-  (outline-regexp . ";;[;*]+[\s\t]+")
+  (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")
   ;; extra config here: https://github.com/abo-abo/oremacs/blob/github/modes/ora-elisp-style-guide.el
   ;; (lisp-indent-function . common-lisp-indent-function)
   ))


### PR DESCRIPTION
This reverts commit a89825b205608f5bcb87b1fcaf9239804dde6b54,
which was added to #1681.

The default value of `outline-regexp` as used in `elisp-mode`
is `";;;\\(;* [^ \t\n]\\|###autoload\\)\\|("`, see function
`lisp-mode-variables`.

The reason that that does not work in our case is because we
use outline headings like

``` emacs-lisp
;;* section
;;** subsection
;;*** subsubsection
```

instead of the default

``` emacs-lisp
;;; section
;;;; subsection
;;;;; subsubsection
```

`outline-regexp` therefore has to match semicolons followed by
asterisks instead of just semicolons.  That's what the regexp that
we are restoring does.  That is the only part that we should change
compared to the default value.

The default regexp as well as our regexp additionally match autoload
cookies as well as lines beginning with `(`.  (While the regexp does
not begin with `^`, `outline' actually does anchor the searches.)

Features exists that depends on that being the case, lets not
needlessly break them.