### PR TITLE
counsel.el (counsel-ag-function): Extra switches override -i/-s

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2985,11 +2985,11 @@ NEEDLE is the search string."
        (ivy-more-chars))
      (let* ((default-directory (ivy-state-directory ivy-last))
             (regex (counsel--grep-regex search-term))
-            (switches (concat (car command-args)
-                              (counsel--ag-extra-switches regex)
-                              (if (ivy--case-fold-p string)
+            (switches (concat (if (ivy--case-fold-p string)
                                   " -i "
-                                " -s "))))
+                                " -s ")
+                              (counsel--ag-extra-switches regex)
+                              (car command-args))))
        (counsel--async-command (counsel--format-ag-command
                                 switches
                                 (funcall (if (listp counsel-ag-command) #'identity


### PR DESCRIPTION
At the moment, it is impossible to override `ivy--case-fold-p` by providing command-line switches to ag/rg.  This PR reorders the switches so that user-provided switches override any defaults.