### PR TITLE
Check whether `counsel-ag-base-command` is a string for ivy-occur

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3035,7 +3035,8 @@ Works for `counsel-git-grep', `counsel-ag', etc."
 (defun counsel--grep-smart-case-flag ()
   (if (ivy--case-fold-p ivy-text)
       "-i"
-    (if (string-match-p "\\`pt" counsel-ag-base-command)
+    (if (and (stringp counsel-ag-base-command)
+             (string-match-p "\\`pt" counsel-ag-base-command))
         "-S"
       "-s")))
 


### PR DESCRIPTION
`counsel-ag-base-command` can be a list e.g. `counsel-rg-base-command`

Scenario:
1. Call `counsel-rg` with case sensitive characters
2. Call `ivy-occur` (<kbd>C-c C-o</kbd>) over the candidates
3. fails