### PR TITLE
Allow call to swiper with initial-input to find the next closest value after point.

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -816,7 +816,7 @@ When non-nil, INITIAL-INPUT is the initial search pattern."
                    (if initial-input
                        (cl-position-if
                         (lambda (x)
-                          (= (1+ preselect) (swiper--line-number x)))
+                          (<= (1+ preselect) (swiper--line-number x)))
                         (progn
                           (setq ivy--old-re nil)
                           (ivy--filter initial-input candidates)))


### PR DESCRIPTION
When function swiper is called with an initial-input and the current point is on a line that does *not* contain a match, the current code returns nil for preselect, which then causes the first viable candidate to be used, which is the first candidate in the buffer.

This small change selects the first candidate following the current point, which allows for a simple repeat-search function to wrap a call to swiper.

##Background
I have a utility function to perform a repeat search after an initial search. The function is very simple
```
(defun search-repeat ()
  (interactive)
  (let ((a ""))
    (if swiper-history
        (setq a (first swiper-history)))
    (swiper a)))
```
The default behavior of this changed, some time ago (issue abo-abo/swiper#2157 commit 50ead7e). This commit changed the preselect to return the candidate on the current line or to nil, which will cause the first candidate in the entire buffer to be chosen.

As can be in the change, if we modify this from equal to less than, it takes the first candidate with a line number greater than the current point. If this fails (nil) then it will choose the first candidate in the buffer.