### PR TITLE
Preserve text properties of prompt

### DIFF
--- a/ivy.el
+++ b/ivy.el
@@ -3263,9 +3263,14 @@ parts beyond their respective faces `ivy-confirm-face' and
           (when ivy-add-newline-after-prompt
             (setq n-str (concat n-str "\n")))
           (setq n-str (ivy--break-lines n-str (window-width)))
-          (set-text-properties 0 (length n-str)
-                               `(face minibuffer-prompt ,@std-props)
-                               n-str)
+          (let ((old-props (when (fboundp 'object-intervals)
+                             (object-intervals n-str))))
+            (set-text-properties 0 (length n-str)
+                                 `(face minibuffer-prompt ,@std-props)
+                                 n-str)
+            (dolist (propdata old-props)
+              (cl-destructuring-bind (beg end props) propdata
+                (add-text-properties beg end props n-str))))
           (setq n-str (funcall ivy-set-prompt-text-properties-function
                                n-str std-props))
           (insert n-str))


### PR DESCRIPTION
Standard Emacs' functions like `read-from-minibuffer` supports propertized prompts.
But `ivy` overrides text properties of prompt here:
https://github.com/abo-abo/swiper/blob/2257a9d0519e18f5ce7a7fafda8a1a8e5023628e/ivy.el#L3266
This pull request is the fix.