### PR TITLE
Generalize swiper-all function for different buffer lists

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1240,11 +1240,11 @@ otherwise continue prompting for buffers."
       (t (buffer-file-name buffer)))))
 
 ;;* `swiper-all'
-(defun swiper-all-function (str)
-  "Search in all open buffers for STR."
+(defun swiper-all-buffers-function (str buffers)
+  "Search in all given BUFFERS for STR."
   (or
    (ivy-more-chars)
-   (let* ((buffers (cl-remove-if-not #'swiper-all-buffer-p (buffer-list)))
+   (let* ((buffers (cl-remove-if-not #'swiper-all-buffer-p buffers))
           (re-full ivy-regex)
           re re-tail
           cands match
@@ -1275,6 +1275,10 @@ otherwise continue prompting for buffers."
      (if (null cands)
          (list "")
        (setq ivy--old-cands (nreverse cands))))))
+
+(defun swiper-all-function (str)
+  "Search in all buffers for STR."
+  (swiper-all-buffers-function str (buffer-list)))
 
 (defun swiper--all-format-function (cands)
   "Format CANDS for `swiper-all'.


### PR DESCRIPTION
Recently a colleague asked me if it was possible to get the same
behaviour as `swiper-all` with only the buffers of the current
project.

The solution I wrote for him involved a copy of `swiper-all-function`
as the list of buffers was not variable. I think this is something
that might be useful for others so here's half of that work to allow
others to do the same: search through a custom list of buffers with
all the niceties of `swiper-all`.

I haven't done the paperwork for the copyright assignment to the FSF
yet so I can't provide `swiper-projectile`. When I have the paperwork
done I can make a separate PR for that if people are interested.