### PR TITLE
Use query-replace history in swiper-query-replace

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -206,24 +206,20 @@ If the input is empty, select the previous history element instead."
               (let* ((enable-recursive-minibuffers t)
                      (from (ivy-re-to-str ivy-regex))
                      (groups (number-sequence 1 ivy--subexps))
-                     (default
-                      (list
-                       (mapconcat (lambda (i) (format "\\%d" i)) groups " ")
-                       (format "\\,(concat %s)"
-                               (if (<= ivy--subexps 1)
-                                   "\\&"
-                                 (mapconcat
-                                  (lambda (i) (format "\\%d" i))
-                                  groups
-                                  " \" \" ")))))
+                     (hist (delq t (mapcar (lambda (elt)
+                                             (if (string-equal from (car elt))
+                                                 (cdr elt)
+                                               t))
+                                           query-replace-defaults)))
                      (to
                       (query-replace-compile-replacement
                        (ivy-read
-                        (format "Query replace %s with: " from) nil
-                        :def default
+                        (format "Query replace %s with: " from) hist
+                        :history query-replace-to-history-variable
                         :caller 'swiper-query-replace)
                        t)))
                 (swiper--cleanup)
+                (add-to-history 'query-replace-defaults (cons from to))
                 (ivy-exit-with-action
                  (lambda (_)
                    (with-ivy-window


### PR DESCRIPTION
Apparently it's not possible to resume a previous `swiper-query-replace` operartion, so I would like to propose the attached change.

The candidates in the `swiper-query-replace` prompt will be the previous replacement texts used for the given replacement subject. The history in that query will be the full history of replacement texts.

I frankly never understood what that old `:def` parameter in the `ivy-read` call is supposed to be telling me, and I removed it. If I'm missing something clever here, let me know :-).

Another idea, which I could work on if there is interest, would be to modify `swiper-query-replace` so that it also makes sense when called outside of swiper. This would be a variant of swiper where hitting `RET` asks for a replacement text instead of just exiting the search. This is closer to the usual `query-replace` and might feel more familiar to some people.