### PR TITLE
ivy--restore-session: Add a caller

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1182,6 +1182,7 @@ If the text hasn't changed as a result, forward to `ivy-alt-done'."
                            ivy-text)
                        (ivy-read "Choose ivy session: "
                                  ivy--sessions
+                                 :caller 'ivy--restore-session
                                  :require-match t)))))
     (setq ivy-last (or (cdr (assq session ivy--sessions))
                        ivy-last)))


### PR DESCRIPTION
The sorting that the external package `ivy-prescient` applies does not
work well with `ivy--restore-session`. With a `:caller`, users can tell
`ivy-prescient-mode` to let `ivy` alone take care of things.