### PR TITLE
Add call and recenter option under ivy-hydra 'calling'

### DIFF
--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -58,10 +58,10 @@
 (defhydra hydra-ivy (:hint nil :color pink)
   "
 ^ ^ ^ ^ ^ ^ | ^Call^      ^ ^  | ^Cancel^ | ^Options^ | Action _w_/_s_/_a_: %-14s(ivy-action-name)
-^-^-^-^-^-^-+-^-^---------^-^--+-^-^------+-^-^-------+-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------------
-^ ^ _k_ ^ ^ | _f_ollow occ_U_r | _i_nsert | _c_: calling %-5s(if ivy-calling \"on\" \"off\") _C_ase-fold: %-10`ivy-case-fold-search
-_h_ ^+^ _l_ | _d_one      ^ ^  | _o_ops   | _M_: matcher %-5s(ivy--matcher-desc)^^^^^^^^^^^^ _T_runcate: %-11`truncate-lines
-^ ^ _j_ ^ ^ | _g_o        ^ ^  | ^ ^      | _<_/_>_: shrink/grow^^^^^^^^^^^^^^^^^^^^^^^^^^^^ _D_efinition of this menu
+^-^-^-^-^-^-+-^-^---------^-^--+-^-^------+-^-^-------+-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------
+^ ^ _k_ ^ ^ | _f_ollow occ_U_r | _i_nsert | _c_: calling %-5s(pcase ivy-calling ('rc \"rc\") ('on \"on\") (t \"off\")) _C_ase-fold: %-10`ivy-case-fold-search
+_h_ ^+^ _l_ | _d_one      ^ ^  | _o_ops   | _M_: matcher %-5s(ivy--matcher-desc)^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ _T_runcate: %-11`truncate-lines
+^ ^ _j_ ^ ^ | _g_o        ^ ^  | ^ ^      | _<_/_>_: shrink/grow^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ _D_efinition of this menu
 "
   ;; arrows
   ("h" ivy-beginning-of-buffer)

--- a/ivy.el
+++ b/ivy.el
@@ -1262,7 +1262,9 @@ if one exists."
   (setq ivy--index index)
   (when ivy-calling
     (ivy--exhibit)
-    (ivy-call)))
+    (pcase ivy-calling
+      ('rc (ivy-call-and-recenter))
+      (_ (ivy-call)))))
 
 (defun ivy-beginning-of-buffer ()
   "Select the first completion candidate."
@@ -1330,8 +1332,10 @@ If the input is empty, select the previous history element instead."
 (defun ivy-toggle-calling ()
   "Flip `ivy-calling'."
   (interactive)
-  (when (setq ivy-calling (not ivy-calling))
-    (ivy-call)))
+  (setq ivy-calling (pcase ivy-calling
+                      ('on 'rc)
+                      ('rc nil)
+                      (_ 'on))))
 
 (defun ivy-toggle-ignore ()
   "Toggle user-configured candidate filtering."
@@ -1515,7 +1519,7 @@ See variable `ivy-recursive-restore' for further information."
   (interactive)
   (ivy-call)
   (with-ivy-window
-    (recenter-top-bottom)))
+    (recenter)))
 
 (defun ivy-next-line-and-call (&optional arg)
   "Move cursor vertically down ARG candidates.


### PR DESCRIPTION
I would like a recenter option (like when calling `ivy-call-and-recenter`), but then combined with 'previous/next line' option.
I think this PR is probably the fastest way to achieve it. Let me know if you are interested and then how to modify it and where
to update the docs, so I can update the PR.

This would be a generalized solution for #2838, and a few other issues, I guess