### PR TITLE
counsel-company invokes ivy-read only if there are candidates

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -381,9 +381,10 @@ Update the minibuffer with the amount of lines collected every
     (when len
       (setq ivy-completion-beg (- (point) len))
       (setq ivy-completion-end (point))
-      (ivy-read "Candidate: " company-candidates
-                :action #'ivy-completion-in-region-action
-                :caller 'counsel-company))))
+      (when company-candidates
+        (ivy-read "Candidate: " company-candidates
+                  :action #'ivy-completion-in-region-action
+                  :caller 'counsel-company)))))
 
 (ivy-configure 'counsel-company
   :display-transformer-fn #'counsel--company-display-transformer


### PR DESCRIPTION
Hi, this is a small change to `counsel-company` that I think is generally useful.

In my use case, I am using `counsel-company` as a completion-at-point-function. With my proposed change, I am enjoying to see the message "No completion found" instead of being prompted by ivy with no candidates available.

I am setting it up like this:

```
(defun my--completion-at-point ()
  #'counsel-company)

(setq-local completion-at-point-functions '(my--completion-at-point t))
```
