### PR TITLE
ivy-completion-in-region: correctly calculate the length of replacement for file category

### DIFF
--- a/ivy-test.el
+++ b/ivy-test.el
@@ -1012,6 +1012,11 @@ Since `execute-kbd-macro' doesn't pick up a let-bound `default-directory'.")
               #("test/"
                 0 2 (face completions-common-part)
                 2 3 (face (completions-first-difference))))))
+  (should (= 2
+             (ivy-completion-common-length
+              #("test/"
+                0 2 (face completions-common-part)
+                2 3 (face completions-first-difference)))))
   (should (= 5
              (ivy-completion-common-length
               #("Math/E"
@@ -1020,7 +1025,8 @@ Since `execute-kbd-macro' doesn't pick up a let-bound `default-directory'.")
   (should (= 3
              (ivy-completion-common-length
               #("vec"
-                0 3 (face (completions-common-part)))))))
+                0 3 (face (completions-common-part))))))
+  )
 
 (ert-deftest ivy--sort-function ()
   "Test `ivy--sort-function' behavior."


### PR DESCRIPTION
- Ensure accurate calculation of the common length for completion items. The string face may contain only a single `completions-first-difference`, rather than a list of them.
- Additionally, when dealing with `file` category completions, calculate the prefix offset from the file name directory, not the entire input string. This adjustment is necessary because fuzzy completion styles can lead to incorrect common length values. The prefix offset ensures that we replace only the relevant portion of the input when calculating completion items.