### PR TITLE
Fix kill-ring-save for swiper-isearch

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -4912,16 +4912,12 @@ The \"pulse\" duration is determined by `ivy-pulse-delay'."
     (setq ivy--pulse-overlay nil)))
 
 (defun ivy-kill-ring-save ()
-  "Store the current candidates into the kill ring.
+  "Save the current candidates in the kill ring.
 If the region is active, forward to `kill-ring-save' instead."
   (interactive)
-  (if (region-active-p)
-      (call-interactively 'kill-ring-save)
-    (kill-new
-     (mapconcat
-      #'identity
-      ivy--old-cands
-      "\n"))))
+  (if (use-region-p)
+      (call-interactively #'kill-ring-save)
+    (kill-new (string-join ivy--old-cands "\n"))))
 
 (defun ivy-insert-current ()
   "Make the current candidate into current input.


### PR DESCRIPTION
The default `M-w` binding of `ivy-kill-ring-save` expects `ivy--old-cands` to be a list of strings, but `swiper-isearch` has long switched to a list of buffer positions instead.

* `ivy.el` (`ivy-kill-ring-save`): Prefer `use-region-p` over `region-active-p`.  Use `string-join`.  Tweak docstring.
* `swiper.el`: Set `swiper` and `swiper-isearch` actions closer to their corresponding commands.
(`swiper--isearch-kill-ring-save`): New command modeled after `ivy-kill-ring-save`.
(`swiper-isearch-map`): Remap `ivy-kill-ring-save` and `kill-ring-save` to it.  By default, the former remap is defensive, and only the latter is needed.

Fixes #3000.
Cc: @bgoodr