### PR TITLE
counsel.el (counsel-git-log-cmd): Disable coloring.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1631,7 +1631,7 @@ done") "\n" t)))
               :caller 'counsel-git-stash)))
 
 ;;** `counsel-git-log'
-(defvar counsel-git-log-cmd "GIT_PAGER=cat git log --grep '%s'"
+(defvar counsel-git-log-cmd "GIT_PAGER=cat git log --no-color --grep '%s'"
   "Command used for \"git log\".")
 
 (defun counsel-git-log-function (_)


### PR DESCRIPTION
I switched to `fish` as my terminal emulator recently and noticed that this was necessary to ensure that `counsel-git-log-show-commit-action` worked there. `fish` seems to color a lot more stuff than `bash` does.