### PR TITLE
* counsel.el: fix counsel failure with python-mode.el

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -4692,7 +4692,6 @@ S will be of the form \"[register]: content\"."
 (defvar imenu-auto-rescan-maxout)
 (declare-function imenu--subalist-p "imenu")
 (declare-function imenu--make-index-alist "imenu")
-(declare-function python-imenu-create-flat-index "python")
 
 (defun counsel--imenu-candidates ()
   (require 'imenu)
@@ -4704,7 +4703,8 @@ S will be of the form \"[register]: content\"."
          (items (delete (assoc "*Rescan*" items) items))
          (items (cond ((eq major-mode 'emacs-lisp-mode)
                        (counsel-imenu-categorize-functions items))
-                      ((eq major-mode 'python-mode)
+                      ((and (derived-mode-p 'python-mode)
+                            (fboundp 'python-imenu-create-flat-index))
                        (python-imenu-create-flat-index))
                       (t
                        items))))


### PR DESCRIPTION
Problem: counsel-imenu fails in python buffers with python-mode
    from python-mode.el enabled.

Context: There is an emacs builtin python-mode and some others, also
     named python-mode. There is also a hard-coded call to
     python-imenu-create-flat-index function in counsel.el. This call
     is guarded by checking that the current mode's symbol is
     ''python-mode. The issue is, both the builtin mode and the
     python-mode.el modes use that symbol.

Solution: since guarding the mode symbol is insufficient, let's check
     if the function we want to use is bound.

fixes #2992