### PR TITLE
counsel.el (counsel-git-branch-list): Call git branch with --no-color

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1795,7 +1795,8 @@ currently checked out."
                (and (string-match "\\`[[:blank:]]+" line)
                     (list (substring line (match-end 0)))))
              (let ((default-directory (counsel-locate-git-root)))
-               (split-string (shell-command-to-string "git branch -vv --all")
+               (split-string (shell-command-to-string
+                              "git branch -vv --all --no-color")
                              "\n" t))))
 
 ;;;###autoload


### PR DESCRIPTION
Having color.ui=always in .gitconfig makes counsel-git-branch-list show escape
sequences in the branch list.