### PR TITLE
Fix for ivy-immediate-done with counsel-M-x

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -884,7 +884,7 @@ packages are, in order of precedence, `amx' and `smex'."
 
 (defun counsel-M-x-action (cmd)
   "Execute CMD."
-  (setq cmd (intern (string-remove-prefix "^" cmd)))
+  (setq cmd (intern (replace-regexp-in-string " " "-" (string-remove-prefix "^" cmd))))
   (cond ((bound-and-true-p amx-initialized)
          (amx-rank cmd))
         ((bound-and-true-p smex-initialized-p)


### PR DESCRIPTION
For for `ivy-immediate-done` with `counsel-M-x` when trying to call a command that has been typed using spaces instead of dashes.  The fix is simply to replace " " with "-".  See also Issue #2448.

The use case that this addresses is as follows:
- Run `counsel-M-x`
- Type "ediff buffers" (note use of space character instead of dash, as is customary when typing commands in the minibuffer)
- Completion list is highlighting `ediff-buffers3`, which is not what we want, so we cannot just press enter.  Instead:
- Run `ivy-immediate-done` (`C-M-j`)

Without this fix, this produces an error `Wrong type argument: commandp, ediff\ buffers`.  This fix simply replaces the space with a dash, so that `ivy-immediate-done` will work as expected in these situations.