### PR TITLE
silence docstring warnings during byte-compilation

### DIFF
--- a/ivy-hydra.el
+++ b/ivy-hydra.el
@@ -157,3 +157,6 @@ _h_ ^+^ _l_ | _d_one      ^ ^  | _o_ops   | _M_: matcher %-5s(ivy--matcher-desc)
 (provide 'ivy-hydra)
 
 ;;; ivy-hydra.el ends here
+;; Local Variables:
+;; byte-compile-warnings: (not docstrings)
+;; End:


### PR DESCRIPTION
emacs 28 is aggressive about byte-compiling everything.
Hydra docstrings violate the mandated 80-char docstring limit.
Use a local variable to get it to shut up for ivy-hydra.el.