### PR TITLE
ivy--set-candidate: always dedup candidates

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3568,10 +3568,7 @@ CANDIDATES are assumed to be static."
         (setq res (append
                    (ivy--filter ivy-text (cadr source))
                    res))))
-    (setq ivy--all-candidates
-          (if (cdr ivy--extra-candidates)
-              (delete-dups res)
-            res))))
+    (setq ivy--all-candidates (delete-dups res))))
 
 (defun ivy--shorter-matches-first (_name cands)
   "Sort CANDS according to their length."


### PR DESCRIPTION
It seems that `completing-read` is de-duplicates entries in collection but `ivy-read` is not.
![image](https://user-images.githubusercontent.com/2631472/109416523-1d001500-7a02-11eb-9a2a-171d89617ab1.png)
![image](https://user-images.githubusercontent.com/2631472/109416540-34d79900-7a02-11eb-835a-6fbb58e7d8ad.png)

This PR is trying to match `ivy-read` behavior with `completing-read`