### PR TITLE
Percent-encode search query in counsel-search-action

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -6805,7 +6805,7 @@ We update it in the callback with `ivy-update-candidates'."
   (browse-url
    (concat
     (nth 2 (assoc counsel-search-engine counsel-search-engines-alist))
-    x)))
+    (url-hexify-string x))))
 
 (defun counsel-search ()
   "Ivy interface for dynamically querying a search engine."


### PR DESCRIPTION
I saw that `counsel-search` passes a string containing spaces to `browse-url`, which, at least on my MacBook, causes no browser tab to be opened.  Percent-encoding the URL makes it work, and should also prevent issues with special characters in the search query.