### PR TITLE
Correctly extract project directory from project-current

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -45,6 +45,7 @@
 
 (require 'compile)
 (require 'dired)
+(require 'project)
 
 (eval-when-compile
   (require 'subr-x))
@@ -6410,7 +6411,7 @@ Use `projectile-project-root' to determine the root."
   "Return root of current project or nil on failure.
 Use `project-current' to determine the root."
   (and (fboundp 'project-current)
-       (cdr (project-current))))
+       (project-root (project-current))))
 
 (defun counsel--configure-root ()
   "Return root of current project or nil on failure.


### PR DESCRIPTION
`project-current` has changed behaviour upstream to also include backend type ([here](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=86969f9658e278ebacb3d625d0309046ff1f2b54)), thus `project-root` must be used in place of `cdr`. There is some discussion on the emacs bug mailing list about the change [here](https://lists.gnu.org/archive/html/bug-gnu-emacs/2022-03/msg00408.html).