### PR TITLE
Fix find-file-ignore-regexp's "Ignored Extensions".

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1969,7 +1969,7 @@ but the leading dot is a lot faster."
           (const :tag "None" nil)
           (const :tag "Dotfiles and Lockfiles" "\\(?:\\`\\|[/\\]\\)\\(?:[#.]\\)")
           (const :tag "Ignored Extensions"
-                 ,(regexp-opt completion-ignored-extensions))
+                 ,(concat (regexp-opt completion-ignored-extensions) "\\'"))
           (regexp :tag "Regex")))
 
 (defvar counsel--find-file-predicate nil


### PR DESCRIPTION
Add "$" at the end of the regexp, since completion-ignored-extensions
are meant to be the last of the file name.
For example: it contains ".cp", which ignore "\.cpp$" files unless "$"
is added.