### PR TITLE
`swiper-all`: Ignore image-mode buffers

### DIFF
--- a/swiper.el
+++ b/swiper.el
@@ -1244,6 +1244,8 @@ otherwise continue prompting for buffers."
     (cond
       ;; Ignore TAGS buffers, they tend to add duplicate results.
       ((eq mode #'tags-table-mode) nil)
+      ;; Ignore buffers being displayed as images
+      ((eq mode 'image-mode) nil)
       ;; Always consider dired buffers, even though they're not backed
       ;; by a file.
       ((eq mode #'dired-mode) t)


### PR DESCRIPTION
Image-mode buffers display images. If the user is displaying an image, it is unlikely that they would want to include their (typically binary) content when searching with `swiper-all`.