### PR TITLE
Properly quote ` and ' in docstring to avoid curly quotes

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -1962,10 +1962,10 @@ choose between `yes-or-no-p' and `y-or-n-p'; otherwise default to
 These files are un-ignored if `ivy-text' matches them.  The
 common way to show all files is to start `ivy-text' with a dot.
 
-Example value: \"\\(?:\\`[#.]\\)\\|\\(?:[#~]\\'\\)\".  This will hide
+Example value: \"\\(?:\\\\=`[#.]\\)\\|\\(?:[#~]\\\\='\\)\".  This will hide
 temporary and lock files.
 \\<ivy-minibuffer-map>
-Choosing the dotfiles option, \"\\`\\.\", might be convenient,
+Choosing the dotfiles option, \"\\\\=`\\.\", might be convenient,
 since you can still access the dotfiles if your input starts with
 a dot. The generic way to toggle ignored files is \\[ivy-toggle-ignore],
 but the leading dot is a lot faster."


### PR DESCRIPTION
* counsel.el (counsel-find-file-ignore-regexp): Fix quoting of ` and ' in
docstring to avoid them using curly quotes.