### PR TITLE
Fix insert action for swiper-isearch

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1533,7 +1533,21 @@ Return to original position."
         (kill-new (match-string 0)))
     (goto-char swiper--opoint)))
 
+(defun swiper-isearch-action-insert (cand)
+  "Insert `swiper-isearch' candidate CAND where invoked."
+  (unwind-protect
+       (progn
+         (unless (and (setq cand (swiper--isearch-candidate-pos cand))
+                      ;; FIXME: Better way of getting current candidate?
+                      (goto-char cand)
+                      (looking-back (ivy-re-to-str ivy-regex) (point-min)))
+           (error "Could not insert `swiper-isearch' candidate: %S" cand))
+         (goto-char swiper--opoint)
+         (insert (match-string 0)))
+    (goto-char swiper--opoint)))
+
 (ivy-add-actions 'swiper-isearch '(("w" swiper-isearch-action-copy "copy")))
+(ivy-add-actions 'swiper-isearch '(("i" swiper-isearch-action-insert "insert")))
 (ivy-add-actions 'swiper '(("w" swiper-action-copy "copy")))
 
 (defun swiper-isearch-thing-at-point ()


### PR DESCRIPTION
`swiper-isearch` passes a buffer position to `ivy--action-insert`. The existing insert action throws an error. https://github.com/abo-abo/swiper/issues/2929
This change assumes numbers passed to `ivy--action-insert` are valid buffer positions in the current buffer, and converts them to a string containing the line that buffer position is on, allowing `insert` to do the right thing.

    make compile - check for new compilation warnings ✅ 
    make deps - install dependencies for testing ✅ 
    make test - check for failing tests ✅ 
    make checkdoc - check documentation guidelines ✅ 
