### PR TITLE
ivy-switch-buffer: downrank current buffer

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4460,7 +4460,11 @@ Skip buffers that match `ivy-ignore-buffers'."
                  (string-match-p regexp (buffer-local-value 'default-directory b))
                  (not (string-match-p "^\\*" s)))))
         candidates))
-    (let ((res (ivy--re-filter regexp candidates)))
+    (let ((res (ivy--re-filter regexp candidates))
+          (buf-name (buffer-name)))
+      ;; Downrank our current buffer to end of res, if present.
+      (when (and buf-name (member buf-name res))
+        (setq res (nconc (delete buf-name res) (list buf-name))))
       (if (or (null ivy-use-ignore)
               (null ivy-ignore-buffers))
           res


### PR DESCRIPTION
When switching buffers, move the current buffer's entry to the end of
the candidate list. You probably don't want to switch to the buffer
you already have open.

Fixes #1500.