### PR TITLE
Fix punctuation in some error messages

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1734,7 +1734,7 @@ TREE is the selected candidate."
     (ivy-read "Select worktree: "
               (or (cl-delete default-directory (counsel-git-worktree-list)
                              :key #'counsel-git-worktree-parse-root :test #'string=)
-                  (error "No other worktrees!"))
+                  (error "No other worktrees"))
               :action (lambda (tree)
                         (counsel-git-change-worktree-action
                          (ivy-state-directory ivy-last) tree))
@@ -2799,7 +2799,8 @@ FZF-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
 
 (defun counsel--find-return-list (args)
   (unless (listp args)
-    (user-error "`counsel-file-jump-args' is a list now, please customize accordingly."))
+    (user-error
+     "`counsel-file-jump-args' is a list now; please customize accordingly"))
   (counsel--call
    (cons find-program args)
    (lambda ()
@@ -4119,7 +4120,7 @@ When ARG is non-nil, display all active evil registers."
         (if candidates
             (counsel-mark--ivy-read candidates 'counsel-evil-marks)
           (message "no evil marks are active")))
-    (user-error "Required feature `evil' not installed or not loaded.")))
+    (user-error "Required feature `evil' not installed or loaded")))
 
 ;;** `counsel-package'
 (defvar package--initialized)
@@ -4522,7 +4523,7 @@ matching the register's value description against a regexp in
                 :require-match t
                 :action #'counsel-evil-registers-action
                 :caller 'counsel-evil-registers)
-    (user-error "Required feature `evil' not installed.")))
+    (user-error "Required feature `evil' not installed")))
 
 (ivy-configure 'counsel-evil-registers
   :height 5
@@ -5493,7 +5494,7 @@ This is a combination of `kmacro-ring' and, together in a list, `last-kbd-macro'
               (condition-case nil
                   (format-kbd-macro (if (listp kmacro) (car kmacro) kmacro) 1)
                 ;; Recover from error from `edmacro-fix-menu-commands'.
-                (error "Warning: Cannot display macros containing mouse clicks.")))
+                (error "Warning: Cannot display macros containing mouse clicks")))
       kmacro))
    (cons
     (if (listp last-kbd-macro)

--- a/ivy.el
+++ b/ivy.el
@@ -1829,7 +1829,7 @@ This string is inserted into the minibuffer."
          (error "Package avy isn't installed"))
         ((= (minibuffer-depth) 0)
          (user-error
-          "This command is intended to be called with \"C-'\" from `ivy-read'."))
+          "This command is intended to be called from within `ivy-read'"))
         (t
          (let* ((avy-all-windows nil)
                 (avy-keys (or (cdr (assq 'ivy-avy avy-keys-alist))
@@ -2498,8 +2498,7 @@ This is useful for recursive `ivy-read'."
 (defun ivy-add-prompt-count (prompt)
   "Add count information to PROMPT."
   (cond ((null ivy-count-format)
-         (error
-          "`ivy-count-format' can't be nil.  Set it to \"\" instead"))
+         (error "`ivy-count-format' must not be nil; set it to \"\" instead"))
         ((string-match "%d.*\\(%d\\)" ivy-count-format)
          (let* ((w
                   (if (listp ivy--all-candidates)
@@ -4870,7 +4869,7 @@ You can also delete an element from history with \\[ivy-reverse-i-search-kill]."
   (cond
     ((= (minibuffer-depth) 0)
      (user-error
-      "This command is intended to be called with \"C-r\" from `ivy-read'."))
+      "This command is intended to be called from within `ivy-read'"))
     ;; don't recur
     ((and (> (minibuffer-depth) 1)
           (eq (ivy-state-caller ivy-last) 'ivy-reverse-i-search)))


### PR DESCRIPTION
* `counsel.el` (`counsel-git-change-worktree`)
  (`counsel--find-return-list`, `counsel-evil-marks`)
  (`counsel-evil-registers`, `counsel--kmacro-candidates`):
* `ivy.el` (`ivy-avy`, `ivy-add-prompt-count`, `ivy-reverse-i-search`):

Improve wording of error messages: remove trailing punctuation as per Emacs conventions and avoid hard-coding key bindings.