### PR TITLE
Descriptions from prefix keys are displayed in counsel-org-capture.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3844,7 +3844,7 @@ include attachments of other Org buffers."
                                     org-capture-templates-contexts)
                                    '(("t" "Task" entry (file+headline "" "Tasks")
                                       "* TODO %?\n  %u\n  %a")))
-                               messages)
+                               (reverse messages))
                       (let ((x-keys (nth 0 x)))
                         ;; Remove prefixed keys until we get one that matches the current item x.
                         (while (and prefixes

--- a/counsel.el
+++ b/counsel.el
@@ -3835,32 +3835,32 @@ include attachments of other Org buffers."
   (interactive)
   (require 'org-capture)
   (ivy-read "Capture template: "
-            (delq nil
-                  (let (messages prefixes)
-                    ;; We build the list of capture templates as in
-                    ;; `org-capture-select-template':
-                    (dolist (x (or (org-contextualize-keys
-                                    (org-capture-upgrade-templates org-capture-templates)
-                                    org-capture-templates-contexts)
-                                   '(("t" "Task" entry (file+headline "" "Tasks")
-                                      "* TODO %?\n  %u\n  %a")))
-                               (reverse messages))
-                      (let ((x-keys (nth 0 x)))
-                        ;; Remove prefixed keys until we get one that matches the current item x.
-                        (while (and prefixes
-                                    (let ((p1-keys (nth 0 (car prefixes))))
-                                      (or
-                                       (<= (length x-keys) (length p1-keys))
-                                       (not (string-equal (substring x-keys 0 (length p1-keys)) p1-keys)))))
-                          (pop prefixes))
-                        (if (> (length x) 2)
-                            (setq messages (cons (format "%-5s %s" x-keys
-                                                         (string-join
-                                                          (mapcar (lambda (x) (nth 1 x))
-                                                                  (reverse (cons x prefixes)))
-                                                          " | "))
-                                                 messages))
-                          (setq prefixes (cons x prefixes)))))))
+            ;; We build the list of capture templates as in
+            ;; `org-capture-select-template':
+            (reverse
+             (car
+              (cl-reduce
+               (lambda (mp x)
+                 (let ((x-keys (car x)))
+                   ;; Remove prefixed keys until we get one that matches the current item x.
+                   (while (and (cadr mp)
+                               (let ((p1-keys (caar (cadr mp))))
+                                 (or
+                                  (<= (length x-keys) (length p1-keys))
+                                  (not (string-prefix-p p1-keys x-keys)))))
+                     (pop (cadr mp)))
+                   (if (> (length x) 2)
+                       (let ((description (mapconcat #'cadr (reverse (cons x (cadr mp))) " | ")))
+                         (push (format "%-5s %s" x-keys description) (car mp)))
+                     (push x (cadr mp)))
+                   mp))
+               (delq nil
+                     (or (org-contextualize-keys
+                          (org-capture-upgrade-templates org-capture-templates)
+                          org-capture-templates-contexts)
+                         '(("t" "Task" entry (file+headline "" "Tasks")
+                            "* TODO %?\n  %u\n  %a"))))
+               :initial-value '(nil nil))))
             :require-match t
             :action (lambda (x)
                       (org-capture nil (car (split-string x))))


### PR DESCRIPTION
I like to organize my org capture templates using the prefix key system, but I also like being able to query using counsel. While the prefix keys were present in the displayed choices, the descriptions were not. 

This commit adds the descriptions by walking the prefix key hierarchy and appending the descriptions in the form "desc1 | desc2 | ... | descN | desc Template". 