### PR TITLE
Don't insert ^ on aborting completion in region

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2726,12 +2726,12 @@ See `completion-in-region' for further information."
                  (setq initial nil)
                  (setq predicate nil)
                  (setq collection comps))
-               (if (functionp collection)
-                   (setq collection comps)
-                 (setq initial (concat "^" initial)))
-               (ivy-read (format "(%s): " str) collection
+               (ivy-read (format "(%s): " str)
+                         (if (functionp collection) comps collection)
                          :predicate predicate
-                         :initial-input initial
+                         :initial-input (concat (unless (functionp collection)
+                                                  "^")
+                                                initial)
                          :action #'ivy-completion-in-region-action
                          :unwind (lambda ()
                                    (unless (eq ivy-exit 'done)


### PR DESCRIPTION
### Issue

1. `make plain`
2. `(mess`<kbd>C-M-i</kbd>
3. <kbd>C-g</kbd>

Expected contents preceding point: `(mess`
Actual contents preceding point: `(^mess`

### Fix

* `ivy.el` (`ivy-completion-in-region`): Don't permanently prepend `"^"` to initial input, otherwise it will get inserted on <kbd>C-g</kbd>.

---

Re: #2562