### PR TITLE
Recognize remote executables in Emacs >= 27.1.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -124,7 +124,7 @@ To skip the `executable-find' check, start the string with a space."
                      (car (split-string cmd)))))
       (or (and (stringp program)
                (not (string= program ""))
-               (if (version<= "27.1" emacs-version)
+               (if (version< "27" emacs-version)
                    (executable-find program (tramp-tramp-file-p default-directory))
                  (executable-find program)))
           (user-error "Required program \"%s\" not found in your path" program)))))

--- a/counsel.el
+++ b/counsel.el
@@ -124,7 +124,7 @@ To skip the `executable-find' check, start the string with a space."
                      (car (split-string cmd)))))
       (or (and (stringp program)
                (not (string= program ""))
-               (if (< 27 emacs-major-version)
+               (if (<= 27 emacs-major-version)
                    (executable-find program (file-remote-p default-directory))
                  (executable-find program)))
           (user-error "Required program \"%s\" not found in your path" program)))))

--- a/counsel.el
+++ b/counsel.el
@@ -124,7 +124,7 @@ To skip the `executable-find' check, start the string with a space."
                      (car (split-string cmd)))))
       (or (and (stringp program)
                (not (string= program ""))
-               (if (version< "27" emacs-version)
+               (if (< 27 emacs-major-version)
                    (executable-find program (tramp-tramp-file-p default-directory))
                  (executable-find program)))
           (user-error "Required program \"%s\" not found in your path" program)))))

--- a/counsel.el
+++ b/counsel.el
@@ -124,9 +124,9 @@ To skip the `executable-find' check, start the string with a space."
                      (car (split-string cmd)))))
       (or (and (stringp program)
                (not (string= program ""))
-               (executable-find program
-                                (and (version<= "27.1" emacs-version)
-                                     (tramp-tramp-file-p default-directory))))
+               (if (version<= "27.1" emacs-version)
+                   (executable-find program (tramp-tramp-file-p default-directory))
+                 (executable-find program)))
           (user-error "Required program \"%s\" not found in your path" program)))))
 
 (declare-function eshell-split-path "esh-util")

--- a/counsel.el
+++ b/counsel.el
@@ -124,7 +124,9 @@ To skip the `executable-find' check, start the string with a space."
                      (car (split-string cmd)))))
       (or (and (stringp program)
                (not (string= program ""))
-               (executable-find program))
+               (executable-find program
+                                (and (version<= "27.1" emacs-version)
+                                     (tramp-tramp-file-p default-directory))))
           (user-error "Required program \"%s\" not found in your path" program)))))
 
 (declare-function eshell-split-path "esh-util")

--- a/counsel.el
+++ b/counsel.el
@@ -125,7 +125,7 @@ To skip the `executable-find' check, start the string with a space."
       (or (and (stringp program)
                (not (string= program ""))
                (if (< 27 emacs-major-version)
-                   (executable-find program (tramp-tramp-file-p default-directory))
+                   (executable-find program (file-remote-p default-directory))
                  (executable-find program)))
           (user-error "Required program \"%s\" not found in your path" program)))))
 


### PR DESCRIPTION
`default-directory` no longer affects `executable-find` by default on Emacs 27.1+.

```
(executable-find COMMAND &optional REMOTE)

Documentation
Search for COMMAND in exec-path and return the absolute file name.

Return nil if COMMAND is not found anywhere in exec-path.  If
REMOTE is non-nil, search on the remote host indicated by
default-directory instead.
```