### PR TITLE
Call isearch-filter-predicate instead of isearch-range-invisible

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1,6 +1,6 @@
 ;;; swiper.el --- Isearch with an overview. Oh, man! -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2019  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2020  Free Software Foundation, Inc.
 
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/swiper
@@ -964,8 +964,9 @@ the face, window and priority of the overlay."
                     (setq swiper--current-line num))
                   (when (re-search-forward re (line-end-position) t)
                     (setq swiper--current-match-start (match-beginning 0))))
-                (isearch-range-invisible (line-beginning-position)
-                                         (line-end-position))
+                (funcall isearch-filter-predicate
+                         (line-beginning-position)
+                         (line-end-position))
                 (swiper--maybe-recenter)))
             (swiper--add-overlays
              re
@@ -1214,8 +1215,9 @@ otherwise continue prompting for buffers."
           (re-search-forward
            (ivy--regex ivy-text)
            (line-end-position) t)
-          (isearch-range-invisible (line-beginning-position)
-                                   (line-end-position))
+          (funcall isearch-filter-predicate
+                   (line-beginning-position)
+                   (line-end-position))
           (unless (eq ivy-exit 'done)
             (swiper--cleanup)
             (swiper--add-overlays (ivy--regex ivy-text))))))))
@@ -1338,8 +1340,9 @@ See `ivy-format-functions-alist' for further information."
         (with-ivy-window
           (switch-to-buffer buffer-name)
           (goto-char (get-text-property 0 'point x))
-          (isearch-range-invisible (line-beginning-position)
-                                   (line-end-position))
+          (funcall isearch-filter-predicate
+                   (line-beginning-position)
+                   (line-end-position))
           (unless (eq ivy-exit 'done)
             (swiper--cleanup)
             (swiper--add-overlays (ivy--regex ivy-text))))))))
@@ -1483,7 +1486,7 @@ that we search only for one character."
                             (eq last-command 'ivy-previous-line-or-history)))
                    (looking-back ivy-regex (line-beginning-position)))
           (goto-char (match-beginning 0)))
-        (isearch-range-invisible (point) (1+ (point)))
+        (funcall isearch-filter-predicate (point) (1+ (point)))
         (swiper--maybe-recenter)
         (if (eq ivy-exit 'done)
             (progn


### PR DESCRIPTION
```
When `isearch' itself is being used, then a major-mode can change the
value of variable `isearch-filter-predicate' to control how `isearch'
determines whether a certain range of text is visible already and how
to make it visible otherwise.

While `swiper' relies on `isearch' to deal with invisible text, it
bypasses this variable causing major-modes to lose control over how
this is done.

The default value of this variable is `isearch-filter-visible', which
in turn calls `isearch-range-invisible'.  However it does not do so
unconditionally:

  (defun isearch-filter-visible (beg end)
    "Return non-nil if text between BEG and END is deemed visible by Isearch.
  This function is intended to be used as `isearch-filter-predicate'.
  It returns non-nil if the text between BEG and END is visible to
  Isearch, at least partially, as determined by `isearch-range-invisible'.
  If `search-invisible' is t, which allows Isearch matches inside
  invisible text, this function will always return non-nil, regardless
  of what `isearch-range-invisible' says."
    (or (eq search-invisible t)
        (not (isearch-range-invisible beg end))))

The reason why `swiper' instead calls `isearch-range-invisible'
directly probably is that we concluded that we should make sure that
text is always made visible.  That is the wrong conclusion for a few
reasons, not least that it achieves the opposite in some cases.

If `search-invisible' is non-nil, then that means that "search" should
not skip over invisible text.  If it is `open' then that means that
"search" itself should take care of making that text visible.

A value of t means that "search" should forgo making the text visible.
Enabling `reveal-mode' or `global-reveal-mode' sets `search-invisible'
to t, because these modes themselves take care of making text visible
if necessary.

Respecting `isearch-filter-predicate' is less likely to break
anything, then it is to ignore the wishes of major-modes, which
provide their own implementation because they know that the default
implementation won't work for them.
```