### PR TITLE
`counsel-find-file': open file in foreground

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1986,15 +1986,14 @@ Skip some dotfiles unless `ivy-text' requires them."
 
 (defun counsel-find-file-action (x)
   "Find file X."
-  (with-ivy-window
-    (cond ((and counsel-find-file-speedup-remote
-                (file-remote-p ivy--directory))
-           (let ((find-file-hook nil))
-             (find-file (expand-file-name x ivy--directory))))
-          ((member (file-name-extension x) counsel-find-file-extern-extensions)
-           (counsel-find-file-extern x))
-          (t
-           (find-file (expand-file-name x ivy--directory))))))
+  (cond ((and counsel-find-file-speedup-remote
+              (file-remote-p ivy--directory))
+         (let ((find-file-hook nil))
+           (find-file (expand-file-name x ivy--directory))))
+        ((member (file-name-extension x) counsel-find-file-extern-extensions)
+         (counsel-find-file-extern x))
+        (t
+         (find-file (expand-file-name x ivy--directory)))))
 
 (defun counsel--preselect-file ()
   "Return candidate to preselect during filename completion.


### PR DESCRIPTION
`counsel-find-file-action` calls `find-file` wrapped in `with-ivy-window`, which
causes the file to be opened in the `ivy` window, which is destroyed
afterwards. This causes the file to be opened in the background. Wrap the body
in `with-ivy-window`, since that isn't needed, fixing the bug.
