### PR TITLE
ivy.el (ivy--update-minibuffer): don't filter while there's input

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3463,8 +3463,10 @@ Should be run via minibuffer `post-command-hook'."
                          (ivy--buffer-list "" ivy-use-virtual-buffers)))
                  (setq ivy--old-re nil))))
         (with-current-buffer (ivy-state-buffer ivy-last)
-          (ivy--format
-           (ivy--filter ivy-text ivy--all-candidates))))
+          (let ((ret (while-no-input
+                       (ivy--format
+                        (ivy--filter ivy-text ivy--all-candidates)))))
+            (unless (booleanp ret) ret))))
     (setq ivy--old-text ivy-text)))
 
 (defun ivy-display-function-fallback (str)


### PR DESCRIPTION
`ivy--update-minibuffer` is slow when there's a lot of candidates (like in the case of `counsel-describe-symbol`).
We should stop doing `ivy--filter` when there's input.

Here is profiler report when using `counsel-describe-symbol`
![image](https://user-images.githubusercontent.com/2631472/82112663-f54d0280-9789-11ea-9c00-ec293b1fed44.png)
