### PR TITLE
Respect original default choice when deduplicating extra actions

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -229,9 +229,9 @@ ACTIONS that have the same key."
              ("o" identity "default")
              ,@extra-actions))
           (t
-           `(1
-             ,@(cl-delete-duplicates (cdr (append action extra-actions))
-                                     :key #'car :test #'equal :from-end t))))))
+           (cons (car action)
+                 (cl-delete-duplicates (cdr (append action extra-actions))
+                                       :key #'car :test #'equal :from-end t))))))
 
 (defvar ivy--prompts-list nil)
 


### PR DESCRIPTION
Proposed fix for #2589 