### PR TITLE
counsel.el: Add counsel-info-apropos, counsel-info-manual-apropos.

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -508,6 +508,267 @@ Used by commands `counsel-describe-symbol',
       (ivy-append-face var 'ivy-highlight-face)
     var))
 
+;;** `counsel-info-apropos'
+(require 'generator)
+
+(defun counsel-info-apropos--manuals ()
+  "Calculate all known info manuals using fresh buffer `BUF'."
+  (require 'info)
+  (when (null Info-directory-list) (info-initialize))
+  (with-temp-buffer
+    (let ((Info-fontify-maximum-menu-size nil)
+          (ohist Info-history)
+          (ohist-list Info-history-list)
+          (manuals '()))
+      (Info-mode)
+      (Info-find-node-2 "dir" "top")
+      (goto-char (point-min))
+      (re-search-forward "\\* Menu: *\n" nil t)
+      (while (re-search-forward "\\*.*: *(\\([^)]+\\))" nil t)
+        (cl-pushnew (match-string 1) manuals :test #'equal))
+      (setq Info-history ohist
+            Info-history-list ohist-list)
+      manuals)))
+
+(defun counsel-info-manual--buffer-name (manual)
+  "Name of the `COUNSEL-INFO-APROPOS-FOR-MANUAL' for `MANUAL'."
+  (format "*counsel-info-node-search-%s*" manual))
+
+(iter-defun counsel-info-manual--matches (manual pat)
+  "Calculate all nodes in `MANUAL' matching `PAT'."
+  (require 'info)
+  (let ((pattern (format "\n\\* +\\([^\n]*\\(%s\\)[^\n]*\\):[ \t]+\\([^\n]+\\)\\.\\(?:[ \t\n]*(line +\\([0-9]+\\))\\)?"
+                         pat))
+        (buf (get-buffer-create
+              (counsel-info-manual--buffer-name manual)))
+        (obuf (current-buffer))
+        (opoint (point))
+        (ohist Info-history)
+        (ohist-list Info-history-list)
+        (Info-fontify-maximum-menu-size nil)
+        node nodes)
+    (set-buffer buf)
+    (Info-mode)
+    (goto-char (point-min))
+    (condition-case err
+        (if (setq nodes (Info-index-nodes (Info-find-file manual)))
+            (let ((inner-buf (current-buffer))
+                  (inner-point (point))
+                  (current-node Info-current-node)
+                  (current-file Info-current-file))
+              (Info-find-node manual (car nodes))
+              (while
+                  (progn
+                    (goto-char (point-min))
+                    (while (progn
+                             (set-buffer inner-buf)
+                             (goto-char inner-point)
+                             (re-search-forward pattern nil t))
+                      (let ((entry (match-string-no-properties 1))
+                            (nodename (match-string-no-properties 3))
+                            (line (match-string-no-properties 4)))
+                        (add-text-properties
+                         (- (match-beginning 2) (match-beginning 1))
+                         (- (match-end 2) (match-beginning 1))
+                         '(face info-index-match) entry)
+                        (setq inner-buf (current-buffer)
+                              inner-point (point))
+                        (set-buffer obuf)
+                        (iter-yield (list manual entry nodename line))))
+                    (setq nodes (cdr nodes) node (car nodes)))
+                (progn (Info-goto-node node)
+                       (setq current-node Info-current-node
+                             current-file Info-current-file)))))
+      (error
+       (setq Info-history ohist
+             Info-history-list ohist-list)
+       (set-buffer obuf)
+       (goto-char opoint)
+       (message "%s" (if (eq (car-safe err) 'error)
+                         (nth 1 err) err))
+       (sit-for 1 t)))
+    (kill-buffer buf)))
+
+(defun counsel-info-apropos--format-candidate (node)
+  "Format `NODE' for display in `COUNSEL-INFO-NODE-FOR-MANUAL'."
+  (pcase node
+    (`(,manual ,entry ,nodename ,_)
+     (format "(%s)%s -- %s" manual nodename entry))))
+
+(defun counsel-info-apropos--node-match-p (node)
+  "Match `NODE' with `RE' or `IVY-REGEX', predicate only."
+  (string-match (ivy-re-to-str ivy-regex)
+                (counsel-info-apropos--format-candidate node)))
+
+(defvar counsel-info-apropos-timer nil
+  "A timer used to collect info nodes in the background.")
+
+(cl-defstruct counsel-info-apropos-state
+  "Holds the current state of `COUNSEL-INFO-APROPOS'."
+  (nodes (make-vector 0 nil))
+  iter)
+
+(defun counsel-info-apropos--set-candidates (state candidates)
+  "Add `CANDIDATES' to `COUNSEL-INFO-APROPOS-STATE-NODES' nodes in `STATE'.
+
+Setup ivy apropriately."
+  (require 'seq)
+  (setf (counsel-info-apropos-state-nodes state)
+        (vconcat (counsel-info-apropos-state-nodes state) candidates))
+  (ivy--set-candidates
+   (seq-filter #'counsel-info-apropos--node-match-p
+               (counsel-info-apropos-state-nodes state)))
+  (ivy--insert-minibuffer (ivy--format ivy--all-candidates)))
+
+(defun counsel-info-apropos--collect-entries (state &key chunks-of)
+  "Collect `CHUNKS-OF' entries or until done and append to `STATE' nodes.
+
+Set the ivy collection accordingly."
+  (require 'seq)
+  (let ((node-iter (counsel-info-apropos-state-iter state))
+        (buffer (make-vector chunks-of nil))
+        (i 0))
+    (condition-case _
+        (let ((node (iter-next node-iter)))
+          (while (< i chunks-of)
+            (aset buffer i node)
+            (setq node (iter-next node-iter)
+                  i (1+ i)))
+          (counsel-info-apropos--set-candidates state buffer)
+          'continue)
+      (iter-end-of-sequence
+       (progn
+         (counsel-info-apropos--set-candidates
+          state (if (eq i chunks-of)
+                    buffer
+                  (apply #'vector (seq-filter #'identity buffer))))
+         'done)))))
+
+(defun counsel-info-apropos--start-timer (state k)
+  "Start collecting nodes from `NODE-ITER' into `STATE'.
+
+Run `K' when done."
+  (let ((timer-fn
+         (lambda ()
+           (with-local-quit
+             (pcase (counsel-info-apropos--collect-entries
+                     state :chunks-of 50)
+               ('continue (counsel-info-apropos--start-timer state k))
+               ('done (funcall k)))))))
+    (setq counsel-info-apropos-timer
+          (run-at-time (/ 4 1000.0) nil timer-fn))))
+
+(defun counsel-info-manual-apropos--handle-input (state)
+  "Set ivy candidates according to `STATE'."
+  (lambda (_)
+    (or (ivy-more-chars)
+        (seq-filter #'counsel-info-apropos--node-match-p
+                    (counsel-info-apropos-state-nodes state)))))
+
+(defun counsel-info-apropos--goto-selection (selection)
+  "Go to `SELECTION' from `COUNSEL-INFO-APROPOS' variants."
+  (require 'info)
+  (pcase selection
+    (`(,manual ,_ ,nodename ,line)
+     (Info-find-node (Info-find-file manual) nodename)
+     (forward-line (string-to-number line)))))
+
+(defun counsel-info-apropos--cleanup-buffer-for-manual (manual)
+  "Remove search buffer for `MANUAL' if it still exists."
+  (when-let ((search-buf
+              (get-buffer (counsel-info-manual--buffer-name manual))))
+    (kill-buffer search-buf)))
+
+(defun counsel-info-apropos--cleanup-timer ()
+  "Cancels any more timers for `COUNSEL-INFO-APROPOS' variants."
+  (when counsel-info-apropos-timer
+    (cancel-timer counsel-info-apropos-timer)))
+
+;;;###autoload
+(defun counsel-info-apropos-for-manual (manual)
+  "Search for an Info symbol in `MANUAL'."
+  (interactive "sManual: ")
+  (require 'seq)
+  (require 'info)
+
+  (unless (seq-contains-p (counsel-info-apropos--manuals) manual #'equal)
+    (user-error "Manual not found: %s" manual))
+  (cl-letf (((symbol-function 'ivy--dynamic-collection-cands)
+             (lambda (input)
+               (funcall (ivy-state-collection ivy-last) input))))
+    (let* ((ivy-dynamic-exhibit-delay-ms 2)
+           (gc-cons-threshold (* 1000 1000 1000 8))
+           (state (make-counsel-info-apropos-state
+                   :iter (counsel-info-manual--matches manual ".*?"))))
+      (counsel-info-apropos--start-timer
+       state (lambda () (message "Done searching manual: %s" manual)))
+      (ivy-read "Node: " (counsel-info-manual-apropos--handle-input state)
+                :dynamic-collection t
+                :action (lambda (selection)
+                          (if (listp selection)
+                              (counsel-info-apropos--goto-selection selection)
+                            (Info-find-node (Info-find-file manual) "top")))
+                :unwind (lambda ()
+                          (counsel-info-apropos--cleanup-buffer-for-manual manual)
+                          (counsel-info-apropos--cleanup-timer))
+                :caller 'counsel-info-apropos-for-manual))))
+
+(ivy-configure 'counsel-info-apropos-for-manual
+  :display-transformer-fn #'counsel-info-apropos--format-candidate)
+
+;;;###autoload
+(defun counsel-info-manual-apropos ()
+  "Ivy complete an Info manual then nodes in that manual."
+  (interactive)
+  (ivy-read "Manual: " (sort (counsel-info-apropos--manuals) #'string<)
+            :action #'counsel-info-apropos-for-manual
+            :require-match t
+            :caller 'my-counsel-info-manual-apropos))
+
+(iter-defun counsel-info-apropos--matches (manuals pat)
+  "Generator that yields all entries in all `MANUALS'."
+  (dolist (manual manuals)
+    (iter-do (node (counsel-info-manual--matches manual pat))
+      (iter-yield node))
+    (message "Done searching manual: %s" manual))
+  (signal 'iter-end-of-sequence nil))
+
+;;;###autoload
+(defun counsel-info-apropos ()
+  "Search for an Info symbol in all manuals.
+
+If you would rather search in one manual only, use
+`COUNSEL-INFO-MANUAL-APROPOS'."
+  (interactive)
+  (require 'seq)
+  (cl-letf (((symbol-function 'ivy--dynamic-collection-cands)
+             (lambda (input)
+               (funcall (ivy-state-collection ivy-last) input))))
+    (let* ((ivy-dynamic-exhibit-delay-ms 2)
+           (gc-cons-threshold (* 1000 1000 1000 8))
+           (manuals (sort (counsel-info-apropos--manuals) #'string<))
+           (cleanup (lambda ()
+                      (seq-do #'counsel-info-apropos--cleanup-buffer-for-manual manuals)
+                      (counsel-info-apropos--cleanup-timer))))
+      (ivy-read "Node: "
+                (lambda (in)
+                  (or (ivy-more-chars)
+                      (let ((state (make-counsel-info-apropos-state
+                                    :iter (counsel-info-apropos--matches
+                                           manuals (regexp-quote in)))))
+                        (funcall cleanup)
+                        (counsel-info-apropos--start-timer
+                         state (lambda () "Done searching for: %s" in))
+                        '())))
+                :dynamic-collection t
+                :require-match t
+                :action #'counsel-info-apropos--goto-selection
+                :unwind cleanup
+                :caller 'counsel-info-apropos))))
+
+(ivy-configure 'counsel-info-apropos
+  :display-transformer-fn #'counsel-info-apropos--format-candidate)
+
 ;;;###autoload
 (defun counsel-describe-variable ()
   "Forward to `describe-variable'.


### PR DESCRIPTION
This is a working draft pull request that fixes some issues I have with the discoverability of Info in Emacs.  I have wanted a way to use ivy to search info pages that did not rely on `info-look` since it often searches a manual that I am not interested in.  The PR adds two new major commands, `counsel-info-apropos` and `counsel-info-manual-apropos`.  The former is a more direct replacement for `info-apropos` and the latter lets you choose a manual and narrow results from there.

These functions augment info-apropos to with an ivy interface.
counsel-info-apropos will search just like info-apropos but with a
dynamic-collection that searches again each time the input is changed.
counsel-info-apropos-for collects all entries for a manual that can be
narrowed with ivy.  Both use a timer and generator to keep the
minibuffer input fast and responsive.

* counsel.el (counsel-info-apropos--manuals): New function to get all
known manuals.
* counsel.el (counsel-info-manual--buffer-name): New function to
compute the temp buffer name used to search an Info manual.
* counsel.el (counsel-info-manual--matches): New generator to search
all entries in a manual.
* counsel.el (counsel-info-apropos--format-candidate): New function to
format candidates of counsel-info-apropos and
counsel-info-apropos-for-manual.
* counsel.el (counsel-info-apropos--node-match-p): New predicate to
check if a candidate Info entry matches the search criteria.
* counsel.el (counsel-info-apropos-timer): New variable that stores
the timer used to collect Info entries.
* counsel.el (counsel-info-apropos-state): New struct type to hold
buffer and iterator for Info searches.
* counsel.el (counsel-info-apropos--set-candidates): New function to
set ivy-candidates and update counsel-info-apropos-state.
* counsel.el (counsel-info-apropos--start-timer): New function to
start a timer that collects Info search results.
* counsel.el (counsel-info-manual-apropos--handle-input): New function
to handle input for counsel-info-manual-apropos.
* counsel.el (counsel-info-apropos--goto-selection): New function to
jump to a search result as the :action of counsel-info-apropos and
counsel-info-manual-apropos.
* counsel.el (counsel-info-apropos--cleanup-buffer-for-manual): New
function to cleanup counsel-info-apropos search buffers.
* counsel.el (counsel-info-apropos--cleanup-timer): New function to
cleanup timer for collecting search results.
* counsel.el (counsel-info-apropos-for-manual): New command to search
all entries in a manual.
* counsel.el (counsel-info-manual-apropos): New command to select an
Info manual and then search all entries in the manual.
* counsel.el (counsel-info-apropos--matches): New iterator to search
all Info manuals for a pattern.
* counsel.el (counsel-info-apropos): New command to add an ivy
interface to info-apropos.