### PR TITLE
Fix #2663

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2156,7 +2156,7 @@ customizations apply to the current completion session."
                     (ivy-state-initial-input ivy-last)
                     (make-composed-keymap keymap ivy-minibuffer-map)
                     nil
-                    hist)
+                    (copy-tree hist))
                  (error
                   (unless (equal err '(error "Selecting deleted buffer"))
                     (signal (car err) (cdr err))))))


### PR DESCRIPTION
All right after some testing I found out we just need to `(setq history-add-new-input nil)` and no modifications to ivy--update-history. 

Ivy-read calls read-from-minibuffer which will add the selection to history if history-add-new-input is non-nil.

My issue is gone and the test are ok.

But now it will break some workflow like if someone prefer let's say find-file instead of counsel-find-file the history won't work. It's not really efficient but as a workaround instead of passing the real hist var to read-from-minibuffer we can pass a copy of it and so we can leave history-add-new-input as it is.
