### PR TITLE
Pass imenu item to counsel-imenu instead of position

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4747,7 +4747,7 @@ PREFIX is used to create the key."
 
 (defun counsel-imenu-action (x)
   (with-ivy-window
-    (imenu (cdr x))))
+    (imenu x)))
 
 (defvar counsel-imenu-history nil
   "History for `counsel-imenu'.")


### PR DESCRIPTION
This PR implements a tiny correction to `counsel-imenu-action`

The imenu function expects an imenu item, not a position. The imenu function
will then correctly use the 'imenu-default-goto-function' to jump to the correct
position (could also be e.g. some page-number in doc-view).