### PR TITLE
`ivy-update-candidates': support alists

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3994,7 +3994,8 @@ in this case."
 
 (defun ivy--format-minibuffer-line (str)
   "Format line STR for use in minibuffer."
-  (let* ((str (ivy-cleanup-string (copy-sequence str)))
+  (let* ((str (if (consp str) (car str) str))
+         (str (ivy-cleanup-string (copy-sequence str)))
          (str (if (eq ivy-display-style 'fancy)
                   (if (memq (ivy-state-caller ivy-last)
                             ivy-highlight-grep-commands)


### PR DESCRIPTION
Elements of CANDS are eventually passed trough to `ivy--format-minibuffer-line`,
which errors out as it expects a string, not conses. Modify it to accept conses,
rendering their `car`.

Fixes #2715.