### PR TITLE
Encode --pcre switch correctly for ivy-occur

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -3063,10 +3063,11 @@ Works for `counsel-git-grep', `counsel-ag', etc."
               (funcall cmd-template ivy-text)
             (let* ((command-args (counsel--split-command-args ivy-text))
                    (regex (counsel--grep-regex (cdr command-args)))
+                   (extra-switches (counsel--ag-extra-switches regex))
                    (all-args (append
                               (when (car command-args)
                                 (split-string (car command-args)))
-                              (when-let ((extra-switches (counsel--ag-extra-switches regex)))
+                              (when extra-switches
                                 (split-string extra-switches))
                               (list
                                (counsel--grep-smart-case-flag)

--- a/counsel.el
+++ b/counsel.el
@@ -3066,7 +3066,8 @@ Works for `counsel-git-grep', `counsel-ag', etc."
                    (all-args (append
                               (when (car command-args)
                                 (split-string (car command-args)))
-                              (counsel--ag-extra-switches regex)
+                              (when-let ((extra-switches (counsel--ag-extra-switches regex)))
+                                (split-string extra-switches))
                               (list
                                (counsel--grep-smart-case-flag)
                                regex))))


### PR DESCRIPTION
This fixes the way the `--pcre2` switch is appended when using a PCRE expression for ivy-occur.

# Reproduction Steps
1. Run `counsel-rg` with input `"foo bar"`
2. Execute `ivy-occur` on the text
3. Error thrown

```
Debugger entered--Lisp error: (wrong-type-argument stringp 32)
  call-process("rg" nil (t "/var/folders/gr/n1_1kt5126dbgmjjzwm44nf00000gn/T/emacsIa9u2e") nil "-M" "240" "--with-filename" "--no-heading" "--line-number" "--color" "never" 32 45 45 112 99 114 101 50 32 "-i" "^(?=.*foo)(?=.*bar)")
```

It appears the flag ` --pcre ` is accidentally encoded as `32 45 45 112 99 114 101 50 32`

Fixes #2635