### PR TITLE
Add counsel-esh-dir-history

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4909,13 +4909,12 @@ directory to the Eshell buffer prefixed by \"cd \", allowing the
 caller to modify parts of the directory before switching to it."
   (ivy--action-insert (format "cd %s" (car pair))))
 
-(defvar eshell-last-dir-ring)
-
 ;;;###autoload
 (cl-defun counsel-esh-dir-history ()
   "Use Ivy to navigate and jump through Eshell's directory stack."
   (interactive)
   (require 'em-dirs)
+  (defvar eshell-last-dir-ring)
   (ivy-read "Directory to change to: " (ivy-history-contents eshell-last-dir-ring)
             :keymap ivy-reverse-i-search-map
             :action #'counsel--esh-dir-history-action-cd

--- a/counsel.el
+++ b/counsel.el
@@ -4820,6 +4820,39 @@ An extra action allows to switch to the process buffer."
                         (insert (substring-no-properties (car x))))
               :caller 'counsel-minibuffer-history)))
 
+;;** `counsel-esh-dir-history'
+(declare-function eshell/cd "em-dirs")
+
+(defun counsel--esh-dir-history-action-cd (pair)
+  "Change the current working directory to the selection.
+This function is the default action for `counsel-esh-dir-history'
+and changes the working directory in Eshell to the selected
+candidate which must be provided as the `car' of PAIR."
+  (eshell/cd (car pair)))
+
+(defun counsel--esh-dir-history-action-edit (pair)
+  "Insert the selection to the Eshell buffer prefixed by \"cd \".
+This function is an action for `counsel-esh-dir-history' to
+insert the selected directory (provided as the `car' of PAIR) to
+the Eshell buffer prefixed by \"cd \", allowing the caller to
+modify parts of the directory before switching to it."
+  (insert "cd " (car pair)))
+
+;;;###autoload
+(defun counsel-esh-dir-history ()
+  "Use Ivy to browse Eshell's directory stack."
+  (interactive)
+  (require 'em-dirs)
+  (defvar eshell-last-dir-ring)
+  (counsel--browse-history eshell-last-dir-ring
+                           :caller #'counsel-esh-dir-history
+                           :action #'counsel--esh-dir-history-action-cd
+                           :prompt "Directory to change to: "))
+
+(ivy-set-actions
+ 'counsel-esh-dir-history
+ '(("e" counsel--esh-dir-history-action-edit "edit")))
+
 ;;** `counsel-esh-history'
 (defvar comint-input-ring-index)
 (defvar eshell-history-index)
@@ -4898,39 +4931,6 @@ An extra action allows to switch to the process buffer."
   (require 'comint)
   (counsel--browse-history comint-input-ring
                            :caller #'counsel-shell-history))
-
-;;** `counsel-esh-dir-history'
-(declare-function eshell/cd "em-dirs")
-
-(defun counsel--esh-dir-history-action-cd (pair)
-  "Change the current working directory to the selection.
-This function is the default action for `counsel-esh-dir-history'
-and changes the working directory in Eshell to the selected
-candidate which must be provided as the `car' of PAIR."
-  (eshell/cd (car pair)))
-
-(defun counsel--esh-dir-history-action-edit (pair)
-  "Insert the selection to the Eshell buffer prefixed by \"cd \".
-This function is an action for `counsel-esh-dir-history' to
-insert the selected directory (provided as the `car' of PAIR) to
-the Eshell buffer prefixed by \"cd \", allowing the caller to
-modify parts of the directory before switching to it."
-  (insert "cd " (car pair)))
-
-;;;###autoload
-(defun counsel-esh-dir-history ()
-  "Use Ivy to browse Eshell's directory stack."
-  (interactive)
-  (require 'em-dirs)
-  (defvar eshell-last-dir-ring)
-  (counsel--browse-history eshell-last-dir-ring
-                           :caller #'counsel-esh-dir-history
-                           :action #'counsel--esh-dir-history-action-cd
-                           :prompt "Directory to change to: "))
-
-(ivy-set-actions
- 'counsel-esh-dir-history
- '(("e" counsel--esh-dir-history-action-edit "edit")))
 
 (defadvice comint-previous-matching-input (before
                                            counsel-set-comint-history-index

--- a/counsel.el
+++ b/counsel.el
@@ -4848,7 +4848,11 @@ An extra action allows to switch to the process buffer."
        nil))
     (ivy-completion-in-region-action (car pair))))
 
-(cl-defun counsel--browse-history (ring &key caller)
+(cl-defun counsel--browse-history (ring
+                                   &key
+                                     caller
+                                     (prompt "History: ")
+                                     (action #'counsel--browse-history-action))
   "Use Ivy to navigate through RING."
   (let* ((proc (get-buffer-process (current-buffer)))
          (end (point))
@@ -4859,10 +4863,10 @@ An extra action allows to switch to the process buffer."
                   (concat "^" (buffer-substring beg end)))))
     (setq ivy-completion-beg beg)
     (setq ivy-completion-end end)
-    (ivy-read "History: " (ivy-history-contents ring)
+    (ivy-read prompt (ivy-history-contents ring)
               :keymap ivy-reverse-i-search-map
               :initial-input input
-              :action #'counsel--browse-history-action
+              :action action
               :caller caller)))
 
 (defvar eshell-history-ring)
@@ -4919,10 +4923,10 @@ modify parts of the directory before switching to it."
   (interactive)
   (require 'em-dirs)
   (defvar eshell-last-dir-ring)
-  (ivy-read "Directory to change to: " (ivy-history-contents eshell-last-dir-ring)
-            :keymap ivy-reverse-i-search-map
-            :action #'counsel--esh-dir-history-action-cd
-            :caller #'counsel-esh-dir-history))
+  (counsel--browse-history eshell-last-dir-ring
+                           :caller #'counsel-esh-dir-history
+                           :action #'counsel--esh-dir-history-action-cd
+                           :prompt "Directory to change to: "))
 
 (ivy-set-actions
  'counsel-esh-dir-history

--- a/counsel.el
+++ b/counsel.el
@@ -4899,14 +4899,18 @@ An extra action allows to switch to the process buffer."
 (declare-function eshell/cd "em-dirs")
 
 (defun counsel--esh-dir-history-action-cd (pair)
-  "Default action for counsel-esh-dir-history. It changes the
-current working directory to the one selected by the user."
+  "Change the current working directory to the selection.
+This function is the default action for `counsel-esh-dir-history'
+and changes the working directory in Eshell to the selected
+candidate which must be provided as the `car' of PAIR."
   (eshell/cd (car pair)))
 
 (defun counsel--esh-dir-history-action-edit (pair)
-  "Action for counsel-esh-dir-history to insert the selected
-directory to the Eshell buffer prefixed by \"cd \", allowing the
-caller to modify parts of the directory before switching to it."
+  "Insert the selection to the Eshell buffer prefixed by \"cd \".
+This function is an action for `counsel-esh-dir-history' to
+insert the selected directory (provided as the `car' of PAIR) to
+the Eshell buffer prefixed by \"cd \", allowing the caller to
+modify parts of the directory before switching to it."
   (insert (format "cd %s" (car pair))))
 
 ;;;###autoload

--- a/counsel.el
+++ b/counsel.el
@@ -4846,8 +4846,8 @@ modify parts of the directory before switching to it."
   (defvar eshell-last-dir-ring)
   (counsel--browse-history eshell-last-dir-ring
                            :caller #'counsel-esh-dir-history
-                           :action #'counsel--esh-dir-history-action-cd
-                           :prompt "Directory to change to: "))
+                           :prompt "Directory to change to: "
+                           :action #'counsel--esh-dir-history-action-cd))
 
 (ivy-set-actions
  'counsel-esh-dir-history

--- a/counsel.el
+++ b/counsel.el
@@ -4911,7 +4911,7 @@ caller to modify parts of the directory before switching to it."
 
 ;;;###autoload
 (defun counsel-esh-dir-history ()
-  "Use Ivy to navigate and jump through Eshell's directory stack."
+  "Use Ivy to browse Eshell's directory stack."
   (interactive)
   (require 'em-dirs)
   (defvar eshell-last-dir-ring)

--- a/counsel.el
+++ b/counsel.el
@@ -4896,7 +4896,7 @@ An extra action allows to switch to the process buffer."
                            :caller #'counsel-shell-history))
 
 ;;** `counsel-esh-dir-history'
-(declare-function eshell/cd "eshell")
+(declare-function eshell/cd "em-dirs")
 
 (defun counsel--esh-dir-history-action-cd (pair)
   "Default action for counsel-esh-dir-history. It changes the

--- a/counsel.el
+++ b/counsel.el
@@ -4907,7 +4907,7 @@ current working directory to the one selected by the user."
   "Action for counsel-esh-dir-history to insert the selected
 directory to the Eshell buffer prefixed by \"cd \", allowing the
 caller to modify parts of the directory before switching to it."
-  (ivy--action-insert (format "cd %s" (car pair))))
+  (insert (format "cd %s" (car pair))))
 
 ;;;###autoload
 (defun counsel-esh-dir-history ()

--- a/counsel.el
+++ b/counsel.el
@@ -4910,7 +4910,7 @@ caller to modify parts of the directory before switching to it."
   (ivy--action-insert (format "cd %s" (car pair))))
 
 ;;;###autoload
-(cl-defun counsel-esh-dir-history ()
+(defun counsel-esh-dir-history ()
   "Use Ivy to navigate and jump through Eshell's directory stack."
   (interactive)
   (require 'em-dirs)

--- a/counsel.el
+++ b/counsel.el
@@ -4895,29 +4895,6 @@ An extra action allows to switch to the process buffer."
   (counsel--browse-history comint-input-ring
                            :caller #'counsel-shell-history))
 
-(defadvice comint-previous-matching-input (before
-                                           counsel-set-comint-history-index
-                                           activate)
-  "Reassign `comint-input-ring-index'."
-  (when (and (memq last-command '(ivy-alt-done ivy-done))
-             (equal (ivy-state-caller ivy-last) 'counsel-shell-history))
-    (setq comint-input-ring-index counsel-shell-history--index-last)))
-
-(defvar slime-repl-input-history)
-
-;;;###autoload
-(defun counsel-slime-repl-history ()
-  "Browse Slime REPL history."
-  (interactive)
-  (require 'slime-repl)
-  (counsel--browse-history slime-repl-input-history
-                           :caller #'counsel-slime-repl-history))
-
-;; TODO: add advice for slime-repl-input-previous/next to properly
-;; reassign the ring index and match string.  This requires a case for
-;; `counsel-slime-repl-history' within
-;; `counsel--browse-history-action'.
-
 ;;** `counsel-esh-dir-history'
 (declare-function eshell/cd "eshell")
 
@@ -4947,6 +4924,29 @@ caller to modify parts of the directory before switching to it."
 (ivy-set-actions
  'counsel-esh-dir-history
  '(("e" counsel--esh-dir-history-action-edit "edit")))
+
+(defadvice comint-previous-matching-input (before
+                                           counsel-set-comint-history-index
+                                           activate)
+  "Reassign `comint-input-ring-index'."
+  (when (and (memq last-command '(ivy-alt-done ivy-done))
+             (equal (ivy-state-caller ivy-last) 'counsel-shell-history))
+    (setq comint-input-ring-index counsel-shell-history--index-last)))
+
+(defvar slime-repl-input-history)
+
+;;;###autoload
+(defun counsel-slime-repl-history ()
+  "Browse Slime REPL history."
+  (interactive)
+  (require 'slime-repl)
+  (counsel--browse-history slime-repl-input-history
+                           :caller #'counsel-slime-repl-history))
+
+;; TODO: add advice for slime-repl-input-previous/next to properly
+;; reassign the ring index and match string.  This requires a case for
+;; `counsel-slime-repl-history' within
+;; `counsel--browse-history-action'.
 
 ;;** `counsel-hydra-heads'
 (defvar hydra-curr-body-fn)

--- a/counsel.el
+++ b/counsel.el
@@ -4915,7 +4915,7 @@ This function is an action for `counsel-esh-dir-history' to
 insert the selected directory (provided as the `car' of PAIR) to
 the Eshell buffer prefixed by \"cd \", allowing the caller to
 modify parts of the directory before switching to it."
-  (insert (format "cd %s" (car pair))))
+  (insert "cd " (car pair)))
 
 ;;;###autoload
 (defun counsel-esh-dir-history ()

--- a/counsel.el
+++ b/counsel.el
@@ -4926,6 +4926,12 @@ An extra action allows to switch to the process buffer."
 current working directory to the one selected by the user."
   (eshell/cd (car pair)))
 
+(defun counsel--esh-dir-history-action-edit (pair)
+  "Action for counsel-esh-dir-history to insert the selected
+directory to the Eshell buffer prefixed by \"cd \", allowing the
+caller to modify parts of the directory before switching to it."
+  (ivy--action-insert (format "cd %s" (car pair))))
+
 (defvar eshell-last-dir-ring)
 
 ;;;###autoload
@@ -4937,6 +4943,10 @@ current working directory to the one selected by the user."
             :keymap ivy-reverse-i-search-map
             :action #'counsel--esh-dir-history-action-cd
             :caller #'counsel-esh-dir-history))
+
+(ivy-set-actions
+ 'counsel-esh-dir-history
+ '(("e" counsel--esh-dir-history-action-edit "edit")))
 
 ;;** `counsel-hydra-heads'
 (defvar hydra-curr-body-fn)

--- a/counsel.el
+++ b/counsel.el
@@ -4886,7 +4886,8 @@ modify parts of the directory before switching to it."
                                      caller
                                      (prompt "History: ")
                                      (action #'counsel--browse-history-action))
-  "Use Ivy to navigate through RING."
+  "Use Ivy to navigate through RING.
+A custom PROMPT and a default ACTION may be provided."
   (let* ((proc (get-buffer-process (current-buffer)))
          (end (point))
          (beg (if proc

--- a/counsel.el
+++ b/counsel.el
@@ -4918,6 +4918,26 @@ An extra action allows to switch to the process buffer."
 ;; `counsel-slime-repl-history' within
 ;; `counsel--browse-history-action'.
 
+;;** `counsel-esh-dir-history'
+(declare-function eshell/cd "eshell")
+
+(defun counsel--esh-dir-history-action-cd (pair)
+  "Default action for counsel-esh-dir-history. It changes the
+current working directory to the one selected by the user."
+  (eshell/cd (car pair)))
+
+(defvar eshell-last-dir-ring)
+
+;;;###autoload
+(cl-defun counsel-esh-dir-history ()
+  "Use Ivy to navigate and jump through Eshell's directory stack."
+  (interactive)
+  (require 'em-dirs)
+  (ivy-read "Directory to change to: " (ivy-history-contents eshell-last-dir-ring)
+            :keymap ivy-reverse-i-search-map
+            :action #'counsel--esh-dir-history-action-cd
+            :caller #'counsel-esh-dir-history))
+
 ;;** `counsel-hydra-heads'
 (defvar hydra-curr-body-fn)
 (declare-function hydra-keyboard-quit "ext:hydra")


### PR DESCRIPTION
This interactive function helps navigating Eshell's directory stack and jumping across recently visited directories.

In action here:

https://github.com/nbarrientos/dotfiles/commit/d0d5ea091b8c2d5e69f03a7c80ecf3c8e6e265c7

Nothing fancy but it does the job. I think that it's much better than doing `cd =` and then `cd -N`. Mix it with working with several TRAMP sessions and jumping around servers takes nothing.

I'd be happy to add the new command to `doc/ivy.org` somewhere but it's not clear to me where it should go.  I rgrepped for `counsel-esh-history` for hints but there were no matches.