### PR TITLE
ivy.el (ivy-occur-press): add regex for Windows path separator

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -5115,7 +5115,7 @@ EVENT gives the mouse position."
   (ivy--occur-press-update-window)
   (when (save-excursion
           (beginning-of-line)
-          (looking-at "\\(?:./\\|    \\)\\(.*\\)$"))
+          (looking-at "\\(?:.[/\\]\\|    \\)\\(.*\\)$"))
     (let* ((ivy-last ivy-occur-last)
            (ivy-text (ivy-state-text ivy-last))
            (str (buffer-substring


### PR DESCRIPTION
`ivy-occur-press` is not working in Windows using `counsel-rg` since the paths returned are using `\` as path separator instead of `/`.
For example
![image](https://user-images.githubusercontent.com/2631472/102359143-bfa81a80-3ff3-11eb-98c7-f29f81e011a5.png)

This change add regex for `\` as path separator into `ivy-occur-press` so it works and jump to correct position.