### PR TITLE
completion--done should recieve 'finished if completion is done

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2520,7 +2520,9 @@ The previous string is between `ivy-completion-beg' and `ivy-completion-end'."
         (delete-region beg end))
       (setq ivy-completion-beg (point))
       (insert (substring-no-properties str))
-      (completion--done str 'exact)
+      (completion--done str (if (eq ivy-exit 'done)
+                                'finished
+                              'exact))
       (setq ivy-completion-end (point))
       (save-excursion
         (dolist (cursor fake-cursors)


### PR DESCRIPTION
This one should fix #2345

Many modes that utilize `completion-at-point` use `:exit-function` to perform additional cleanup. However, they do so only when 'finished is passed to `:exit-function` as an argument.

In particular I get wrong completion results with `eglot` with some servers, since `eglot` uses `:exit-function` to do actual text insertion, [but only when 'finished is passed](https://github.com/joaotavora/eglot/blob/2fbcab293e11e1502a0128ca5f59de0ea7888a75/eglot.el#L2264)