### PR TITLE
Fix recent regression in ivy--preselect-index

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1538,6 +1538,24 @@ a buffer visiting a file."
            (counsel--split-command-args "counsel--format")
            '("" . "counsel--format"))))
 
+(ert-deftest ivy--preselect-index ()
+  "Test `ivy--preselect-index' behavior."
+  (should (eql (ivy--preselect-index nil ()) 0))
+  (should (eql (ivy--preselect-index nil '(nil)) 0))
+  (should (eql (ivy--preselect-index nil '(t)) 0))
+  (should (eql (ivy--preselect-index nil '(t nil)) 1))
+  (should (eql (ivy--preselect-index 0 ()) 0))
+  (should (eql (ivy--preselect-index 0 '(0)) 0))
+  (should (eql (ivy--preselect-index 0 '(1)) 0))
+  (should (eql (ivy--preselect-index 0 '(1 0)) 1))
+  (should (eql (ivy--preselect-index 0 '(a)) 0))
+  (should (eql (ivy--preselect-index 1 '(a)) 1))
+  (should (eql (ivy--preselect-index "" ()) 0))
+  (should (eql (ivy--preselect-index "" '("")) 0))
+  (should (eql (ivy--preselect-index "" '("a")) 0))
+  (should (eql (ivy--preselect-index "a+" '("a")) 0))
+  (should (eql (ivy--preselect-index "a+" '("b" "a")) 1)))
+
 (defun ivy-test-run-tests ()
   (let ((test-sets
          '(

--- a/ivy.el
+++ b/ivy.el
@@ -2746,14 +2746,14 @@ Minibuffer bindings:
 
 (defun ivy--preselect-index (preselect candidates)
   "Return the index of PRESELECT in CANDIDATES."
-  (cond ((integerp preselect)
-         (if (integerp (car candidates))
-             (cl-position preselect candidates)
-           preselect))
-        ((cl-position preselect candidates :test #'equal))
-        ((and (ivy--regex-p preselect)
-              (cl-position preselect candidates :test #'string-match-p)))
-        (t 0)))
+  (or (cond ((integerp preselect)
+             (if (integerp (car candidates))
+                 (cl-position preselect candidates)
+               preselect))
+            ((cl-position preselect candidates :test #'equal))
+            ((ivy--regex-p preselect)
+             (cl-position preselect candidates :test #'string-match-p)))
+      0))
 
 ;;* Implementation
 ;;** Regex


### PR DESCRIPTION
### Issue

1. `make plain`
2. ```el
   (setq ivy-initial-inputs-alist ())
   ```
   <kbd>C-x</kbd><kbd>C-e</kbd>
3. <kbd>C-x</kbd><kbd>C-f</kbd>
4. <kbd>C-h</kbd><kbd>C-v</kbd>

This results in:

```
Error in post-command-hook (ivy--queue-exhibit): (wrong-type-argument number-or-marker-p nil)
```

Here's the call stack:

1. `ivy--queue-exhibit`
2. `ivy--exhibit`
3. `ivy--update-minibuffer`
4. `ivy--format`
5. `ivy--index` is `nil`

The error was introduced in commit 2bf73171f15452dec78b60e20e37e5caf0c483b4.

### Fix

* `ivy.el` (`ivy--preselect-index`): Always return an index, never `nil`.