### PR TITLE
Suppress mdfind UserQueryParser output

### DIFF
--- a/counsel.el
+++ b/counsel.el
@@ -2651,7 +2651,7 @@ library, which see."
 (defun counsel-locate-cmd-mdfind (input)
   "Return a `mdfind' shell command based on INPUT."
   (counsel-require-program "mdfind")
-  (format "mdfind -name %s" (shell-quote-argument input)))
+  (format "mdfind -name %s 2> /dev/null" (shell-quote-argument input)))
 
 (defun counsel-locate-cmd-es (input)
   "Return a `es' shell command based on INPUT."


### PR DESCRIPTION
Sometimes on macOS, `mdfind` would output some non-result messages,

for example:

```bash
mdfind -name "vim xml"
2024-03-31 08:03:00.375 mdfind[8907:1002287] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-03-31 08:03:00.375 mdfind[8907:1002287] [UserQueryParser] Loading keywords and predicates for locale "en"
/usr/share/vim/vim90/ftplugin/ps1xml.vim
/usr/share/vim/vim90/ftplugin/xml.vim
/usr/share/vim/vim90/indent/xml.vim
```