### PR TITLE
Add `counsel-kill-buffer'

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -6268,6 +6268,14 @@ in the current window."
  '(("x" counsel-open-buffer-file-externally "open externally")
    ("j" ivy--switch-buffer-other-window-action "other window")))
 
+(defun counsel-kill-buffer ()
+  "Kill a buffer interactively using `ivy'."
+  (interactive)
+  (ivy-read "Kill buffer: " #'internal-complete-buffer
+            :action #'ivy--kill-buffer-action
+            :matcher #'ivy--switch-buffer-matcher
+            :caller 'counsel-kill-buffer))
+
 ;;** `counsel-compile'
 (defvar counsel-compile-history nil
   "History for `counsel-compile'.


### PR DESCRIPTION
This way, a more convenient user-interface specifically to kill buffers can be
provided (`ivy-rich`, ...).


----

#