### PR TITLE
Fix for counsel-grep-like-occur

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3068,7 +3068,7 @@ Works for `counsel-git-grep', `counsel-ag', etc."
                  (lambda (x) (if (string= x "%s") (copy-sequence all-args) (list x)))
                  cmd-template)))))
          (cands (counsel--split-string
-                 (if (stringp cmd-template)
+                 (if (stringp cmd)
                      (shell-command-to-string cmd)
                    (counsel--call cmd)))))
     (swiper--occur-insert-lines (mapcar #'counsel--normalize-grep-match cands))))


### PR DESCRIPTION
See Issue #2571.  Fix wrong-type-argument when calling `counsel-grep-like-occur`.  Suspect
that it was simply a typo to check `(stringp cmd-template)` instead of `(stringp cmd)` prior to calling the command.

Please double-check the fix.
