### PR TITLE
counsel.el: Add `other window` for Bookmarks

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2490,7 +2490,8 @@ By default `counsel-bookmark' opens a dired buffer for directories."
 
 (ivy-set-actions
  'counsel-bookmark
- `(("d" bookmark-delete "delete")
+ `(("j" bookmark-jump-other-window "other window")
+   ("d" bookmark-delete "delete")
    ("e" bookmark-rename "edit")
    ("s" bookmark-set "overwrite")
    ("x" ,(counsel--apply-bookmark-fn #'counsel-find-file-extern)


### PR DESCRIPTION
Add actions `other window `and `other frame` to counsel-bookmark, in line with similar actions for counsel-find-file and ivy-switch-buffer.

This is just for consistency with the other interfaces. I was looking for these actions in the bookmarks menu and couldn't find them, so here they are.