### PR TITLE
Fix compatibility with `tramp` 2.6.0.2 and above

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -1067,6 +1067,10 @@ contains a single candidate.")
              (defvar tramp-completion-mode)
              (with-no-warnings
                (let* ((tramp-completion-mode t)
+                      ;; Alternative to `tramp-completion-mode' in newer Tramp.
+                      (non-essential t)
+                      ;; Non-nil changes completion since Tramp 2.6.0.2.
+                      (minibuffer-completing-file-name nil)
                       (file (expand-file-name
                              (if (> ivy--length 0) (ivy-state-current ivy-last) ivy-text)
                              ivy--directory)))


### PR DESCRIPTION
With `tramp` 2.6.0.2 and above, in a `dired` minibuffer, type in "//ssh:" followed by "C-j" (ivy-alt-done) gives the error "Reading directory: No such file or directory, /ssh:". Previously the output was a list of possible completions. This pull request should fix the issue.

For more context, see
https://lists.gnu.org/archive/html/tramp-devel/2023-03/msg00014.html.