### PR TITLE
Bind "M-C" to `ivy-toggle-case-fold`.

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -1041,6 +1041,9 @@ bindings that work here:
 
      Switch to matching literally since file names include =.=, which
      is for matching any char in regexp mode.
+- ~M-C~ (=ivy-toggle-case-fold=) ::
+     Toggle case folding (match both upper and lower case characters for lower
+     case input).
 
 - User Option =ivy-extra-directories= ::
      Decide if you want to see =../= and =./= during file name

--- a/doc/ivy.texi
+++ b/doc/ivy.texi
@@ -1382,6 +1382,13 @@ Toggle between input as regexp or not.
 Switch to matching literally since file names include @code{.}, which
 is for matching any char in regexp mode.
 @end indentedblock
+@subsubheading @kbd{M-C} (@code{ivy-toggle-case-fold})
+@vindex ivy-toggle-case-fold
+@kindex M-C
+@indentedblock
+Toggle case folding (match both upper and lower case
+characters for lower case input).
+@end indentedblock
 @defopt ivy-extra-directories
 Decide if you want to see @code{../} and @code{./} during file name
 completion.

--- a/ivy.el
+++ b/ivy.el
@@ -343,6 +343,7 @@ Remove DEF from `counsel-M-x' list."
     (ivy-define-key map (kbd "C-M-p") 'ivy-previous-line-and-call)
     (ivy-define-key map (kbd "M-a") 'ivy-toggle-marks)
     (ivy-define-key map (kbd "M-r") 'ivy-toggle-regexp-quote)
+    (ivy-define-key map (kbd "M-C") 'ivy-toggle-case-fold)
     (ivy-define-key map (kbd "M-j") 'ivy-yank-word)
     (ivy-define-key map (kbd "M-i") 'ivy-insert-current)
     (ivy-define-key map (kbd "C-M-y") 'ivy-insert-current-full)


### PR DESCRIPTION
Although "M-C" doesn't work in the terminal, I think it's a nice convenience for GUI users because toggling case folding is trivial enough to not calling `ivy-hydra`.

"M-c" maybe more preferable, since Emacs' vanilla `isearch` uses it as well as many other popular editors do, but it may break workflows of some existing users.