### PR TITLE
delete-selection-mode for counsel-yank-pop

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4570,6 +4570,8 @@ Note: Duplicate elements of `kill-ring' are always deleted."
               :action #'counsel-yank-pop-action
               :caller 'counsel-yank-pop)))
 
+(put #'counsel-yank-pop 'delete-selection 'yank)
+
 (ivy-configure 'counsel-yank-pop
   :height 5
   :format-fn #'counsel--yank-pop-format-function)


### PR DESCRIPTION
Hi M.abo and M.conto

delete-selection-mode ... well, delete the active region before some
commands, Notably the yank command.

This commit makes it aware of counsel-yank-pop without any further
action from the user (if he is lucky enough to have activated
delete-selection-mode before installing counsel ?).