### PR TITLE
Adding functionality for switching between counsel-file-jump and counsel-find-file

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2025,11 +2025,11 @@ The preselect behavior can be customized via user options
         buffer-file-name
         (file-name-nondirectory buffer-file-name))))
 
-(defun counsel--find-file-1 (prompt initial-input action caller &optional initial-directory)
+(defun counsel--find-file-1 (prompt initial-input action caller)
   (let ((default-directory
          (if (eq major-mode 'dired-mode)
              (dired-current-directory)
-           (or initial-directory default-directory))))
+           default-directory)))
     (ivy-read prompt #'read-file-name-internal
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input
@@ -2045,11 +2045,10 @@ The preselect behavior can be customized via user options
   "Forward to `find-file'.
 When INITIAL-INPUT is non-nil, use it in the minibuffer during completion."
   (interactive)
-  (counsel--find-file-1
-   "Find file: " initial-input
-   #'counsel-find-file-action
-   'counsel-find-file
-   initial-directory))
+  (let ((default-directory (or initial-directory default-directory)))
+    (counsel--find-file-1 "Find file: " initial-input
+                          #'counsel-find-file-action
+                          'counsel-find-file)))
 
 (ivy-configure 'counsel-find-file
   :parent 'read-file-name-internal

--- a/counsel.el
+++ b/counsel.el
@@ -2025,7 +2025,7 @@ The preselect behavior can be customized via user options
         buffer-file-name
         (file-name-nondirectory buffer-file-name))))
 
-(defun counsel--find-file-1 (prompt initial-input action caller initial-directory)
+(defun counsel--find-file-1 (prompt initial-input action caller &optional initial-directory)
   (let ((default-directory
           (if (eq major-mode 'dired-mode)
               (dired-current-directory)

--- a/counsel.el
+++ b/counsel.el
@@ -1812,25 +1812,11 @@ currently checked out."
     (define-key map [remap undo] 'counsel-find-file-undo)
     map))
 
-;;* File
-;;** `counsel-file-jump'
-(defvar counsel-file-jump-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "`") #'counsel-find-file-from-jump)
-    map)
-  "Key bindings to be used when in a file-jump minibuffer.")
-
 (defun counsel-file-jump-from-find ()
   "Switch to `counsel-file-jump' from `counsel-find-file'."
   (interactive)
   (ivy-quit-and-run
     (counsel-file-jump ivy-text (ivy-state-directory ivy-last))))
-
-(defun counsel-find-file-from-jump ()
-  "Switch to `counsel-find-file' from `counsel-file-jump'."
-  (interactive)
-  (ivy-quit-and-run
-    (counsel-find-file ivy-text (ivy-state-directory ivy-last))))
 
 (when (executable-find "git")
   (add-to-list 'ivy-ffap-url-functions 'counsel-github-url-p)
@@ -2858,6 +2844,18 @@ FZF-PROMPT, if non-nil, is passed as `ivy-read' prompt argument."
   :type '(repeat string))
 
 ;;** `counsel-file-jump'
+(defvar counsel-file-jump-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "`") #'counsel-find-file-from-jump)
+    map)
+  "Key bindings to be used when in a file-jump minibuffer.")
+
+(defun counsel-find-file-from-jump ()
+  "Switch to `counsel-find-file' from `counsel-file-jump'."
+  (interactive)
+  (ivy-quit-and-run
+    (counsel-find-file ivy-text (ivy-state-directory ivy-last))))
+
 ;;;###autoload
 (defun counsel-file-jump (&optional initial-input initial-directory)
   "Jump to a file below the current directory.

--- a/counsel.el
+++ b/counsel.el
@@ -1816,7 +1816,7 @@ currently checked out."
   "Switch to `counsel-file-jump' from `counsel-find-file'."
   (interactive)
   (ivy-quit-and-run
-    (counsel-file-jump ivy-text)))
+    (counsel-file-jump ivy-text (ivy-state-directory ivy-last))))
 
 (when (executable-find "git")
   (add-to-list 'ivy-ffap-url-functions 'counsel-github-url-p)

--- a/counsel.el
+++ b/counsel.el
@@ -1816,8 +1816,9 @@ currently checked out."
 ;;** `counsel-file-jump'
 (defvar counsel-file-jump-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "`") #'counsel-file-find-from-jump)
-    map))
+    (define-key map (kbd "`") #'counsel-find-file-from-jump)
+    map)
+  "Key bindings to be used when in a file-jump minibuffer.")
 
 (defun counsel-file-jump-from-find ()
   "Switch to `counsel-file-jump' from `counsel-find-file'."
@@ -1825,12 +1826,11 @@ currently checked out."
   (ivy-quit-and-run
     (counsel-file-jump ivy-text (ivy-state-directory ivy-last))))
 
-(defun counsel-file-find-from-jump ()
+(defun counsel-find-file-from-jump ()
   "Switch to `counsel-find-file' from `counsel-file-jump'."
   (interactive)
   (ivy-quit-and-run
-    (counsel-find-file ivy-text (ivy-state-directory ivy-last)))
-  )
+    (counsel-find-file ivy-text (ivy-state-directory ivy-last))))
 
 (when (executable-find "git")
   (add-to-list 'ivy-ffap-url-functions 'counsel-github-url-p)
@@ -2027,9 +2027,9 @@ The preselect behavior can be customized via user options
 
 (defun counsel--find-file-1 (prompt initial-input action caller &optional initial-directory)
   (let ((default-directory
-          (if (eq major-mode 'dired-mode)
-              (dired-current-directory)
-            (or initial-directory default-directory))))
+         (if (eq major-mode 'dired-mode)
+             (dired-current-directory)
+           (or initial-directory default-directory))))
     (ivy-read prompt #'read-file-name-internal
               :matcher #'counsel--find-file-matcher
               :initial-input initial-input


### PR DESCRIPTION
Please take a look at these changes. First, they allow the user to to open counsel-file-jump from whatever directory they are currently viewing in counsel-find-file. Second, they add functionality to jump back to counsel-find-file from counsel-file-jump. This supplies a simple, interactive way to browse through and search within directories.

I followed the pattern of existing code for my edits and have run
```
make compile
make deps
make test
make checkdoc
```
without errors.