### PR TITLE
Change "C-r" key in swiper-isearch.

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1536,10 +1536,19 @@ When not running `swiper-isearch' already, start it."
           (setq thing (ivy-thing-at-point))))
       (swiper-isearch thing))))
 
+(defun swiper-isearch-C-r (&optional arg)
+  "Move cursor vertically up ARG candidates.
+When the input is empty, browse the search history instead."
+  (interactive "p")
+  (if (string= ivy-text "")
+      (ivy-reverse-i-search)
+    (ivy-previous-line arg)))
+
 (defvar swiper-isearch-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map swiper-map)
     (define-key map (kbd "M-n") 'swiper-isearch-thing-at-point)
+    (define-key map (kbd "C-r") 'swiper-isearch-C-r)
     map)
   "Keymap for `swiper-isearch'.")
 


### PR DESCRIPTION
swiper-isearch-C-r: partially mimics vanilla `isearch`'s behaviours:
If the input is empty, search for previous history
Else move the previous match.

User who uses `swiper-isearch` typically expects `isearch-forward`-like behaviours: 
press "C-s" to move to the next match, "C-r" to the previous one,
but swiper/counsel/ivy in general bind "C-r" to `ivy-reverse-i-search` universally.