### PR TITLE
Update the locate db more reliably

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2679,7 +2679,7 @@ library, which see."
      seconds))
 
 (defun counsel--locate-updatedb ()
-  (when (file-exists-p "~/.Private")
+  (when (file-exists-p (file-name-directory counsel-locate-db-path))
     (let ((db-fname (expand-file-name counsel-locate-db-path)))
       (setenv "LOCATE_PATH" db-fname)
       (when (or (not (file-exists-p db-fname))


### PR DESCRIPTION
Previously it would be updated only if a file (or directory) named
~/.Private existed.

* counsel.el (counsel--locate-updatedb): Replace spurious reference to
~/.Private with the file-name-directory of counsel-locate-db-path.