### PR TITLE
ivy.el: try fixing handling of dollar signs in directory names when completing file names

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -2361,6 +2361,8 @@ This is useful for recursive `ivy-read'."
                      (all-completions "" collection predicate))))
             ((memq collection '(read-file-name-internal ffap-read-file-or-url-internal))
              (require 'tramp)
+             (when initial-input
+               (setq initial-input (substitute-in-file-name initial-input)))
              (when (and (equal def initial-input)
                         (member "./" ivy-extra-directories))
                (setq def nil))


### PR DESCRIPTION
This PR should fix #3060 

Honestly, not sure how to test this, and cannot do it right now. Feel free to do as you please (edits by maintainers enabled, if you fancy adding the tests and merging)