### PR TITLE
Revert ".dir-locals.el (outline-regexp): "^(" is not an outline start"

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -8,7 +8,7 @@
   (sentence-end-double-space . t))
  (emacs-lisp-mode
   (indent-tabs-mode . nil)
-  (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)")
+  (outline-regexp . ";;\\([;*]+ [^\s\t\n]\\|###autoload\\)\\|(")
   ;; extra config here: https://github.com/abo-abo/oremacs/blob/github/modes/ora-elisp-style-guide.el
   ;; (lisp-indent-function . common-lisp-indent-function)
   ))


### PR DESCRIPTION
This reverts commit 4f6bd9e1848456d2e0709daf1751e13f4b664028, except
for the parts of that commit that have nothing to do with the stated
purpose.

In `outline-minor-mode` "^(" actually it is an outline start.

See #2529.