### PR TITLE
ivy--compute-extra-actions does not dedup on "key"

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -229,7 +229,9 @@ ACTIONS that have the same key."
              ("o" identity "default")
              ,@extra-actions))
           (t
-           (delete-dups (append action extra-actions))))))
+           `(1
+             ,@(cl-delete-duplicates (cdr (append action extra-actions))
+                                   :key #'car :test #'equal :from-end t))))))
 
 (defvar ivy--prompts-list nil)
 

--- a/ivy.el
+++ b/ivy.el
@@ -231,7 +231,7 @@ ACTIONS that have the same key."
           (t
            `(1
              ,@(cl-delete-duplicates (cdr (append action extra-actions))
-                                   :key #'car :test #'equal :from-end t))))))
+                                     :key #'car :test #'equal :from-end t))))))
 
 (defvar ivy--prompts-list nil)
 


### PR DESCRIPTION
When `actions` and `extra-actions` have the same "key" they `ivy--compute-extra-actions` should dedup the list of actions. Currently it does not and it leads to some, in my opinion, unexpected behavior. 

This change makes it so when there is a duplicate, it removes it from the list of actions. Specifically, the duplicate from extra-actions is removed.

For me, with the following set:
```emacs-lisp
(setq ivy-read-action-function #'ivy-hydra-read-action)
```
I get a hydra with two actions showing as bound to the same key. The hydra displays all the actions that are provided to it (the list is generated by `ivy--compute-extra-actions`). I have a duplicate action coming from `extra-actions`, which is not the one I want or would expect to apply as it is second in the list. Due to the way the hydra works the second action is the one that takes precedence, because it binds over the first action. 

This seems like the appropriate place to fix this issue, but maybe not? Anyway, let me know if you need more detail / clarification. Thanks!