### PR TITLE
Abbreviate paths in counsel-buffer-or-recentf-candidates

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2389,7 +2389,7 @@ This function uses the `dom' library from Emacs 25.1 or later."
          (delq nil
                (mapcar (lambda (b)
                          (when (buffer-file-name b)
-                           (buffer-file-name b)))
+                           (abbreviate-file-name (buffer-file-name b))))
                        (buffer-list)))))
     (append
      buffers


### PR DESCRIPTION
Abbreviate paths of open buffers in counsel-buffer-or-recentf-candidates to prevent duplicated entries in the list, since the values returned by counsel-recentf-candidates (which are taken from recentf-list) are abbreviated.

With the current behavior, you get both the abbreviated and non-abbreviated versions of the filename in the list, like this:
<img width="388" alt="Screen Shot 2020-09-30 at 15 39 03" src="https://user-images.githubusercontent.com/32876/94692685-18d8aa00-0333-11eb-8489-0773c879e7b8.png">
