### PR TITLE
Only enable dynamic exhibit delay while typing

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3412,6 +3412,7 @@ Otherwise, ~/ will move home."
   "Delay in ms before dynamic collections are refreshed"
   :type 'integer)
 
+(defvar ivy--queue-last-input nil)
 (defvar ivy--exhibit-timer nil)
 
 (defun ivy--queue-exhibit ()
@@ -3419,7 +3420,8 @@ Otherwise, ~/ will move home."
 dynamic collections.
 Should be run via minibuffer `post-command-hook'."
   (if (and (> ivy-dynamic-exhibit-delay-ms 0)
-           (ivy-state-dynamic-collection ivy-last))
+           (ivy-state-dynamic-collection ivy-last)
+           (not (equal ivy--queue-last-input (ivy--input))))
       (progn
         (when ivy--exhibit-timer (cancel-timer ivy--exhibit-timer))
         (setq ivy--exhibit-timer
@@ -3427,7 +3429,8 @@ Should be run via minibuffer `post-command-hook'."
                (/ ivy-dynamic-exhibit-delay-ms 1000.0)
                nil
                'ivy--exhibit)))
-    (ivy--exhibit)))
+    (ivy--exhibit))
+  (setq ivy--queue-last-input (ivy--input)))
 
 (defalias 'ivy--file-local-name
   (if (fboundp 'file-local-name)


### PR DESCRIPTION
Fixes #1218

Adds an extra check to `ivy--queue-exhibit` to only debounce if the input has
actually changed. It also maintains the previous input variable to match against.