### PR TITLE
Fix Hydra menu documentation for ivy-rotate-preferred-builders

### DIFF
--- a/doc/ivy.org
+++ b/doc/ivy.org
@@ -540,7 +540,7 @@ Hydra menu offers these additional bindings:
      Toggle calling the action after each candidate change. It
      modifies ~j~ to ~jg~, ~k~ to ~kg~ etc.
 
-- ~m~ (=ivy-rotate-preferred-builders=) ::
+- ~M~ (=ivy-rotate-preferred-builders=) ::
      Rotate the current regexp matcher.
 
 - ~>~ (=ivy-minibuffer-grow=) ::


### PR DESCRIPTION
Hydra documentation for `ivy-rotate-preferred-builders` indicates that lowercase `m` is bound to the regex matcher rotate, when it is in fact `M`, a change introduced in 28e88ab23a191420a93a4f920ca076674ee53f94.