### PR TITLE
speed-up swiper with buffer-substring-no-properties

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -512,9 +512,10 @@ such as `scroll-conservatively' are set to a high value.")
                     (point))
                 (line-end-position))))
 
-    (concat
-     " "
-     (buffer-substring beg end))))
+    (concat " "
+            (if swiper-candidates-no-properties
+                (buffer-substring-no-properties beg end)
+              (buffer-substring beg end)))))
 
 (defvar swiper-use-visual-line-p
   (lambda (n-lines)
@@ -524,6 +525,10 @@ such as `scroll-conservatively' are set to a high value.")
          (< n-lines 400)))
   "A predicate that decides whether `line-move' or `forward-line' is used.
 Note that `line-move' can be very slow.")
+
+(defvar swiper-candidates-no-properties nil
+  "`swiper--line' calls `buffer-substring' when this predicate is NIL;
+otherwise it calls `buffer-substring-no-properties'.")
 
 (defun swiper--candidates (&optional numbers-width)
   "Return a list of this buffer lines.
@@ -559,7 +564,8 @@ numbers; replaces calculating the width from buffer line count."
           (while (< (point) (point-max))
             (when (swiper-match-usable-p)
               (let ((str (swiper--line)))
-                (setq str (ivy-cleanup-string str))
+                (unless swiper-candidates-no-properties
+                  (setq str (ivy-cleanup-string str)))
                 (let ((line-number-str
                        (format swiper--format-spec line-number)))
                   (if swiper-include-line-number-in-search


### PR DESCRIPTION
Okay... So a couple of points; only the last is relevant for this PR:

1. I tried `swiper-isearch` - it is fast, but I liked the line-based nature of `swiper`. I'm unsure how to get `C-n` to behave as per `next-line` even after I used the `:bind` option of `use-package` with `swiper-isearch-map`.

2. I tried setting `(setq swiper-use-visual-line nil)` and `(setq swiper-use-visual-line-p 'ignore)` but this didn't seem to have much impact on performance.

3. So, I ended up playing around with the `swiper` function and noted that `swiper--line` is causing substantial slowness. Ideally,  avoiding `concat` *and* using `buffer-substring-no-properties` should get maximal performance. But avoiding `concat` causes the first character of each line to not be visible, and I'm unsure where else to tweak so that the first character remains visible; the first character does get used up for searches though! Until then and perhaps even then, using the `no-properties` versions should help with performance!

And thanks for the package!