### PR TITLE
Fix counsel-find-file's alt-done-fn

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2013,7 +2013,8 @@ When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
 
 (ivy-configure 'counsel-find-file
   :parent 'read-file-name-internal
-  :occur #'counsel-find-file-occur)
+  :occur #'counsel-find-file-occur
+  :alt-done-fn #'ivy--directory-done)
 
 (defvar counsel-find-file-occur-cmd "ls -a | %s | xargs -d '\\n' ls -d --group-directories-first"
   "Format string for `counsel-find-file-occur'.")


### PR DESCRIPTION
This should be ivy--directory-done so you can continue into
directories instead of opening in dired.