### PR TITLE
counsel.el (counsel-git-grep-switch-cmd): allow recursive minibuffer

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1576,14 +1576,15 @@ When CMD is non-nil, prompt for a specific \"git grep\" command."
 (defun counsel-git-grep-switch-cmd ()
   "Set `counsel-git-grep-cmd' to a different value."
   (interactive)
-  (setq counsel-git-grep-cmd
-        (ivy-read "cmd: " counsel-git-grep-cmd-history
-                  :history 'counsel-git-grep-cmd-history))
-  (setq counsel-git-grep-cmd-history
-        (delete-dups counsel-git-grep-cmd-history))
-  (unless (ivy-state-dynamic-collection ivy-last)
-    (setq ivy--all-candidates
-          (all-completions "" 'counsel-git-grep-function))))
+  (let ((enable-recursive-minibuffers t))
+    (setq counsel-git-grep-cmd
+          (ivy-read "cmd: " counsel-git-grep-cmd-history
+                    :history 'counsel-git-grep-cmd-history))
+    (setq counsel-git-grep-cmd-history
+          (delete-dups counsel-git-grep-cmd-history))
+    (unless (ivy-state-dynamic-collection ivy-last)
+      (setq ivy--all-candidates
+            (all-completions "" 'counsel-git-grep-function)))))
 
 (defun counsel--normalize-grep-match (str)
   ;; Prepend ./ if necessary:


### PR DESCRIPTION
Fixes #2720.

Locally sets `enable-recursive-minibuffers` so that if this is not set in the user's environment, it won't cause an error when attempting to configure the `git-grep` command.