### PR TITLE
Fix ivy-restrict-to-matches for dynamic colls

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4877,9 +4877,16 @@ You can also delete an element from history with \\[ivy-reverse-i-search-kill]."
   (delete-minibuffer-contents)
   (if (ivy-state-dynamic-collection ivy-last)
       (progn
-        (setf (ivy-state-dynamic-collection ivy-last) nil)
-        (setf (ivy-state-collection ivy-last)
-              (setq ivy--all-candidates ivy--old-cands)))
+        ;; By disabling `ivy-state-dynamic-collection', we lose the ability
+        ;; to clearly differentiate between ternary programmed completion
+        ;; functions and Ivy's unary dynamic collections (short of using
+        ;; `func-arity' or otherwise redesigning things).  So we must also
+        ;; update the dynamic binding of `minibuffer-completion-table' to no
+        ;; longer hold a dynamic collection.
+        (setq minibuffer-completion-table ivy--old-cands)
+        (setq ivy--all-candidates ivy--old-cands)
+        (setf (ivy-state-collection ivy-last) ivy--old-cands)
+        (setf (ivy-state-dynamic-collection ivy-last) nil))
     (setq ivy--all-candidates
           (ivy--filter ivy-text ivy--all-candidates))))
 


### PR DESCRIPTION
Other parts of Ivy, specifically `ivy--wnd-cands-to-str`, use `ivy-state-dynamic-collection` to differentiate between programmed completion functions and Ivy's dynamic collections.  By disabling `ivy-state-dynamic-collection` in `ivy-restrict-to-matches`, we lose this ability.  This leads to errors when collections are mishandled.

* `ivy.el` (`ivy-restrict-to-matches`): When disabling `ivy-state-dynamic-collection`, also make sure that `minibuffer-completion-table` no longer holds a dynamic collection.

Cc: @ambihelical, @gexplorer.
Re: #2875.
Fixes #2893.