### PR TITLE
swiper: fix minibuffer highlighter selection

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2235,8 +2235,11 @@ This is useful for recursive `ivy-read'."
     (setq ivy-use-ignore ivy-use-ignore-default)
     (setf (ivy-state-ignore state) ivy-use-ignore)
     (setq ivy--highlight-function
-          (or (cdr (assq ivy--regex-function ivy-highlight-functions-alist))
-              #'ivy--highlight-default))
+          (let ((re-builder (if (eq caller 'swiper)
+                                (ivy-alist-setting ivy-re-builders-alist)
+                              ivy--regex-function)))
+            (or (cdr (assq re-builder ivy-highlight-functions-alist))
+                #'ivy--highlight-default)))
     (let ((ivy-recursive-restore nil)
           coll sort-fn)
       (cond ((eq collection #'Info-read-node-name-1)


### PR DESCRIPTION
The highlight function is picked by looking at the
ivy--regex-function, but swiper sets its own regex builder function
swiper--re-builder which always results in ivy--highlight-default
being chosen. Add a special case to ivy-read so it uses the user's
configured re builder to look up the highlighting function instead of
trying to look it up based on the swiper--re-builder builder. In
particular, this fixes minibuffer multi part highlighting for
ivy--regex-ignore-order builder.

After 33fa992aebe9605a3130d221543a232dafce5ab9 swiper doesn't mess
around with the regex builder output as much, so the
"ivy--regex-ignore-order" builder output is passed along and seems to
work properly with its highlighter.

Fixes #2167.